### PR TITLE
fix: 解决最小尺寸，最近删除清空后，最近删除标题显示不完整的问题

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -2417,6 +2417,8 @@ void AlbumView::restoreTitleDisplay()
     //顶部栏不存在时的标题处理（涉及样式还原）
     if (!m_trashBatchOperateWidget->isVisible()) {//最近删除界面标题
         m_TrashTitleLab->setText(tr("Trash"));
+        // 最近删除内容被清空后，顶部操作栏隐藏，需要重新调整"最近删除"标题显示大小
+        m_TrashTitleLab->adjustSize();
         m_TrashTitleLab->show();
         m_TrashTitleLab->raise();
     }

--- a/src/album/widgets/batchoperatewidget.cpp
+++ b/src/album/widgets/batchoperatewidget.cpp
@@ -248,6 +248,8 @@ void BatchOperateWidget::sltSelectionChanged(const QItemSelection &selected, con
     Q_UNUSED(selected)
     Q_UNUSED(deselected)
     if (m_thumbnailListView->getAppointTypeSelectItemCount(ItemTypeNull) == 0) {
+        if (AlbumViewTrashType == m_operateType)
+            batchSelectChanged(true, false);
         refreshBtnEnabled(true);
         return;
     }


### PR DESCRIPTION
Description: 顶部操作栏不显示时，重新调整标题标签显示大小

Log: 解决最小尺寸，最近删除清空后，最近删除标题显示不完整的问题

Bug: https://pms.uniontech.com/bug-view-138659.html