### PR TITLE
fix: 修复系统语言为“波兰语”时，图片信息弹框上标题显示不全

### DIFF
--- a/src/album/widgets/dialogs/imginfodialog.cpp
+++ b/src/album/widgets/dialogs/imginfodialog.cpp
@@ -103,12 +103,13 @@ void ImgInfoDialog::initUI()
     //title
     DLabel *title = new DLabel(this);
     title->setText(tr("Image info"));
-    title->setGeometry(this->x() + (this->width() - title->width()) / 2, this->y(), 112, 50);
+    title->setGeometry(this->x() + 100 / 2, this->y(), width()-100, 50);
     title->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
     DFontSizeManager::instance()->bind(title, DFontSizeManager::T6);
     DPalette pa = DApplicationHelper::instance()->palette(title);
     pa.setBrush(DPalette::Text, pa.color(DPalette::TextTitle));
     title->setPalette(pa);
+    title->setWordWrap(true); //自动换行
 
     setContentsMargins(0, 0, 0, 0);
 


### PR DESCRIPTION
Description: 标题栏文本框太短，字符长了显示不下。增加标题栏文本框长度，同时设置可自动换行。

Log: 修复系统语言为“波兰语”时，图片信息弹框上标题显示不全
Bug: https://pms.uniontech.com/bug-view-158545.html