### PR TITLE
fix: 修复相册界面插入U盘,相册顶栏+展示Focus状态

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -2301,6 +2301,7 @@ void AlbumView::sltLoadMountFileList(const QString &path, QStringList fileList)
     //线程已处理完成数据，通知等待窗口计时自动隐藏
     QTimer::singleShot(1500, this, [ = ] {
         m_waitDeviceScandialog->close();
+        m_pRightPhoneThumbnailList->setFocus();
     });
     QString strPath;
     QString phoneTitle;


### PR DESCRIPTION
Description: 挂载设备数据更新完成后设置右视图获取焦点

Log: 修复相册界面插入U盘,相册顶栏+展示Focus状态
Bug: https://pms.uniontech.com/bug-view-164389.html