### PR TITLE
fix: 解决系统语言为“波兰语”时，图片信息弹框上显示不全的问题

### DIFF
--- a/src/album/widgets/dialogs/imginfodialog.cpp
+++ b/src/album/widgets/dialogs/imginfodialog.cpp
@@ -103,12 +103,13 @@ void ImgInfoDialog::initUI()
     //title
     DLabel *title = new DLabel(this);
     title->setText(tr("Image info"));
-    title->setGeometry(this->x() + (this->width() - title->width()) / 2, this->y(), 112, 50);
+    title->setGeometry(this->x() + 100 / 2, this->y(), width()-100, 50);
     title->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
     DFontSizeManager::instance()->bind(title, DFontSizeManager::T6);
     DPalette pa = DApplicationHelper::instance()->palette(title);
     pa.setBrush(DPalette::Text, pa.color(DPalette::TextTitle));
     title->setPalette(pa);
+    title->setWordWrap(true); //自动换行
 
     setContentsMargins(0, 0, 0, 0);
 


### PR DESCRIPTION
Description: 查找过程使用“下一个”按钮触发跳转，但未触发滚屏信号，没有立即刷新页面的代码高亮效果。在查询过程跳转后刷新页面的代码高亮效果。

Log: 修复查找过程中，代码着色会消失，需滚动鼠标才能恢复
Bug: https://pms.uniontech.com/bug-view-144323.html
Influence: 代码高亮