### PR TITLE
fix: 解决文管卸载外设后，相册依然刷新显示外设列表的问题

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -1527,7 +1527,8 @@ void AlbumView::getAllDeviceName()
         }
         udispname = label;
     runend1:
-        blk->mount({});
+        // 不能强制挂载，否则卸载不了
+        //blk->mount({});
         QByteArrayList qbl = blk->mountPoints();
         QString mountPoint = "file://";
         QList<QByteArray>::iterator qb = qbl.begin();


### PR DESCRIPTION
Description: 相册卸载回调不再强制重载外设

Log: 解决文管卸载外设后，相册依然刷新显示外设列表的问题

Bug: https://pms.uniontech.com/bug-view-141657.html