### PR TITLE
fix: 解决非特效模式下，相册删选弹窗四角显示黑框的问题

### DIFF
--- a/src/album/widgets/expansionpanel.cpp
+++ b/src/album/widgets/expansionpanel.cpp
@@ -41,9 +41,6 @@ ExpansionPanel::ExpansionPanel(QWidget *parent)
     this->setWindowFlag(Qt::Popup);
     layout = new QVBoxLayout;
 
-    //设置圆角
-    setBlurRectXRadius(18);
-    setBlurRectYRadius(18);
     setBlurEnabled(true);
     setMode(DBlurEffectWidget::GaussianBlur);
 


### PR DESCRIPTION
Description: 去掉额外添加的圆角设置代码

Log: 解决非特效模式下，相册删选弹窗四角显示黑框的问题

Bug: https://pms.uniontech.com/bug-view-137209.html