### PR TITLE
fix: 修复筛选条件改变后，我的收藏和自定义相册左上角总数标签未刷新的问题

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -1982,6 +1982,19 @@ void AlbumView::updatePicNum()
     }
 }
 
+void AlbumView::updateTotalLabelNum()
+{
+    if (COMMON_STR_FAVORITES == m_currentType) {
+        //重置数量显示
+        resetLabelCount(m_favoriteThumbnailList->getAppointTypeItemCount(ItemTypePic)
+                        , m_favoriteThumbnailList->getAppointTypeItemCount(ItemTypeVideo), m_pFavoritePicTotal);
+    } else if (COMMON_STR_CUSTOM == m_currentType) {
+        //重置数量显示
+        resetLabelCount(m_customThumbnailList->getAppointTypeItemCount(ItemTypePic)
+                        , m_customThumbnailList->getAppointTypeItemCount(ItemTypeVideo), m_pRightPicTotal);
+    }
+}
+
 void AlbumView::restorePicNum()
 {
     int photoCount = 0;
@@ -2366,6 +2379,7 @@ void AlbumView::sltLoadMountFileList(const QString &path, QStringList fileList)
 //筛选显示，当先列表中内容为无结果
 void AlbumView::slotNoPicOrNoVideo(bool isNoResult)
 {
+    qDebug() << "1....";
     if (sender() == m_customThumbnailList) {
         m_customNoResultWidget->setVisible(isNoResult);
         m_customThumbnailList->setVisible(!isNoResult);
@@ -2386,6 +2400,7 @@ void AlbumView::slotNoPicOrNoVideo(bool isNoResult)
         m_pStatusBar->m_pAllPicNumLabel->setText(QObject::tr("No results"));
     } else {
         updatePicNum();
+        updateTotalLabelNum();
     }
 }
 

--- a/src/album/albumview/albumview.h
+++ b/src/album/albumview/albumview.h
@@ -82,6 +82,7 @@ public:
     void SearchReturnUpdate();
     void restorePicNum();
     void updatePicNum();
+    void updateTotalLabelNum();
     void updateRightView();
     void updateAlbumView(int UID);
     void updateDeviceLeftList();


### PR DESCRIPTION
Description: 筛选内容，补齐刷新标签内容逻辑

Log: 修复筛选条件改变后，我的收藏和自定义相册左上角总数标签未刷新的问题

Bug: https://pms.uniontech.com/bug-view-164245.html