### PR TITLE
fix: 修复回收站删除、还原与相册的最近删除未同步问题

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -162,6 +162,9 @@ AlbumView::AlbumView()
     m_spinner = new DSpinner(this);
     m_spinner->setFixedSize(40, 40);
     m_spinner->hide();
+
+    ImageEngineApi::instance()->StartSynRecycleBinToTrashThread();
+    connect(ImageEngineApi::instance(), &ImageEngineApi::sigTrashUpdate, this, &AlbumView::onTrashUpdate);
 }
 
 AlbumView::~AlbumView()
@@ -2756,4 +2759,11 @@ void AlbumView::showEvent(QShowEvent *e)
 {
     adjustTitleContent();
     QWidget::showEvent(e);
+}
+
+void AlbumView::onTrashUpdate()
+{
+    if (m_pRightTrashThumbnailList->isVisible()) {
+        updateRightTrashView();
+    }
 }

--- a/src/album/albumview/albumview.h
+++ b/src/album/albumview/albumview.h
@@ -181,6 +181,7 @@ private slots:
     void onImportFailedToView();
     void onWaitDailogTimeout();
     void onLeftListViewMountListWidgetClicked(const QModelIndex &index);
+    void onTrashUpdate();
 
     //接收到设备中文件列表加载完成信号
     void sltLoadMountFileList(const QString &path, QStringList fileList);

--- a/src/album/dbmanager/dbmanager.cpp
+++ b/src/album/dbmanager/dbmanager.cpp
@@ -1696,6 +1696,7 @@ QStringList DBManager::recoveryImgFromTrash(const QStringList &paths)
         if (QFile::rename(deletePath, recoveryName)) { //尝试正常恢复
             successedHashs.push_back(pathHashs[i]); //正常恢复成功
             succesedPaths.insert(pathHashs[i], recoveryName);
+            utils::base::delTrashFile(paths[i]); //同步删除回收站数据
         } else { //正常恢复失败，尝试恢复至内部路径
             if (!internalRecoveryDir.exists()) { //检查文件夹是否存在，不存在则创建
                 internalRecoveryDir.mkpath(internalRecoveryPath);
@@ -1724,6 +1725,7 @@ QStringList DBManager::recoveryImgFromTrash(const QStringList &paths)
             if (QFile::rename(deletePath, recoveryName)) {
                 successedHashs.push_back(pathHashs[i]); //恢复至内部路径
                 succesedPaths.insert(pathHashs[i], recoveryName);
+                utils::base::delTrashFile(paths[i]); //同步删除回收站数据
             } else { //TODO：极端特殊情况：使用内部恢复路径恢复失败
                 continue;
             }

--- a/src/album/imageengine/imageengineapi.cpp
+++ b/src/album/imageengine/imageengineapi.cpp
@@ -272,3 +272,18 @@ bool ImageEngineApi::recoveryImagesFromTrash(QStringList files)
 #endif
     return true;
 }
+
+void ImageEngineApi::StartSynRecycleBinToTrashThread()
+{
+    if (threadSynRBT) {
+        threadSynRBT->needStop(nullptr);
+    }
+    threadSynRBT = new SynRecycleBinToTrashThread;
+
+    connect(threadSynRBT, &SynRecycleBinToTrashThread::sigTrashUpdate, this, &ImageEngineApi::sigTrashUpdate);
+#ifdef NOGLOBAL
+    m_qtpool.start(thread);
+#else
+    QThreadPool::globalInstance()->start(threadSynRBT);
+#endif
+}

--- a/src/album/imageengine/imageengineapi.h
+++ b/src/album/imageengine/imageengineapi.h
@@ -59,6 +59,9 @@ public:
     //设置线程循环跳出
     void     setThreadShouldStop();
 
+    //启动同步回收站与最近删除线程
+    void StartSynRecycleBinToTrashThread();
+
 private slots:
     void sltImageFilesImported(void *imgobject, QStringList &filelist);
 signals:
@@ -85,6 +88,8 @@ signals:
     void sigLoadMountFileList(QString path);
     //同步设备卸载
     void sigDeciveUnMount(const QString &path);
+    //发送更新信号给[最近删除]
+    void sigTrashUpdate();
 public:
     int m_FirstPageScreen = 0;
     QStringList m_imgLoaded;//已经加载过的图片，防止多次加载
@@ -102,6 +107,8 @@ private:
 
     DBandImgOperate *m_worker = nullptr;
     QMutex m_dataMutex;
+
+    SynRecycleBinToTrashThread *threadSynRBT = nullptr; //同步线程-同步回收站与最近删除
 };
 
 #endif // IMAGEENGINEAPI_H

