### PR TITLE
fix: 修复相册名称过长时与界面控件重叠

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -650,6 +650,7 @@ void AlbumView::initCustomAlbumWidget()
             onBatchSelectChanged(cancel);
         }
     }, Qt::QueuedConnection);
+    connect(m_customBatchOperateWidget, &BatchOperateWidget::sigFilterBtnWidthChanged, this, &AlbumView::onFilterBtnWidthChanged);
 
     m_customAlbumTitle = new DWidget(m_pCustomAlbumWidget);
     m_customAlbumTitle->setFocusPolicy(Qt::ClickFocus);
@@ -2783,4 +2784,9 @@ void AlbumView::onTrashUpdate()
     if (m_pRightTrashThumbnailList->isVisible()) {
         updateRightTrashView();
     }
+}
+
+void AlbumView::onFilterBtnWidthChanged(int width)
+{
+    adjustTitleContent();
 }

--- a/src/album/albumview/albumview.h
+++ b/src/album/albumview/albumview.h
@@ -198,6 +198,8 @@ private slots:
     void onBatchSelectChanged(bool isBatchSelect);
     //默认导入路径已被销毁
     void onMonitorDestroyed(int UID);
+    //筛选条件按钮宽度变化响应槽
+    void onFilterBtnWidthChanged(int width);
 public:
     int m_iAlubmPicsNum;
     QString m_currentAlbum;

--- a/src/album/widgets/batchoperatewidget.cpp
+++ b/src/album/widgets/batchoperatewidget.cpp
@@ -87,6 +87,7 @@ void BatchOperateWidget::initConnection()
     connect(m_cancelBatchSelect, &DCommandLinkButton::clicked, this, &BatchOperateWidget::sltBatchSelectChanged);
     //筛选条件变化
     connect(m_ToolButton, &FilterWidget::currentItemChanged, this, &BatchOperateWidget::sltCurrentFilterChanged);
+    connect(m_ToolButton, &FilterWidget::sigWidthChanged, this, &BatchOperateWidget::sigFilterBtnWidthChanged);
     //点击最近删除恢复按钮
     connect(m_trashRecoveryBtn, &DPushButton::clicked, this, &BatchOperateWidget::onTrashRecoveryBtnClicked);
     //点击最近删除中删除按钮

--- a/src/album/widgets/batchoperatewidget.h
+++ b/src/album/widgets/batchoperatewidget.h
@@ -76,6 +76,8 @@ signals:
     void signalBatchSelectChanged(bool isBatchSelect);
     //取消全选时通知标题栏刷新
     void sigCancelAll(bool cancel);
+    //筛选条件按钮宽度变化信号
+    void sigFilterBtnWidthChanged(int width);
 public slots:
     //批量操作状态改变
     void sltBatchSelectChanged();

--- a/src/album/widgets/expansionmenu.cpp
+++ b/src/album/widgets/expansionmenu.cpp
@@ -117,6 +117,12 @@ bool FilterWidget::eventFilter(QObject *obj, QEvent *event)
     return QWidget::eventFilter(obj, event);
 }
 
+void FilterWidget::resizeEvent(QResizeEvent *e)
+{
+    sigWidthChanged(this->width());
+    QWidget::resizeEvent(e);
+}
+
 
 ExpansionMenu::ExpansionMenu(QWidget *parent)
     : QObject(parent)

--- a/src/album/widgets/expansionmenu.h
+++ b/src/album/widgets/expansionmenu.h
@@ -32,6 +32,7 @@ class FilterWidget : public QWidget
 public:
     explicit FilterWidget(QWidget *parent);
     ~FilterWidget() override;
+    void resizeEvent(QResizeEvent *e) override;
 
     void setIcon(QIcon icon);
     void setText(QString text);
@@ -46,6 +47,7 @@ protected:
 signals:
     void clicked();
     void currentItemChanged(ExpansionPanel::FilteData &data);
+    void sigWidthChanged(int width);
 public:
     FilterLabel        *m_btn = nullptr;
     FilterLabel        *m_leftLabel = nullptr;


### PR DESCRIPTION
Description: 筛选按钮宽度发生变化后，发出消息，通知标题栏做出相应调整

Log: 修复相册名称过长时与界面控件重叠
Bug: https://pms.uniontech.com/bug-view-164275.html