### PR TITLE
fix: 解决控制中心切换字体大小20后，相册所有页面显示异常的问题

### DIFF
--- a/src/album/albumview/albumview.h
+++ b/src/album/albumview/albumview.h
@@ -164,6 +164,8 @@ private:
     //恢复标题显示
     void restoreTitleDisplay();
 
+    // 字体改变、尺寸改变，同步调整标题栏区域控件显示大小
+    void adjustTitleContent();
 signals:
     void sigSearchEditIsDisplay(bool bIsDisp);
     void sigLoadMountImagesStart(QString mountName, QString path);
@@ -250,6 +252,7 @@ private:
     DWidget *m_customAlbumTitle = nullptr;           //自定义相册悬浮标题
     DWidget *m_pCustomAlbumWidget = nullptr;          //自定义相册右侧展示界面外层窗口
     NoResultWidget *m_customNoResultWidget = nullptr;
+    QString m_CustomRightPicTotalFullStr;
     //我的收藏标题栏
     DWidget *m_pFavoriteWidget = nullptr;
     DWidget *m_FavoriteTitleWidget = nullptr;
@@ -257,12 +260,15 @@ private:
     DLabel *m_pFavoritePicTotal;
     BatchOperateWidget *m_favoriteBatchOperateWidget = nullptr;
     NoResultWidget *m_favoriteNoResultWidget = nullptr;
+    QString m_FavoritePicTotalFullStr;
     //外部设备
     DLabel *m_pPhoneTitle;
     DLabel *m_pPhonePicTotal;
     SearchView *m_pSearchView;
     DGioVolumeManager *m_vfsManager;
     DDiskManager *m_diskManager;
+    QString m_PhonePicTotalFullStr;
+    QString m_phoneTitleFullStr;
     //最近删除标题
     DLabel *m_TrashTitleLab = nullptr;
     DLabel *m_TrashDescritionLab = nullptr;

--- a/src/album/importtimelineview/importtimelineview.cpp
+++ b/src/album/importtimelineview/importtimelineview.cpp
@@ -43,6 +43,7 @@
 
 const int MAINWINDOW_NEEDCUT_WIDTH = 775;
 const int LISTVIEW_MINMUN_WIDTH = 520;
+const int IMPORTTITLE_FIX_WIDTH = 90;
 
 ImportTimeLineView::ImportTimeLineView(DWidget *parent)
     : DWidget(parent), m_mainLayout(nullptr)
@@ -113,6 +114,9 @@ void ImportTimeLineView::initConnections()
     connect(m_importTimeLineListView, &ThumbnailListView::sigSelectAll, this, [ = ]() {
         m_suspensionChoseBtn->setText(QObject::tr("Unselect"));
     });
+
+    // 字体改变时,不同尺寸下同步调整标题栏区域控件显示大小
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::fontChanged, this, &ImportTimeLineView::updateSize);
 }
 
 void ImportTimeLineView::themeChangeSlot(DGuiApplicationHelper::ColorType themeType)
@@ -344,6 +348,7 @@ void ImportTimeLineView::initTimeLineViewWidget()
     DFontSizeManager::instance()->bind(m_pImportTitle, DFontSizeManager::T3, QFont::DemiBold);
     m_pImportTitle->setForegroundRole(DPalette::TextTitle);
     m_pImportTitle->setFixedHeight(title_HEIGHT);
+    m_pImportTitle->setFixedWidth(IMPORTTITLE_FIX_WIDTH);
     DPalette ppal_light2 = DApplicationHelper::instance()->palette(m_pImportTitle);
     ppal_light2.setBrush(DPalette::Background, ppal_light2.color(DPalette::Base));
     QGraphicsOpacityEffect *opacityEffect_light2 = new QGraphicsOpacityEffect;
@@ -613,7 +618,7 @@ void ImportTimeLineView::updateDateNumLabel()
 {
     if (topLevelWidget()->width() <= MAINWINDOW_NEEDCUT_WIDTH)
         m_pImportTitle->move(topLevelWidget()->width() - LISTVIEW_MINMUN_WIDTH, 0);
-  
+
     auto fullStr = dateFullStr + "  " + numFullStr;
     auto resultStr = utils::base::reorganizationStr(m_DateNumLabel->font(), fullStr, m_pImportTitle->x() - 19);
     m_DateNumLabel->setText(resultStr);

--- a/src/album/mainwindow.h
+++ b/src/album/mainwindow.h
@@ -125,6 +125,10 @@ private:
     void setConflictShortcutEnabled(bool enable);
     bool processOption(QStringList &paslist);
     void waitImportantProcessBeforeExit();
+
+    // 字体改变、尺寸改变，同步调整标题栏区域控件显示大小
+    void adjustTitleContent();
+
 protected:
     void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
     void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;


### PR DESCRIPTION
Description: 逐个完善对应界面和控件最小尺寸下显示逻辑

Log: 解决控制中心切换字体大小20后，相册所有页面显示异常的问题

Bug: https://pms.uniontech.com/bug-view-131369.html