### PR TITLE
fix: 修复相册已启动并最小到任务栏时，双击打开另一张图片，相册界面未置顶显示的问题

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -99,4 +99,11 @@ ApplicationWindow {
     Album.EventGenerator {
         id: eventGenerator
     }
+
+    Connections {
+        target: albumControl
+        onSigActiveApplicationWindow: {
+            root.requestActivate()
+        }
+    }
 }

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -2661,4 +2661,6 @@ void AlbumControl::onNewAPPOpen(qint64 pid, const QStringList &arguments)
             emit sigOpenImageFromFiles(paths);
         }
     }
+
+    emit sigActiveApplicationWindow();
 }

--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -442,6 +442,9 @@ signals:
     //发送打开看图查看图片信号
     void sigOpenImageFromFiles(const QStringList &paths);
 
+    // 激活应用主窗口
+    void sigActiveApplicationWindow();
+
 private :
     static AlbumControl *m_instance;
     DBImgInfoList m_infoList;  //全部已导入


### PR DESCRIPTION
  再次打开相册，发送重新激活应用窗口主界面请求

Log: 修复相册已启动并最小到任务栏时，双击打开另一张图片，相册界面未置顶显示的问题

https://pms.uniontech.com/bug-view-183649.html