### PR TITLE
fix: 修复loongarch架构插入U盘闪退的问题

### DIFF
--- a/src/album/albumview/albumview.h
+++ b/src/album/albumview/albumview.h
@@ -181,6 +181,7 @@ private slots:
     void onImportViewImportBtnClicked();
     void onImportFailedToView();
     void onWaitDailogTimeout();
+    void onDelayLoadMountTimeout();
     void onLeftListViewMountListWidgetClicked(const QModelIndex &index);
     void onTrashUpdate();
 
@@ -283,6 +284,8 @@ private:
     DWidget *phonetopwidget;
     bool isIgnore;
     QTimer *m_waitDailog_timer;
+    QTimer *m_delayLoadMount_timer; //延迟加载挂载路径-定时器
+    QString m_delayLoadMountPath; //延迟加载路径
     QMap<QString, bool> mountLoadStatus;
 };
 

--- a/src/album/dbmanager/DBandImgOperate.cpp
+++ b/src/album/dbmanager/DBandImgOperate.cpp
@@ -214,8 +214,7 @@ void DBandImgOperate::sltLoadMountFileList(const QString &path)
                 break;
             }
             dir_iterator.next();
-            QFileInfo fileInfo = dir_iterator.fileInfo();
-            allfiles << fileInfo.filePath();
+            allfiles << dir_iterator.filePath();
             if (allfiles.size() == 50) {
                 emit sigMountFileListLoadReady(strPath, allfiles);
             }


### PR DESCRIPTION
   该架构下，存在插入U盘连续发送三组挂载/卸载设备信号的情况，该过程极易导致相册QDirIterator遍历无效目录（已卸载设备目录自然是无效路径）而crash，因此针对loongarch架构机器，做出优化，在收到最后一次挂载信号500ms后，才开始扫描挂载设备目录

Log: 修复loongarch架构插入U盘闪退的问题

Bug: https://pms.uniontech.com/bug-view-190769.html