### PR TITLE
fix: 修复在相册sheet页面，搜索后幻灯片播放并结束，自动调整到所有照片sheet

### DIFF
--- a/src/album/searchview/searchview.cpp
+++ b/src/album/searchview/searchview.cpp
@@ -307,6 +307,7 @@ void SearchView::onSlideShow(const QString &path)
     info.fullScreen = true;
     info.slideShow = true;
     info.viewType = utils::common::VIEW_SEARCH_SRN;
+    info.viewMainWindowID = VIEW_MAINWINDOW_ALBUM;
     emit dApp->signalM->startSlideShow(info);
 }
 


### PR DESCRIPTION
Description: 播放幻灯片，传入当前窗口id

Log: 修复在相册sheet页面，搜索后幻灯片播放并结束，自动调整到所有照片sheet
Bug: https://pms.uniontech.com/bug-view-164731.html