### PR TITLE
fix: 修复部分数据库读写操作未对字符串进行转义

### DIFF
--- a/src/album/dialogs/albumcreatedialog.cpp
+++ b/src/album/dialogs/albumcreatedialog.cpp
@@ -95,7 +95,7 @@ void AlbumCreateDialog::initUI()
     edit->setClearButtonEnabled(false);
     edit->setFixedSize(360, 36);
     edit->move(10, 79);
-    edit->lineEdit()->setMaxLength(255);
+    edit->lineEdit()->setMaxLength(utils::common::ALBUM_NAME_MAX_LENGTH);
     DFontSizeManager::instance()->bind(edit, DFontSizeManager::T6, QFont::DemiBold);
     addButton(tr("Cancel"), false, DDialog::ButtonNormal);
     addButton(tr("Create"), true, DDialog::ButtonRecommend);

--- a/src/album/utils/baseutils.h
+++ b/src/album/utils/baseutils.h
@@ -82,7 +82,7 @@ const int SHADOW_BORDER_RADIUS = 14;
 const int BORDER_WIDTH = 0;
 const int BORDER_WIDTH_SELECTED = 7;
 const int THUMBNAIL_MAX_SCALE_SIZE = 192;
-
+const int ALBUM_NAME_MAX_LENGTH = 255;
 
 const QColor DARK_BACKGROUND_COLOR = QColor("#252525");
 const QColor DARK_BACKGROUND_COLOR2 = QColor(0, 0, 0, 76);

--- a/src/album/widgets/albumlefttabitem.cpp
+++ b/src/album/widgets/albumlefttabitem.cpp
@@ -176,7 +176,7 @@ void AlbumLeftTabItem::initUI()
     m_pLineEdit->lineEdit()->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
 
     m_pLineEdit->setVisible(false);
-    m_pLineEdit->lineEdit()->setMaxLength(255);
+    m_pLineEdit->lineEdit()->setMaxLength(utils::common::ALBUM_NAME_MAX_LENGTH);
 
     m_pLineEdit->setClearButtonEnabled(false);
 


### PR DESCRIPTION
现象是当相册名存在特殊SQL字符时，会导致相册创建失败
解决方法是使用SQLite3自带的转义工具进行转义，确保带特殊字符的相册创建成功

Log: 修复部分数据库读写操作未对字符串进行转义
Bug: https://pms.uniontech.com/bug-view-163535.html