### PR TITLE
fix: 修复双击打开图片提示不支持格式的问题

### DIFF
--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -541,7 +541,7 @@ QStringList FileControl::parseCommandlineGetPaths()
         QString path = UrlInfo(arguments[i]).toLocalFile();
         if (QFileInfo(path).isFile()) {
             QString filepath = QUrl::fromLocalFile(path).toString();
-            if (isImage(path) || isVideo(path)) {
+            if (isImage(filepath) || isVideo(filepath)) {
                 validPaths.push_back(filepath);
             }
             paths.push_back(filepath);


### PR DESCRIPTION
  应使用url路径判断是否为图片

Log: 修复双击打开图片提示不支持格式的问题