### PR TITLE
fix: 解决部分大分辨率图片的缩略图存在波纹

### DIFF
--- a/src/album/application.cpp
+++ b/src/album/application.cpp
@@ -88,16 +88,7 @@ void ImageLoader::updateImageLoader(const QStringList &pathlist, const QList<QIm
             tImg = images.at(i);
         }
 
-        //修改：将QPixmap的变形操作放在QImage里完成
-        if (0 != tImg.height() && 0 != tImg.width() && (tImg.height() / tImg.width()) < 10 && (tImg.width() / tImg.height()) < 10) {
-            if (tImg.height() != 140 && tImg.width() != 140) {
-                if (tImg.height() >= tImg.width()) {
-                    tImg = tImg.scaledToWidth(140,  Qt::FastTransformation);
-                } else if (tImg.height() <= tImg.width()) {
-                    tImg = tImg.scaledToHeight(140,  Qt::FastTransformation);
-                }
-            }
-        }
+        tImg = utils::base::getThumbnailFromImage(tImg, 200);
         QString spath = albumGlobal::CACHE_PATH + pathlist.at(i);
         utils::base::mkMutiDir(spath.mid(0, spath.lastIndexOf('/')));
         tImg.save(spath, "PNG");

--- a/src/album/dbmanager/DBandImgOperate.cpp
+++ b/src/album/dbmanager/DBandImgOperate.cpp
@@ -146,28 +146,9 @@ void DBandImgOperate::loadOneImgForce(QString imagepath, bool refresh)
                 return;
             }
         }
-
     }
 
-    if (0 != tImg.height() && 0 != tImg.width() && (tImg.height() / tImg.width()) < 10 && (tImg.width() / tImg.height()) < 10) {
-        bool cache_exist = false;
-        if (tImg.height() != 200 && tImg.width() != 200) {
-            if (tImg.height() >= tImg.width()) {
-                cache_exist = true;
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
-            } else if (tImg.height() <= tImg.width()) {
-                cache_exist = true;
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
-            }
-        }
-        if (!cache_exist) {
-            if ((static_cast<float>(tImg.height()) / (static_cast<float>(tImg.width()))) > 3) {
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
-            } else {
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
-            }
-        }
-    }
+    tImg = utils::base::getThumbnailFromImage(tImg, 200);
 
     if (!file.exists()) {
         utils::base::mkMutiDir(thumbnailPath.mid(0, thumbnailPath.lastIndexOf('/')));

--- a/src/album/imageengine/imagedataservice.cpp
+++ b/src/album/imageengine/imagedataservice.cpp
@@ -280,46 +280,11 @@ void ReadThumbnailManager::readThumbnail()
                     continue;
                 }
             }
-            //裁切
-            if (!tImg.isNull() && 0 != tImg.height() && 0 != tImg.width() && (tImg.height() / tImg.width()) < 10 && (tImg.width() / tImg.height()) < 10) {
-                bool cache_exist = false;
-                if (tImg.height() != 200 && tImg.width() != 200) {
-                    if (tImg.height() >= tImg.width()) {
-                        cache_exist = true;
-                        tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
-                    } else if (tImg.height() <= tImg.width()) {
-                        cache_exist = true;
-                        tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
-                    }
-                }
-                if (!cache_exist) {
-                    if ((static_cast<float>(tImg.height()) / (static_cast<float>(tImg.width()))) > 3) {
-                        tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
-                    } else {
-                        tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
-                    }
-                }
-            }
-            utils::base::mkMutiDir(thumbnailPath.mid(0, thumbnailPath.lastIndexOf('/')));
         }
         if (!tImg.isNull()) {
-            int width = tImg.width();
-            int height = tImg.height();
-            if (abs((width - height) * 10 / width) >= 1) {
-                QRect rect = tImg.rect();
-                int x = rect.x() + width / 2;
-                int y = rect.y() + height / 2;
-                if (width > height) {
-                    x = x - height / 2;
-                    y = 0;
-                    tImg = tImg.copy(x, y, height, height);
-                } else {
-                    y = y - width / 2;
-                    x = 0;
-                    tImg = tImg.copy(x, y, width, width);
-                }
-            }
+            tImg = utils::base::getThumbnailFromImage(tImg, 200);
             if (!thumbnailFile.exists()) {
+                utils::base::mkMutiDir(thumbnailPath.mid(0, thumbnailPath.lastIndexOf('/')));
                 tImg.save(thumbnailPath, "PNG"); //保存裁好的缩略图，下次读的时候直接刷进去
             }
         }

--- a/src/album/utils/baseutils.cpp
+++ b/src/album/utils/baseutils.cpp
@@ -487,6 +487,64 @@ QList<QExplicitlySharedDataPointer<DGioMount>> getMounts_safe()
     return result;
 }
 
