### PR TITLE
fix: 修复侧边栏选中图标颜色未取反的问题

### DIFF
--- a/src/qml/SideBar/SideBarItemDelegate.qml
+++ b/src/qml/SideBar/SideBarItemDelegate.qml
@@ -33,7 +33,7 @@ ItemDelegate {
         anchors.left: item.left; anchors.leftMargin: 10
         anchors.verticalCenter: item.verticalCenter
         name: model.icon
-        palette: DTK.makeIconPalette(root.palette)
+        palette: DTK.makeIconPalette(item.palette)
         sourceSize: Qt.size(20, 20)
     }
 


### PR DESCRIPTION
  重设侧边栏的调色板，保证侧边栏条目checked状态下图标颜色显示正常

Log: 修复侧边栏选中图标颜色未取反的问题