### PR TITLE
fix: 修复新建相册时，输入html标签，会被解析成页面的问题

### DIFF
--- a/src/album/dialogs/albumcreatedialog.cpp
+++ b/src/album/dialogs/albumcreatedialog.cpp
@@ -96,6 +96,12 @@ void AlbumCreateDialog::initUI()
     edit->setFixedSize(360, 36);
     edit->move(10, 79);
     edit->lineEdit()->setMaxLength(utils::common::ALBUM_NAME_MAX_LENGTH);
+
+    // 相册名称限制特殊字符输入
+    QRegExp regExp("[^/\\\\\\[\\]:|<>+=;,?*'\"]+");
+    QRegExpValidator *pattern = new QRegExpValidator(regExp, this);
+    edit->lineEdit()->setValidator(pattern);
+
     DFontSizeManager::instance()->bind(edit, DFontSizeManager::T6, QFont::DemiBold);
     addButton(tr("Cancel"), false, DDialog::ButtonNormal);
     addButton(tr("Create"), true, DDialog::ButtonRecommend);

--- a/src/album/widgets/albumlefttabitem.cpp
+++ b/src/album/widgets/albumlefttabitem.cpp
@@ -178,6 +178,11 @@ void AlbumLeftTabItem::initUI()
     m_pLineEdit->setVisible(false);
     m_pLineEdit->lineEdit()->setMaxLength(utils::common::ALBUM_NAME_MAX_LENGTH);
 
+    // 相册名称限制特殊字符输入
+    QRegExp regExp("[^/\\\\\\[\\]:|<>+=;,?*'\"]+");
+    QRegExpValidator *pattern = new QRegExpValidator(regExp, this);
+    m_pLineEdit->lineEdit()->setValidator(pattern);
+
     m_pLineEdit->setClearButtonEnabled(false);
 
     pHBoxLayout->addWidget(pImageLabel, Qt::AlignVCenter);


### PR DESCRIPTION
Decscription: 限制相册名称输入特殊字符

Log: 修复新建相册时，输入html标签，会被解析成页面的问题

Bug: https://pms.uniontech.com/bug-view-163847.html