### PR TITLE
fix: 修复导出特殊字符命名的相册，提示导出成功，但实际未导出的问题

### DIFF
--- a/src/album/dialogs/albumcreatedialog.cpp
+++ b/src/album/dialogs/albumcreatedialog.cpp
@@ -96,6 +96,13 @@ void AlbumCreateDialog::initUI()
     edit->setFixedSize(360, 36);
     edit->move(10, 79);
     edit->lineEdit()->setMaxLength(utils::common::ALBUM_NAME_MAX_LENGTH);
+
+    // 相册名称不能包含正斜杠/，与文件路径分割符冲突，否则导出的相册会保存在以"/"之前的字串命名的目录中
+    // 相关bug见：https://pms.uniontech.com/bug-view-163885.html
+    QRegExp regExp("[^/]+");
+    QRegExpValidator *pattern = new QRegExpValidator(regExp, this);
+    edit->lineEdit()->setValidator(pattern);
+
     DFontSizeManager::instance()->bind(edit, DFontSizeManager::T6, QFont::DemiBold);
     addButton(tr("Cancel"), false, DDialog::ButtonNormal);
     addButton(tr("Create"), true, DDialog::ButtonRecommend);

--- a/src/album/widgets/albumlefttabitem.cpp
+++ b/src/album/widgets/albumlefttabitem.cpp
@@ -181,6 +181,12 @@ void AlbumLeftTabItem::initUI()
     m_pLineEdit->setVisible(false);
     m_pLineEdit->lineEdit()->setMaxLength(utils::common::ALBUM_NAME_MAX_LENGTH);
 
+    // 相册名称不能包含正斜杠/，与文件路径分割符冲突，否则导出的相册会保存在以"/"之前的字串命名的目录中
+    // 相关bug见：https://pms.uniontech.com/bug-view-163885.html
+    QRegExp regExp("[^/]+");
+    QRegExpValidator *pattern = new QRegExpValidator(regExp, this);
+    m_pLineEdit->lineEdit()->setValidator(pattern);
+
     m_pLineEdit->setClearButtonEnabled(false);
 
     pHBoxLayout->addWidget(pImageLabel, Qt::AlignVCenter);


### PR DESCRIPTION
Description: 相册名称中包含'/'，程序会把'/'前半部分作为目录创建，后半部分作为文件名写入，因此相册名称限制输入'/'

Log: 修复导出特殊字符命名的相册，提示导出成功，但实际未导出的问题

Bug: https://pms.uniontech.com/bug-view-163885.html