+QImage cheatScaled(const QImage &srcImg, int size, int side)
+{
+    QImage tImg;
+    if (side == 0) {//w
+        tImg = srcImg.scaledToWidth(size * 4, Qt::FastTransformation);
+        tImg = srcImg.scaledToWidth(size, Qt::SmoothTransformation);
+    } else {//h
+        tImg = srcImg.scaledToHeight(size * 4, Qt::FastTransformation);
+        tImg = srcImg.scaledToHeight(size, Qt::SmoothTransformation);
+    }
+    return tImg;
+}
+
+QImage getThumbnailFromImage(const QImage &srcImg, int size)
+{
+    QImage tImg(srcImg);
+
+    if (!tImg.isNull() && 0 != tImg.height() && 0 != tImg.width() && (tImg.height() / tImg.width()) < 10 && (tImg.width() / tImg.height()) < 10) {
+        bool cache_exist = false;
+        if (tImg.height() != size && tImg.width() != size) {
+            if (tImg.height() >= tImg.width()) {
+                cache_exist = true;
+                tImg = cheatScaled(tImg, size, 0);
+            } else if (tImg.height() <= tImg.width()) {
+                cache_exist = true;
+                tImg = cheatScaled(tImg, size, 1);
+            }
+        }
+        if (!cache_exist) {
+            if ((static_cast<float>(tImg.height()) / (static_cast<float>(tImg.width()))) > 3) {
+                tImg = cheatScaled(tImg, size, 0);
+            } else {
+                tImg = cheatScaled(tImg, size, 1);
+            }
+        }
+    }
+    if (!tImg.isNull()) {
+        int width = tImg.width();
+        int height = tImg.height();
+        if (abs((width - height) * 10 / width) >= 1) {
+            QRect rect = tImg.rect();
+            int x = rect.x() + width / 2;
+            int y = rect.y() + height / 2;
+            if (width > height) {
+                x = x - height / 2;
+                y = 0;
+                tImg = tImg.copy(x, y, height, height);
+            } else {
+                y = y - width / 2;
+                x = 0;
+                tImg = tImg.copy(x, y, width, width);
+            }
+        }
+    }
+
+    return tImg;
+}
+
 void multiLoadImage_helper(const QString &path)
 {
     QString srcPath = path;
@@ -511,43 +569,7 @@ void multiLoadImage_helper(const QString &path)
         }
     }
     //裁切
-    if (!tImg.isNull() && 0 != tImg.height() && 0 != tImg.width() && (tImg.height() / tImg.width()) < 10 && (tImg.width() / tImg.height()) < 10) {
-        bool cache_exist = false;
-        if (tImg.height() != 200 && tImg.width() != 200) {
-            if (tImg.height() >= tImg.width()) {
-                cache_exist = true;
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
-            } else if (tImg.height() <= tImg.width()) {
-                cache_exist = true;
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
-            }
-        }
-        if (!cache_exist) {
-            if ((static_cast<float>(tImg.height()) / (static_cast<float>(tImg.width()))) > 3) {
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
-            } else {
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
-            }
-        }
-    }
-    if (!tImg.isNull()) {
-        int width = tImg.width();
-        int height = tImg.height();
-        if (abs((width - height) * 10 / width) >= 1) {
-            QRect rect = tImg.rect();
-            int x = rect.x() + width / 2;
-            int y = rect.y() + height / 2;
-            if (width > height) {
-                x = x - height / 2;
-                y = 0;
-                tImg = tImg.copy(x, y, height, height);
-            } else {
-                y = y - width / 2;
-                x = 0;
-                tImg = tImg.copy(x, y, width, width);
-            }
-        }
-    }
+    tImg = getThumbnailFromImage(tImg, 200);
 
     ImageDataService::instance()->addImage(srcPath, tImg);
 }

--- a/src/album/utils/baseutils.h
+++ b/src/album/utils/baseutils.h
@@ -272,6 +272,10 @@ bool syncCopy(const QString &srcFileName, const QString &dstFileName);
 QList<QExplicitlySharedDataPointer<DGioMount>> getMounts_safe();
 //快速加载图片
 QFuture<void> multiLoadImage(const QStringList &paths);
+//快速平滑缩放
+QImage cheatScaled(const QImage &srcImg, int size, int side);
+//从图片提取缩略图
+QImage getThumbnailFromImage(const QImage &srcImg, int size);
 }  // namespace base
 
 }  // namespace utils


### PR DESCRIPTION
原因是直接采用了隔行删除进行裁剪，导致图片大幅失真
解决方法是先使用隔行删除裁剪至较小尺寸，再使用平滑缩放至目标尺寸，在保证速度的情况下确保不会有太大的失真

Log: 解决部分大分辨率图片的缩略图存在波纹
Bug: https://pms.uniontech.com/bug-view-148641.html