### PR TITLE
fix: 修复相册界面左侧栏当前UID指向错误

### DIFF
--- a/src/album/albumview/leftlistview.cpp
+++ b/src/album/albumview/leftlistview.cpp
@@ -506,9 +506,11 @@ void LeftListView::onPhotoLibListViewPressed(const QModelIndex &index)
         if (COMMON_STR_RECENT_IMPORTED == item->m_albumNameStr) {
             m_ItemCurrentName = COMMON_STR_RECENT_IMPORTED;
             m_ItemCurrentType = COMMON_STR_RECENT_IMPORTED;
+            m_currentUID = -1;
         } else if (COMMON_STR_TRASH == item->m_albumNameStr) {
             m_ItemCurrentName = COMMON_STR_TRASH;
             m_ItemCurrentType = COMMON_STR_TRASH;
+            m_currentUID = -1;
         } else {
             m_ItemCurrentName = COMMON_STR_FAVORITES;
             m_ItemCurrentType = COMMON_STR_FAVORITES;
@@ -598,9 +600,11 @@ void LeftListView::onPhotoLibListViewCurrentItemChanged()
         if (COMMON_STR_RECENT_IMPORTED == item->m_albumNameStr) {
             m_ItemCurrentName = COMMON_STR_RECENT_IMPORTED;
             m_ItemCurrentType = COMMON_STR_RECENT_IMPORTED;
+            m_currentUID = -1;
         } else if (COMMON_STR_TRASH == item->m_albumNameStr) {
             m_ItemCurrentName = COMMON_STR_TRASH;
             m_ItemCurrentType = COMMON_STR_TRASH;
+            m_currentUID = -1;
         } else {
             m_ItemCurrentName = COMMON_STR_FAVORITES;
             m_ItemCurrentType = COMMON_STR_FAVORITES;


### PR DESCRIPTION
原因是切换至已导入和最近删除的lab后，没有刷新当前UID的值
解决方法是添加刷新代码

Log: 修复相册界面左侧栏当前UID指向错误
Bug: https://pms.uniontech.com/bug-view-134081.html