### PR TITLE
fix: 修复未限制相册名长度

### DIFF
--- a/src/album/dialogs/albumcreatedialog.cpp
+++ b/src/album/dialogs/albumcreatedialog.cpp
@@ -95,6 +95,7 @@ void AlbumCreateDialog::initUI()
     edit->setClearButtonEnabled(false);
     edit->setFixedSize(360, 36);
     edit->move(10, 79);
+    edit->lineEdit()->setMaxLength(255);
     DFontSizeManager::instance()->bind(edit, DFontSizeManager::T6, QFont::DemiBold);
     addButton(tr("Cancel"), false, DDialog::ButtonNormal);
     addButton(tr("Create"), true, DDialog::ButtonRecommend);

--- a/src/album/widgets/albumlefttabitem.cpp
+++ b/src/album/widgets/albumlefttabitem.cpp
@@ -176,8 +176,7 @@ void AlbumLeftTabItem::initUI()
     m_pLineEdit->lineEdit()->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
 
     m_pLineEdit->setVisible(false);
-//    m_pLineEdit->setMaxLength(64);
-    m_pLineEdit->lineEdit()->setMaxLength(64);
+    m_pLineEdit->lineEdit()->setMaxLength(255);
 
     m_pLineEdit->setClearButtonEnabled(false);
 


### PR DESCRIPTION
根据需求文档要求，将相册名的创建长度和重命名均限制在255个字符以内

Log: 修复未限制相册名长度
Bug: https://pms.uniontech.com/bug-view-164741.html