--- a/src/album/imageengine/imageenginethread.cpp
+++ b/src/album/imageengine/imageenginethread.cpp
@@ -645,3 +645,42 @@ void RefreshTrashThread::runDetail()
         }
     }
 }
+
+SynRecycleBinToTrashThread::SynRecycleBinToTrashThread()
+{
+}
+
+SynRecycleBinToTrashThread::~SynRecycleBinToTrashThread()
+{
+}
+
+void SynRecycleBinToTrashThread::runDetail()
+{
+    int i = 0;
+    QStringList removepaths;
+    DBImgInfoList allTrashInfos;
+    DBImgInfo pinfo;
+
+    while (!bneedstop) {
+        removepaths.clear();
+
+        //遍历表:最近删除TrashTable3
+        allTrashInfos = DBManager::instance()->getAllTrashInfos_getRemainDays();
+        for (i = 0; i < allTrashInfos.size(); i++) {
+            pinfo = allTrashInfos.at(i);
+            if (!utils::base::isFileInTrash(pinfo.filePath)) {
+                //最近删除里的文件已不在回收站里，则删除
+                removepaths.append(pinfo.filePath);
+            }
+        }
+
+        //删除
+        if (0 < removepaths.length()) {
+            DBManager::instance()->removeTrashImgInfosNoSignal(removepaths);
+            emit sigTrashUpdate();
+        }
+
+        //休息一秒
+        QThread::sleep(1);
+    }
+}

--- a/src/album/imageengine/imageenginethread.h
+++ b/src/album/imageengine/imageenginethread.h
@@ -131,5 +131,21 @@ private:
     DBImgInfoList m_fileinfolist;
 };
 
+//同步回收站与最近删除(删除、恢复回收站文件，需要最近删除中的文件同步删除)
+class SynRecycleBinToTrashThread : public ImageEngineThreadObject
+{
+    Q_OBJECT
+public:
+    SynRecycleBinToTrashThread();
+    ~SynRecycleBinToTrashThread() override;
+
+protected:
+    void runDetail() override;
+
+signals:
+    //发送更新信号给[最近删除]
+    void sigTrashUpdate();
+};
+
 
 #endif // IMAGEENGINETHREAD_H

--- a/src/album/utils/baseutils.cpp
+++ b/src/album/utils/baseutils.cpp
@@ -29,6 +29,7 @@
 #include <QTextStream>
 #include <QtMath>
 #include <QRegularExpression>
+#include <QSettings>
 
 #include <DApplication>
 #include <DDesktopServices>
@@ -435,20 +436,66 @@ bool delTrashFile(const QString &file)
 
     QFileInfo originalInfo(file);
     QString trashname = getNotExistsTrashFileName(originalInfo.fileName());
-    QString infopath = trashInfoPath + "/" + trashname + ".trashinfo";
-    QString filepath = trashFilesPath + "/" + trashname;
 
