### PR TITLE
fix: 修复窗口尺寸由大调到最小时，自定义相册列表滚动条无法正常唤起的问题

### DIFF
--- a/src/album/albumview/leftlistview.cpp
+++ b/src/album/albumview/leftlistview.cpp
@@ -774,10 +774,10 @@ void LeftListView::updateAlbumItemsColor()
 
 void LeftListView::resizeEvent(QResizeEvent *e)
 {
-    DWidget::resizeEvent(e);
     // 设备左边栏
     int deviceHeight = m_pMountListWidget->count() * LEFT_VIEW_LISTITEM_HEIGHT_40;
     m_pMountListWidget->setFixedHeight(deviceHeight);
+    DScrollArea::resizeEvent(e);
 }
 
 void LeftListView::mousePressEvent(QMouseEvent *e)


### PR DESCRIPTION
Description: 大小调整事件交由DScrollArea处理，保证滚动条正常显示

Log: 修复窗口尺寸由大调到最小时，自定义相册列表滚动条无法正常唤起的问题

Bug: https://pms.uniontech.com/bug-view-111262.html