### PR TITLE
fix: 选择任意图片，右键以相册打开，通过xwininfo查询，只返回应用名称，未显示绝对路径

### DIFF
--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -80,7 +80,8 @@ MainWindow::MainWindow()
     //性能优化，此句在构造时不需要执行，增加启动时间,放在showevent之后队列执行
     loadZoomRatio();
     m_bVector << true << true << true;
-
+    //主动设置wintitle
+    setWindowTitleInfo();
     //平板模式下屏蔽最大化最小化及关闭按钮
 #ifdef tablet_PC
     setWindowFlags(windowFlags() & ~(Qt::WindowMinMaxButtonsHint | Qt::WindowCloseButtonHint));


### PR DESCRIPTION
Description: 右键用相册打开图片，此时图片加载完成，不会发送sigUpdateCollectBtn设置wintitle。在打开相册主 动如果有图片信息，主动设置wintitle。

Log: 选择任意图片，右键以相册打开，通过xwininfo查询，只返回应用名称，未显示绝对路径

Bug: https://pms.uniontech.com/bug-view-177469.html