### PR TITLE
fix: 修复wayland环境下视频信息弹窗的位置是随机的

### DIFF
--- a/src/album/widgets/dialogs/videoinfodialog.cpp
+++ b/src/album/widgets/dialogs/videoinfodialog.cpp
@@ -377,13 +377,6 @@ bool VideoInfoDialog::event(QEvent *event)
     return QWidget::event(event);
 }
 
-void VideoInfoDialog::showEvent(QShowEvent *e)
-{
-    this->move((dApp->getMainWindow()->width() - this->width() - 50 + dApp->getMainWindow()->mapToGlobal(QPoint(0, 0)).x())
-               , 100 + dApp->getMainWindow()->mapToGlobal(QPoint(0, 0)).y());
-    return QWidget::showEvent(e);
-}
-
 void VideoInfoDialog::initUI()
 {
     //wayland背景透明问题

--- a/src/album/widgets/dialogs/videoinfodialog.h
+++ b/src/album/widgets/dialogs/videoinfodialog.h
@@ -58,7 +58,6 @@ private:
     QString     SpliteText(const QString &text, const QFont &font, int nLabelSize);
 protected:
     bool event(QEvent *event)override;
-    void showEvent(QShowEvent *e) override;
 private:
     MovieInfo m_movieInfo;
 


### PR DESCRIPTION
原因是在wayland环境下，在外部进行move和在showEvent里面move完成后的坐标是不一样的，相当于会先后move两次
解决方法是移除视频信息弹窗的showEvent代码

Log: 修复wayland环境下视频信息弹窗的位置是随机的
Bug: https://pms.uniontech.com/bug-view-135175.html