### PR TITLE
fix: 修复最近删除中的图片文件被永久删除后，回收站中未物理删除仍然存在该文件的问题

### DIFF
--- a/src/album/dbmanager/dbmanager.cpp
+++ b/src/album/dbmanager/dbmanager.cpp
@@ -1627,6 +1627,7 @@ void DBManager::removeTrashImgInfos(const QStringList &paths)
     for (int i = 0; i != paths.size(); ++i) {
         auto deletePath = utils::base::getDeleteFullPath(pathHashs[i], DBImgInfo::getFileNameFromFilePath(paths[i]));
         QFile::remove(deletePath);
+        utils::base::delTrashFile(paths[i]);
     }
 
     mutex.unlock();

--- a/src/album/utils/baseutils.cpp
+++ b/src/album/utils/baseutils.cpp
@@ -421,6 +421,36 @@ bool trashFile(const QString &file)
     return true;
 }
 
+//彻底删除，删除回收站对应的文件
+bool delTrashFile(const QString &file)
+{
+    QString trashPath;
+    QString trashInfoPath;
+    QString trashFilesPath;
+
+    QString home = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    trashPath = home + "/.local/share/Trash";
+    trashInfoPath = trashPath + "/info";
+    trashFilesPath = trashPath + "/files";
+
+    QFileInfo originalInfo(file);
+    QString trashname = getNotExistsTrashFileName(originalInfo.fileName());
+    QString infopath = trashInfoPath + "/" + trashname + ".trashinfo";
+    QString filepath = trashFilesPath + "/" + trashname;
+
+    trashname = originalInfo.baseName() + ".";
+    if (!originalInfo.completeSuffix().isEmpty()) {
+        trashname += originalInfo.completeSuffix();
+    }
+    infopath = trashInfoPath + "/" + trashname + ".trashinfo";
+    filepath = trashFilesPath + "/" + trashname;
+
+    std::remove(infopath.toStdString().c_str());
+    std::remove(filepath.toStdString().c_str());
+
+    return true;
+}
+
 QString getDeleteFullPath(const QString &hash, const QString &fileName)
 {
     //防止文件过长,采用只用hash的名称;

--- a/src/album/utils/baseutils.h
+++ b/src/album/utils/baseutils.h
@@ -248,6 +248,8 @@ QString reorganizationStr(const QFont &font, const QString &fullStr, int maxWidt
 bool isVaultFile(const QString &path);
 //移动至回收站，抄的看图的代码，看图抄的文管的代码
 bool trashFile(const QString &file);
+//彻底删除，删除回收站对应的文件
+bool delTrashFile(const QString &file);
 //生成deepin-album-delete下的文件路径，hash：原始路径hash，fileName：文件名
 QString getDeleteFullPath(const QString &hash, const QString &fileName);
 //同步文件拷贝，用于区分QFile::copy的异步拷贝


### PR DESCRIPTION
Description: 添加删除回收站对应文件函数，在“最近删除”里面删除时调用

Log: 修复最近删除中的图片文件被永久删除后，回收站中未物理删除仍然存在该文件的问题
Bug: https://pms.uniontech.com/bug-view-157453.html