### PR TITLE
fix: 修复移除挂载手机设备时，设备模块偶现未被移除的问题

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -932,8 +932,7 @@ void AlbumView::updateAlbumView(int UID)
 
 void AlbumView::updateDeviceLeftList()
 {
-    bool tempB = false;
-    m_mounts.count() > 0 ? tempB = true : tempB = false;
+    bool tempB = m_pLeftListView->m_pMountListWidget->count() > 0;
     // 有设备接入时，左边栏显示设备item
     m_pLeftListView->m_pMountListWidget->setVisible(tempB);
     m_pLeftListView->m_pMountWidget->setVisible(tempB);


### PR DESCRIPTION
Description: 挂载标签的显隐不应由mount数决定，改为由设备列表是否内容来决定，设备列表无内容，隐藏设备标签，否则显示

Log: 修复移除挂载收集设备时，设备模块偶现未被移除的问题

Bug: https://pms.uniontech.com/bug-view-164351.html