### PR TITLE
fix: 修复相册界面异常跳转

### DIFF
--- a/src/album/albumview/leftlistview.cpp
+++ b/src/album/albumview/leftlistview.cpp
@@ -57,6 +57,7 @@ LeftListView::LeftListView(QWidget *parent)
     , m_pMountLabel(nullptr), m_pMountListWidget(nullptr), m_pMountWidget(nullptr)
     , m_ItemCurrentName(COMMON_STR_RECENT_IMPORTED)
     , m_ItemCurrentType(COMMON_STR_RECENT_IMPORTED)
+    , m_currentUID(-1)
     , m_pMenu(nullptr)
 {
     //右侧菜单栏支持滑动


### PR DESCRIPTION
原因是左侧栏标签中保存的对应的相册UID没有初始化，导致在内存中的状态是随机的，从而触发异常跳转
修复方法是加上初始化操作

Log: 修复相册界面异常跳转
Bug: https://pms.uniontech.com/bug-view-134081.html