### PR TITLE
fix: 修复删除配置文件后重启相册，有概率导致相册崩溃

### DIFF
--- a/src/album/controller/configsetter.cpp
+++ b/src/album/controller/configsetter.cpp
@@ -37,7 +37,7 @@ ConfigSetter *ConfigSetter::instance()
 void ConfigSetter::setValue(const QString &group, const QString &key,
                             const QVariant &value)
 {
-//    QMutexLocker locker(&m_mutex);
+    QMutexLocker locker(&m_mutex);
 
     m_settings->beginGroup(group);
     m_settings->setValue(key, value);


### PR DESCRIPTION
原因是多线程执行配置文件读写，导致QSetting内部负责group管理的QStack崩溃
解决方法是加上线程锁

Log: 修复删除配置文件后重启相册，有概率导致相册崩溃
Bug: https://pms.uniontech.com/bug-view-169613.html