### PR TITLE
fix: 修复新建相册时，输入html标签，会被解析成页面的问题

### DIFF
--- a/src/album/widgets/albumlefttabitem.cpp
+++ b/src/album/widgets/albumlefttabitem.cpp
@@ -158,6 +158,9 @@ void AlbumLeftTabItem::initUI()
     m_nameLabel->setForegroundRole(DPalette::TextTitle);
 //    m_nameLabel->setPalette(pa);
 
+    // 设置标签不显示多文本
+    m_nameLabel->setTextFormat(Qt::PlainText);
+
     m_pLineEdit->setParent(pWidget);
     m_pLineEdit->setGeometry(QRect(0, 0, 120, 40));
     if (COMMON_STR_RECENT_IMPORTED == m_albumNameStr) {


### PR DESCRIPTION
Description: 标签不显示多文本内容

Log: 修复新建相册时，输入html标签，会被解析成页面的问题

Bug: https://pms.uniontech.com/bug-view-163847.html