-    trashname = originalInfo.baseName() + ".";
-    if (!originalInfo.completeSuffix().isEmpty()) {
-        trashname += originalInfo.completeSuffix();
+    //restore filepath
+    QString fileRestorePath = QString(originalInfo.absoluteFilePath().toUtf8().toPercentEncoding("/"));
+
+    //查找info里所有与目标文件同名的文件列表
+    QDir dirTrashInfo(trashInfoPath);
+    QStringList trashInfofilelist = dirTrashInfo.entryList(QDir::NoDotAndDotDot | QDir::Files);
+    QStringList filterTrashInfofilelist = trashInfofilelist.filter(originalInfo.baseName() + ".");
+
+    //根据目标文件后缀名，做进一步筛选
+    filterTrashInfofilelist = filterTrashInfofilelist.filter("." + originalInfo.completeSuffix() + ".trashinfo");
+
+    //遍历trashinfo同名文件，验证目标文件是否在其中
+    for (int i = 0; i < filterTrashInfofilelist.size(); i++) {
+        QString filterTrashInfofilePath = trashInfoPath + "/" + filterTrashInfofilelist[i];
+        QSettings setting(filterTrashInfofilePath, QSettings::IniFormat);
+        QString path = setting.value("Trash Info/Path").toString();
+        if (path == fileRestorePath) {
+            std::remove(filterTrashInfofilePath.toStdString().c_str());
+            QString filepath = filterTrashInfofilelist[i];
+            filepath = trashFilesPath + "/" + filepath.remove(".trashinfo");
+            std::remove(filepath.toStdString().c_str());
+            return true;
+        }
     }
-    infopath = trashInfoPath + "/" + trashname + ".trashinfo";
-    filepath = trashFilesPath + "/" + trashname;
 
-    std::remove(infopath.toStdString().c_str());
-    std::remove(filepath.toStdString().c_str());
+    return false;
+}
 
-    return true;
+bool isFileInTrash(const QString &file)
+{
+    QString trashPath;
+    QString trashInfoPath;
+    bool isFileIn = false;
+
+    QString home = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    trashPath = home + "/.local/share/Trash";
+    trashInfoPath = trashPath + "/info";
+
+    QFileInfo originalInfo(file);
+    // restore filepath
+    QString fileRestorePath = QString(originalInfo.absoluteFilePath().toUtf8().toPercentEncoding("/"));
+
+    //查找回收站里所有与目标文件同名的文件列表
+    QDir dirTrashInfo(trashInfoPath);
+    QStringList trashInfofilelist = dirTrashInfo.entryList(QDir::NoDotAndDotDot | QDir::Files);
+    QStringList filterTrashInfofilelist = trashInfofilelist.filter(originalInfo.baseName() + ".");
+
+    //遍历同名文件，验证目标文件是否在其中
+    for (int i = 0; i < filterTrashInfofilelist.size(); i++) {
+        QString filterTrashInfofilePath = trashInfoPath + "/" + filterTrashInfofilelist[i];
+        QSettings setting(filterTrashInfofilePath, QSettings::IniFormat);
+        QString path = setting.value("Trash Info/Path").toString();
+        if (path == fileRestorePath) {
+            isFileIn = true;
+            break;
+        }
+    }
+
+    return isFileIn;
 }
 
 QString getDeleteFullPath(const QString &hash, const QString &fileName)

--- a/src/album/utils/baseutils.h
+++ b/src/album/utils/baseutils.h
@@ -250,6 +250,8 @@ bool isVaultFile(const QString &path);
 bool trashFile(const QString &file);
 //彻底删除，删除回收站对应的文件
 bool delTrashFile(const QString &file);
+//判断文件是否在回收站里
+bool isFileInTrash(const QString &file);
 //生成deepin-album-delete下的文件路径，hash：原始路径hash，fileName：文件名
 QString getDeleteFullPath(const QString &hash, const QString &fileName);
 //同步文件拷贝，用于区分QFile::copy的异步拷贝


### PR DESCRIPTION
Description: 相册添加主动监视回收站机制，启动一个线程，每秒钟轮询一次所有最近删除的文件，如果在回收站中找不到，就删除

Log: 修复回收站删除、还原与相册的最近删除未同步问题
Bug: https://pms.uniontech.com/bug-view-158861.html