### PR TITLE
refactor: QML改造，重构QML代码（除日视图、已导入视图）

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -3,13 +3,13 @@ host = https://www.transifex.com
 minimum_perc = 80
 mode = developer
 
-[deepin-album.deepin-album]
+[o:linuxdeepin:p:deepin-album:r:deepin-album]
 file_filter = src/translations/deepin-album_<lang>.ts
 source_file = src/translations/deepin-album.ts
 source_lang = en
 type = QT
 
-[deepin-album.desktop]
+[o:linuxdeepin:p:deepin-album:r:deepin-album_desktop]
 file_filter = src/translations/desktop/desktop_<lang>.ts
 source_file = src/translations/desktop/desktop.ts
 source_lang = en

--- a/LICENSES/GPL-2.0-or-later.txt
+++ b/LICENSES/GPL-2.0-or-later.txt
@@ -1,0 +1,117 @@
+GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is covered by the GNU Lesser General Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Program", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change.
+
+     b) You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License.
+
+     c) If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following:
+
+     a) Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+     b) Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+     c) Accompany it with the information you received as to the offer to distribute corresponding source code. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place counts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the program's name and an idea of what it does. Copyright (C) yyyy name of author
+
+     This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it starts in an interactive mode:
+
+     Gnomovision version 69, Copyright (C) year name of author Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than `show w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:
+
+     Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+signature of Ty Coon, 1 April 1989 Ty Coon, President of Vice

--- a/LICENSES/LGPL-2.0-or-later.txt
+++ b/LICENSES/LGPL-2.0-or-later.txt
@@ -1,0 +1,174 @@
+GNU LIBRARY GENERAL PUBLIC LICENSE
+
+Version 2, June 1991
+
+Copyright (C) 1991 Free Software Foundation, Inc.
+51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Library General Public License, applies to some specially designated Free Software Foundation software, and to any other libraries whose authors decide to use it. You can use it for your libraries, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library, or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link a program with the library, you must provide complete object files to the recipients so that they can relink them with the library, after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+Our method of protecting your rights has two steps: (1) copyright the library, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the library.
+
+Also, for each distributor's protection, we want to make certain that everyone understands that there is no warranty for this free library. If the library is modified by someone else and passed on, we want its recipients to know that what they have is not the original version, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that companies distributing free software will individually obtain patent licenses, thus in effect transforming the program into proprietary software. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License, which was designed for utility programs. This license, the GNU Library General Public License, applies to certain designated libraries. This license is quite different from the ordinary one; be sure to read it in full, and don't assume that anything in it is the same as in the ordinary license.
+
+The reason we have a separate public license for some libraries is that they blur the distinction we usually make between modifying or adding to a program and simply using it. Linking a program with a library, without changing the library, is in some sense simply using the library, and is analogous to running a utility program or application program. However, in a textual and legal sense, the linked executable is a combined work, a derivative of the original library, and the ordinary General Public License treats it as such.
+
+Because of this blurred distinction, using the ordinary General Public License for libraries did not effectively promote software sharing, because most developers did not use the libraries. We concluded that weaker conditions might promote sharing better.
+
+However, unrestricted linking of non-free programs would deprive the users of those programs of all benefit from the free status of the libraries themselves. This Library General Public License is intended to permit developers of non-free programs to use free libraries, while preserving your freedom as a user of such programs to change the free libraries that are incorporated in them. (We have not seen how to achieve this as regards changes in header files, but we have achieved it as regards changes in the actual functions of the Library.) The hope is that this will lead to faster development of free libraries.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, while the latter only works together with the library.
+
+Note that it is possible for a library to be covered by the ordinary General Public License rather than by this special one.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Library General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) The modified work must itself be a software library.
+
+     b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+     c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+     d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also compile or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+     a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+     b) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+     c) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+     d) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+     b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Library General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the library's name and an idea of what it does.
+     Copyright (C) year  name of author
+
+     This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+     This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public License for more details.
+
+     You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+the library `Frob' (a library for tweaking knobs) written
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+Ty Coon, President of Vice
+
+That's all there is to it!

--- a/src/deepin-album.qrc
+++ b/src/deepin-album.qrc
@@ -61,5 +61,8 @@
         <file>qml/MenuItemStates.qml</file>
         <file>qml/PreviewImageViewer/MultiImageListView.qml</file>
         <file>qml/PopProgress/StandardProgressDialog.qml</file>
+        <file>qml/Control/ListView/ThumbnailListView2.qml</file>
+        <file>qml/Control/ListView/ThumbnailListDelegate2.qml</file>
+        <file>qml/Control/ListView/ThumbnailListViewTools.js</file>
     </qresource>
 </RCC>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,12 +111,12 @@ int main(int argc, char *argv[])
     //设置为相册模式
     fileControl->setViewerType(imageViewerSpace::ImgViewerTypeAlbum);
 
+    char uri[] = "org.deepin.album";
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     qmlRegisterType<QAbstractItemModel>();
 #else
     qmlRegisterAnonymousType<QAbstractItemModel>(uri, 0);
 #endif
-    char uri[] = "org.deepin.album";
     qmlRegisterType<ImageDataModel>(uri, 1, 0, "ImageDataModel");
     qmlRegisterType<ThumbnailModel>(uri, 1, 0, "ThumbnailModel");
     qmlRegisterType<ItemViewAdapter>(uri, 1, 0, "ItemViewAdapter");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,19 @@
 #include "src/cursortool.h"
 #include "src/albumControl.h"
 
+#include "src/imageengine/imagedataservice.h"
+#include "thumbnailview/itemviewadapter.h"
+#include "thumbnailview/positioner.h"
+#include "thumbnailview/rubberband.h"
+#include "thumbnailview/mouseeventlistener.h"
+#include "thumbnailview/eventgenerator.h"
+
+#include "thumbnailview/roles.h"
+#include "thumbnailview/imagedatamodel.h"
+#include "thumbnailview/thumbnailmodel.h"
+#include "thumbnailview/types.h"
+#include "thumbnailview/qimageitem.h"
+
 #include <dapplicationhelper.h>
 #include <DApplication>
 
@@ -70,6 +83,8 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("asynImageProvider", load->m_asynImageProvider);
     engine.rootContext()->setContextProperty("publisher", load->m_publisher);
 
+    engine.rootContext()->setContextProperty("imageDataService", ImageDataService::instance());
+
     FileControl *fileControl = new FileControl();
     engine.rootContext()->setContextProperty("fileControl", fileControl);
     // 关联文件处理（需要保证优先处理，onImageFileChanged已做多线程安全）
@@ -95,6 +110,24 @@ int main(int argc, char *argv[])
 
     //设置为相册模式
     fileControl->setViewerType(imageViewerSpace::ImgViewerTypeAlbum);
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    qmlRegisterType<QAbstractItemModel>();
+#else
+    qmlRegisterAnonymousType<QAbstractItemModel>(uri, 0);
+#endif
+    char uri[] = "org.deepin.album";
+    qmlRegisterType<ImageDataModel>(uri, 1, 0, "ImageDataModel");
+    qmlRegisterType<ThumbnailModel>(uri, 1, 0, "ThumbnailModel");
+    qmlRegisterType<ItemViewAdapter>(uri, 1, 0, "ItemViewAdapter");
+    qmlRegisterType<Positioner>(uri, 1, 0, "Positioner");
+    qmlRegisterType<RubberBand>(uri, 1, 0, "RubberBand");
+    qmlRegisterType<MouseEventListener>(uri, 1, 0, "MouseEventListener");
+    qmlRegisterType<EventGenerator>(uri, 1, 0, "EventGenerator");
+    qmlRegisterUncreatableType<Types>(uri, 1, 0, "Types", "Cannot instantiate the Types class");
+    qmlRegisterUncreatableType<Roles>(uri, 1, 0, "Roles", "Cannot instantiate the Roles class");
+
+    qmlRegisterType<QImageItem>(uri, 1, 0, "QImageItem");
 
     engine.load(QUrl(QStringLiteral("qrc:/qml/main.qml")));
     if (engine.rootObjects().isEmpty())

--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -50,7 +50,10 @@ TitleBar {
             }
         } else {
             if (rightLayout.anchors.leftMargin === layoutLeftMargin_AlignLeft && (lastWidth < width)) {
-                layoutMoveToRightAnimation.start()
+                if (global.loading)
+                    rightLayout.anchors.leftMargin = layoutLeftMargin_AlignRight
+                else
+                    layoutMoveToRightAnimation.start()
             }
         }
 
@@ -260,6 +263,7 @@ TitleBar {
                     id:allButton
                     Layout.preferredHeight: parent.height
                     checkable: true
+                    checked: true
                     text: qsTr("All")
                     onClicked: {
                         collectionBtnClicked(3)
@@ -297,6 +301,7 @@ TitleBar {
                 Layout.fillWidth: true
                 textRole: "text"
                 iconNameRole: "icon"
+                currentIndex: 3
                 flat: false
                 visible: global.currentViewIndex === GlobalVar.ThumbnailViewType.Collecttion && albumControl.getYears(refreshVisible).length !== 0 && root.width <= showCollComboWidth
 
@@ -482,8 +487,6 @@ TitleBar {
 
         Component.onCompleted: {
             rightLayout.anchors.leftMargin = title.width <= global.needHideSideBarWidth ? layoutLeftMargin_AlignLeft : layoutLeftMargin_AlignRight
-            // 第一次打开相册，默认显示所有项目界面
-            collectionCombo.setCurrentIndex(3)
         }
     }
 

--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -204,6 +204,7 @@ TitleBar {
                 onClicked: {
                     //1.图片推送器切换
                     asynImageProvider.switchLoadMode()
+		    imageDataService.switchLoadMode()
 
                     //切换图标
                     if(icon.name === "range1"){
@@ -384,7 +385,7 @@ TitleBar {
             spacing: 5
             Layout.alignment: Qt.AlignRight
             ToolButton {
-                visible: global.selectedPaths.length === 0
+                visible: global.selectedPaths.length === 0 || global.currentViewIndex === GlobalVar.ThumbnailViewType.Device
                 id: titleImportBtn
                 Layout.preferredWidth: 36
                 Layout.preferredHeight: 36
@@ -416,7 +417,7 @@ TitleBar {
                 ToolTip.timeout: 5000
                 ToolTip.visible: hovered
                 ToolTip.text: canFavorite ? qsTr("Favorite") : qsTr("Unfavorite")
-                DciIcon.mode: DTK.ControlState.HoveredState
+                DciIcon.mode: DTK.HoveredState
                 icon {
                     name: canFavorite ? "toolbar-collection" : "toolbar-collection2"
                     width: 36
@@ -439,7 +440,7 @@ TitleBar {
 
             ToolButton {
                 id: titleRotateBtn
-                visible: (titleImportBtn.visible ? false : true)
+                visible: (titleImportBtn.visible ? false : true) && global.currentViewIndex !== GlobalVar.ThumbnailViewType.Device
                 enabled: fileControl.isRotatable(global.selectedPaths)
                 ColorSelector.disabled: !fileControl.isRotatable(global.selectedPaths)
                 Layout.preferredWidth: 36
@@ -459,7 +460,7 @@ TitleBar {
             }
             ToolButton {
                 id: titleTrashBtn
-                visible: (titleImportBtn.visible ? false : true)
+                visible: (titleImportBtn.visible ? false : true) && global.currentViewIndex !== GlobalVar.ThumbnailViewType.Device
                 enabled: fileControl.isCanDelete(global.selectedPaths)
                 ColorSelector.disabled: !fileControl.isCanDelete(global.selectedPaths)
                 Layout.preferredWidth: 36

--- a/src/qml/Control/ListView/ThumbnailListDelegate2.qml
+++ b/src/qml/Control/ListView/ThumbnailListDelegate2.qml
@@ -85,48 +85,21 @@ Rectangle {
         visible: false
     }
 
-    //缩略图本体
-//    Image {
-//        id: image
-//        //source: modelData.url !== "" ? "image://asynImageProvider/" + m_displayFlushHelper + theView.displayFlushHelper.toString() + "_" + modelData.url : ""
-//        source: model
-//        asynchronous: false
-//        anchors.centerIn: parent
-//        width: parent.width - 14
-//        height: parent.height - 14
-//        //使用PreserveAspectFit确保在原始比例下不变形
-//        fillMode: Image.PreserveAspectFit
-//        visible: false
+    Loader {
+        id: damageIconLoader
+        anchors.centerIn: parent
 
-//        //由于qml图片加载状态值在使用QQuickAsyncImageProvider异步加载方式后有异常（图片加载错误没有设置错误状态），暂时自定义类型进行判断错误状态
-//        property bool bLoadError: false
-
-//        onStatusChanged: {
-//            if (status === Image.Ready && sourceSize === Qt.size(0, 0)) {
-//                bLoadError = true;
-//            } else {
-//                bLoadError = false;
-//            }
-//        }
-//    }
-
-//    Loader {
-//        id: damageIconLoader
-//        anchors.centerIn: parent
-
-//        // 判断是否加载错误图片状态组件
-//        //active: image.status === Image.Error
-//        active: image.bLoadError
-//        sourceComponent: ActionButton {
-//            anchors.centerIn: parent
-//            ColorSelector.hovered: false
-//            icon {
-//                name: "photo_breach"
-//                width: image.width
-//                height: image.height
-//            }
-//        }
-//    }
+        active: image.null
+        sourceComponent: ActionButton {
+            anchors.centerIn: parent
+            ColorSelector.hovered: false
+            icon {
+                name: "photo_breach"
+                width: image.width
+                height: image.height
+            }
+        }
+    }
 
     // 图片保存完成，缩略图区域重新加载当前图片
     Connections {

--- a/src/qml/Control/ListView/ThumbnailListDelegate2.qml
+++ b/src/qml/Control/ListView/ThumbnailListDelegate2.qml
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.11
+import QtQuick.Window 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
+import QtQml.Models 2.11
+import QtQml 2.11
+import QtQuick.Shapes 1.10
+import org.deepin.dtk 1.0
+import QtGraphicalEffects 1.0
+
+import org.deepin.album 1.0 as Album
+
+import "../"
+import "../../"
+import "./"
+
+Rectangle {
+    color: Qt.rgba(0,0,0,0)
+    //注意：在model里面加进去的变量，这边可以直接进行使用，只是部分位置不好拿到，需要使用变量
+    property string m_index
+    property string m_displayFlushHelper
+    property QtObject modelData
+
+    property int index: model.index
+    property bool blank: model.blank
+    property bool bSelected: model.selected !== undefined ? model.selected : false
+    property bool bHovered: false //属性：是否hover
+    property bool bFavorited: albumControl.photoHaveFavorited(model.url, global.bRefreshFavoriteIconFlag)
+    property Item imageItem: image
+    property Item favoriteBtn: null
+
+    onBSelectedChanged: {
+        if (bSelected && model.modelType !== Album.Types.Device) {
+            if (favoriteBtn == null) {
+                favoriteBtn = favoriteComponent.createObject(buttons)
+            }
+        } else {
+            if (favoriteBtn && !bFavorited) {
+                favoriteBtn.destroy()
+                favoriteBtn = null
+            }
+        }
+    }
+
+    onBFavoritedChanged: {
+        if (bFavorited) {
+            if (favoriteBtn == null) {
+                favoriteBtn = favoriteComponent.createObject(buttons)
+            }
+        } else {
+            if (favoriteBtn && !bHovered && !bSelected) {
+                favoriteBtn.destroy()
+                favoriteBtn = null
+            }
+        }
+    }
+
+    //选中后显示的阴影框
+    Rectangle {
+        id: selectShader
+        anchors.centerIn: parent
+        width: parent.width
+        height: parent.height
+        radius: 10
+        color: "#AAAAAA"
+        visible: bSelected
+        opacity: 0.4
+    }
+
+    Album.QImageItem {
+        id: image
+        anchors.centerIn: parent
+        width: parent.width - 14
+        height: parent.height -14
+        smooth: true
+        image: {
+            gridView.bRefresh
+            modelData.thumbnail
+        }
+        fillMode: Album.QImageItem.PreserveAspectFit
+        visible: false
+    }
+
+    //缩略图本体
+//    Image {
+//        id: image
+//        //source: modelData.url !== "" ? "image://asynImageProvider/" + m_displayFlushHelper + theView.displayFlushHelper.toString() + "_" + modelData.url : ""
+//        source: model
+//        asynchronous: false
+//        anchors.centerIn: parent
+//        width: parent.width - 14
+//        height: parent.height - 14
+//        //使用PreserveAspectFit确保在原始比例下不变形
+//        fillMode: Image.PreserveAspectFit
+//        visible: false
+
+//        //由于qml图片加载状态值在使用QQuickAsyncImageProvider异步加载方式后有异常（图片加载错误没有设置错误状态），暂时自定义类型进行判断错误状态
+//        property bool bLoadError: false
+
+//        onStatusChanged: {
+//            if (status === Image.Ready && sourceSize === Qt.size(0, 0)) {
+//                bLoadError = true;
+//            } else {
+//                bLoadError = false;
+//            }
+//        }
+//    }
+
+//    Loader {
+//        id: damageIconLoader
+//        anchors.centerIn: parent
+
+//        // 判断是否加载错误图片状态组件
+//        //active: image.status === Image.Error
+//        active: image.bLoadError
+//        sourceComponent: ActionButton {
+//            anchors.centerIn: parent
+//            ColorSelector.hovered: false
+//            icon {
+//                name: "photo_breach"
+//                width: image.width
+//                height: image.height
+//            }
+//        }
+//    }
+
+    // 图片保存完成，缩略图区域重新加载当前图片
+    Connections {
+        target: fileControl
+        onCallSavePicDone: {
+            if (path === model.url) {
+                model.reloadThumbnail
+            }
+        }
+    }
+
+    //圆角遮罩Rectangle
+    Rectangle {
+        id: maskRec
+        anchors.centerIn: parent
+        width: image.width
+        height: image.height
+
+        color:"transparent"
+        Rectangle {
+            anchors.centerIn: parent
+            width: image.paintedWidth
+            height: image.paintedHeight
+            color:"black"
+            radius: 10
+        }
+
+        visible: false
+    }
+
+    //遮罩执行
+    OpacityMask {
+        id: mask
+        anchors.fill: image
+        source: image
+        maskSource: maskRec
+    }
+
+    // 边框阴影立体效果
+    DropShadow {
+        anchors.fill: mask
+        z: 0
+
+        verticalOffset: 1
+
+        radius: 5
+        samples: radius * 2 + 1
+        spread: 0.3
+
+        color: "black"
+
+        opacity: 0.3
+
+        source: mask
+
+        visible: true
+    }
+
+    MouseArea {
+        id:mouseAreaTopParentRect
+        anchors.fill: parent
+        hoverEnabled: true
+        propagateComposedEvents: true
+
+        onClicked: {
+            //允许鼠标事件传递给子控件处理,否则鼠标点击缩略图收藏图标不能正常工作
+            mouse.accepted = false
+        }
+
+        onEntered: {
+            if (model.blank)
+                return;
+
+            bHovered = true
+            if (favoriteBtn == null && model.modelType !== Album.Types.Device)
+                favoriteBtn = favoriteComponent.createObject(buttons)
+        }
+
+        onExited: {
+            bHovered = false
+            if (favoriteBtn && !bFavorited && !bSelected) {
+                favoriteBtn.destroy()
+                favoriteBtn = null
+            }
+        }
+    }
+
+    Component {
+        id: favoriteComponent
+        //收藏图标
+        ActionButton {
+            id: itemFavoriteBtn
+            hoverEnabled: false  //设置为false，可以解决鼠标移动到图标附近时，图标闪烁问题
+
+            icon {
+                name: bFavorited ? "collected" : "collection2"
+            }
+
+            MouseArea {
+                id:mouseAreaFavoriteBtn
+                anchors.fill: itemFavoriteBtn
+                propagateComposedEvents: true
+
+                onClicked: {
+                    var paths = []
+                    paths.push(modelData.url)
+
+                    if (bFavorited) {
+                        //取消收藏
+                        albumControl.removeFromAlbum(0, paths)
+                    } else {
+                        //收藏
+                        albumControl.insertIntoAlbum(0, paths)
+                    }
+
+                    global.bRefreshFavoriteIconFlag = !global.bRefreshFavoriteIconFlag
+                    // 若当前视图为我的收藏，需要实时刷新我的收藏列表内容
+                    if (global.currentViewIndex === GlobalVar.ThumbnailViewType.Favorite && global.currentCustomAlbumUId === 0) {
+                        global.sigFlushCustomAlbumView(global.currentCustomAlbumUId)
+                    }
+
+                    mouse.accepted = true
+                }
+
+            }
+        }
+    }
+
+    Column {
+        id: buttons
+
+        visible: true
+
+        anchors {
+            bottom: image.bottom
+            left: image.left
+            leftMargin : (image.width - image.paintedWidth) / 2 + 5
+            bottomMargin : (image.height - image.paintedHeight) / 2 + 5
+        }
+    }
+
+    //选中后显示的图标
+    DciIcon {
+        name: "select_active_1"
+        visible: selectShader.visible
+        anchors.top: image.top
+        anchors.right: image.right
+        anchors.topMargin: 5
+        anchors.rightMargin : 5
+    }
+
+    DciIcon {
+        name: "Inner_shadow"
+        visible: selectShader.visible
+        anchors.top: image.top
+        anchors.right: image.right
+        anchors.topMargin: 5
+        anchors.rightMargin : 5
+    }
+
+    DciIcon {
+        name: "shadow"
+        visible: selectShader.visible
+        anchors.top: image.top
+        anchors.right: image.right
+        anchors.topMargin: 5
+        anchors.rightMargin : 5
+    }
+
+    DciIcon {
+        name: "yes"
+        visible: selectShader.visible
+        anchors.top: image.top
+        anchors.right: image.right
+        anchors.topMargin: 5
+        anchors.rightMargin : 5
+    }
+
+    //剩余天数标签
+    VideoLabel {
+        id: labelRemainDays
+        visible: global.currentViewIndex === GlobalVar.ThumbnailViewType.RecentlyDeleted && !model.blank
+        anchors.bottom: image.bottom
+        anchors.left: image.left
+        anchors.leftMargin : 5
+        anchors.bottomMargin : 5
+        opacity: 0.7
+        displayStr: model.remainDays > 1 ? (model.remainDays + qsTr("days")) : (model.remainDays + qsTr("day"))
+        height: 22
+        width: 44
+    }
+
+    //视频时长标签
+    VideoLabel {
+        id: videoLabel
+        visible: fileControl.isVideo(model.url) && !model.blank
+        anchors.bottom: image.bottom
+        anchors.right: image.right
+        anchors.rightMargin : 5
+        anchors.bottomMargin : 5
+        opacity: 0.7
+        displayStr: fileControl.isVideo(model.url) ? albumControl.getVideoTime(model.url) : "00:00"
+        height: 22
+        width: displayStr.length === 5 ? 44 : 64
+
+        Connections {
+            target: albumControl
+            onSigRefreashVideoTime: {
+                if (url === model.url) {
+                    videoLabel.displayStr = videoTimeStr
+                }
+            }
+        }
+    }
+}

--- a/src/qml/Control/ListView/ThumbnailListView.qml
+++ b/src/qml/Control/ListView/ThumbnailListView.qml
@@ -94,7 +94,7 @@ Item {
 
     //强制重新刷新整个缩略图界面
     function fouceUpdate() {
-        if (visible) {
+        if (thumnailListView && visible) {
             theView.displayFlushHelper = asynImageProvider.getLoadMode()
         }
     }
@@ -105,11 +105,11 @@ Item {
         return global.objIsEmpty(thumbnailListModel) ? 0 : thumbnailListModel.count
     }
 
-    // 获取列表中所有原始路径
-    function allOriginPaths() {
+    // 获取列表中所有原始url
+    function allUrls() {
         var originPaths = []
         for(var i=0 ; i < count(); i++) {
-            originPaths.push(thumbnailListModel.get(i).filePath.toString())
+            originPaths.push(thumbnailListModel.get(i).url.toString())
         }
         return originPaths
     }
@@ -142,13 +142,15 @@ Item {
 
     //执行图片删除操作
     function runDeleteImg() {
-        if ( thumnailListType !== GlobalVar.ThumbnailType.Trash ){
-            albumControl.insertTrash(global.selectedPaths)
-        } else {
-            albumControl.deleteImgFromTrash(selectedOriginPaths)
-            selectAll(false)
-            global.sigFlushRecentDelView()
-        }
+       if (!visible)
+           return
+       if ( thumnailListType !== GlobalVar.ThumbnailType.Trash ){
+           albumControl.insertTrash(global.selectedPaths)
+       } else {
+           albumControl.deleteImgFromTrash(selectedOriginPaths)
+           selectAll(false)
+           global.sigFlushRecentDelView()
+       }
     }
 
     // 查看图片
@@ -743,7 +745,7 @@ Item {
                 text: qsTr("Slide show")
                 visible: menuItemStates.canSlideShow
                 onTriggered: {
-                    var openPaths = thumnailListView.allOriginUrls()
+                    var openPaths = thumnailListView.allUrls()
                     stackControl.startMainSliderShow(openPaths, openPaths.indexOf(selectedPaths[0]))
                 }
 
@@ -752,7 +754,7 @@ Item {
                     autoRepeat: false
                     sequence : "F5"
                     onActivated : {
-                        var openPaths = thumnailListView.allOriginUrls()
+                        var openPaths = thumnailListView.allUrls()
                         stackControl.startMainSliderShow(openPaths, openPaths.indexOf(thumbnailListModel.get(theView.ism[0]).url.toString()))
                     }
                 }

--- a/src/qml/Control/ListView/ThumbnailListView.qml
+++ b/src/qml/Control/ListView/ThumbnailListView.qml
@@ -900,12 +900,6 @@ Item {
                 }
             }
 
-            MenuSeparator {
-                visible: !menuItemStates.isInTrash
-                         && (setAsWallpaperAction.visible || displayInFileManagerAction.visible || photoInfoAction.visible || videoInfoAction.visible)
-                height: visible ? GlobalVar.rightMenuSeparatorHeight : 0
-            }
-
             //设置为壁纸
             RightMenuItem {
                 text: qsTr("Set as wallpaper")

--- a/src/qml/Control/ListView/ThumbnailListView2.qml
+++ b/src/qml/Control/ListView/ThumbnailListView2.qml
@@ -49,8 +49,10 @@ FocusScope {
     property var count: thumbnailModel.count
 
     //缩略图动态变化
-    property int  rowSizeHint: (width - global.thumbnailListRightMargin) / global.cellBaseWidth
-    property real realCellWidth: (width - global.thumbnailListRightMargin) / rowSizeHint
+    property real realCellWidth:  {
+        var rowSizeHint = (width - global.thumbnailListRightMargin) / global.cellBaseWidth
+        return (width - global.thumbnailListRightMargin) / rowSizeHint
+    }
 
     //当前区域时间区间改变信号，字符串可以直接刷新在界面上
     signal timeChanged(string str)
@@ -603,7 +605,7 @@ FocusScope {
                 var midHeight = gridView.cellHeight / 2;
                 var indices = [];
 
-                if (gridView.width > 0) {
+                if (gridView.width > 0 && isFinite(step)) {
                     for (var s = 0; s < stripes; s++) {
                         for (var i = 0; i < perStripe; i++) {
                             var index = (s * perStripe) + i;

--- a/src/qml/Control/ListView/ThumbnailListView2.qml
+++ b/src/qml/Control/ListView/ThumbnailListView2.qml
@@ -1,0 +1,1085 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.9
+import QtQuick.Window 2.2
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
+import QtQml.Models 2.11
+import QtQml 2.11
+import QtQuick.Shapes 1.10
+import org.deepin.dtk 1.0
+import org.deepin.album 1.0 as Album
+
+import "../"
+import "../../"
+import "../../PreviewImageViewer"
+
+import "ThumbnailListViewTools.js" as ThumbnailTools
+
+FocusScope {
+    id : main
+
+    property alias proxyModel: thumbnailModel
+    property QtObject model: thumbnailModel
+
+    property Item rubberBand: null
+
+    property alias enableListenrMouse: listener.enableMouse //使能鼠标操作
+    property bool enableMouse: true
+
+    // 缩略图Item尺寸
+    property real itemWidth: realCellWidth
+    property real itemHeight: realCellWidth
+    // 缩略图显示类型，默认为普通模式
+    property int thumnailListType: GlobalVar.ThumbnailType.Normal
+    // 存在已选项
+    property bool haveSelect: thumbnailModel.selectedIndexes.length > 0
+    // 已选择全部缩略图
+    property bool haveSelectAll: thumbnailModel.selectedIndexes.length === thumbnailModel.rowCount()
+
+    // 已选项个数
+    property int haveSelectCount: thumbnailModel.selectedIndexes.length
+    // 已选路径
+    property var selectedUrls: thumbnailModel.selectedUrls
+    // 已选原始路径
+    property var selectedPaths: thumbnailModel.selectedPaths
+    // 所有项个数
+    property var count: thumbnailModel.count
+
+    //缩略图动态变化
+    property int  rowSizeHint: (width - global.thumbnailListRightMargin) / global.cellBaseWidth
+    property real realCellWidth: (width - global.thumbnailListRightMargin) / rowSizeHint
+
+    //当前区域时间区间改变信号，字符串可以直接刷新在界面上
+    signal timeChanged(string str)
+    signal selectedChanged()
+
+    //设置全选/全取消缩略图
+    function selectAll(doSelect) {
+        if (gridView.visible) {
+            if(doSelect) {
+                thumbnailModel.selectAll()
+            } else {
+                thumbnailModel.clearSelection()
+            }
+        }
+        selectedChanged()
+    }
+
+    function selectUrls(urls) {
+        thumbnailModel.selectUrls(urls)
+    }
+
+    //强制重新刷新整个缩略图界面
+    function fouceUpdate() {
+        if (main && visible) {
+            gridView.bRefresh = !gridView.bRefresh
+        }
+    }
+
+    // 获取列表中项的个数
+    function count()
+    {
+        return thumbnailModel.rowCount()
+    }
+
+    // 获取列表中所有原始路径
+    function allPaths() {
+        return thumbnailModel.allPaths()
+    }
+
+    function allUrls() {
+        return thumbnailModel.allUrls()
+    }
+
+    //统计当前页面的缩略图时间范围
+    function totalTimeScope() {
+        if(thumnailListType === GlobalVar.ThumbnailType.AllCollection &&
+                global.currentViewIndex === GlobalVar.ThumbnailViewType.Collecttion &&
+                collecttionView.currentViewIndex === 3) { //仅在合集模式的时候激活计算，以此节省性能
+            var visilbeIndexs = gridView.rectIndexes(0, 0, gridView.width, gridView.height)
+            if (visilbeIndexs.length > 0) {
+                var url1 = thumbnailModel.data(visilbeIndexs[0], "url")
+                var url2 = thumbnailModel.data(visilbeIndexs[visilbeIndexs.length - 1], "url")
+                var str = albumControl.getFileTime(url1, url2)
+                timeChanged(str)
+            } else {
+                timeChanged("")
+            }
+        }
+    }
+
+//    // 提供给合集日视图和已导入视图使用，用来刷新
+//    function flushRectSel(x,y,w,h,ctrl,mousePress, inPress) {
+//        if (gridView.contains(x,y) && gridView.contains(x+w, y+h) && w !== 0 && h !== 0) {
+//            // 按住Ctrl，鼠标点击事件释放时，处理点选逻辑
+//            if (ctrl && mousePress) {
+//                if (!inPress) {
+//                    var rectSel = gridView.flushRectSel(x, y + gridView.contentY, w, h)
+//                    if (rectSel.length === 1) {
+//            //不直接往theView.ism里面push，是为了触发onIsmChanged
+//                        var tempIsm = gridView.ism
+//                        if (gridView.ism.indexOf(rectSel[0]) === -1) {
+//                            tempIsm.push(rectSel[0])
+//                        } else {
+//                            tempIsm.splice(tempIsm.indexOf(rectSel[0]), 1)
+//                        }
+//                        gridView.ism = tempIsm
+//                    }
+//                }
+//            } else {
+//                gridView.ism = gridView.flushRectSel(x, y + gridView.contentY, w, h)
+//            }
+//        } else {
+//            // 1.按住ctrl，鼠标垮区域框选时，需要清空框选区域外的已选项
+//            // 2.不按住ctrl，鼠标单选，需要清空其他列表的已选项
+//            if (!ctrl && mousePress || ctrl && !mousePress)
+//                gridView.ism = []
+//        }
+
+//        // 跨区域框选后，需要手动激活列表焦点，这样快捷键才能生效
+//        if (gridView.ism.length > 0) {
+//            gridView.forceActiveFocus()
+//        }
+
+//        selectedChanged()
+//    }
+
+    Connections {
+        target: thumbnailImage
+        onEscKeyPressed: {
+            if (haveSelect) {
+                selectAll(false)
+            }
+        }
+    }
+
+    Album.MouseEventListener {
+        id: listener
+
+        anchors { fill: parent }
+
+        property Item pressedItem: null
+        property int pressX: -1
+        property int pressY: -1
+        property variant cPress: null
+        property bool bDbClicked: false
+
+        acceptedButtons: { Qt.LeftButton | Qt.RightButton }
+
+        hoverEnabled: true
+
+        onPressXChanged: {
+            cPress = mapToItem(gridView.contentItem, pressX, pressY)
+        }
+
+        onPressYChanged: {
+            cPress = mapToItem(gridView.contentItem, pressX, pressY);
+        }
+
+        onPressed: {
+            // 鼠标点击在垂直滚动条上，不处理点击事件
+            if (mouse.x >= (parent.width - global.thumbnailListRightMargin - global.thumbnialListCellSpace)) {
+                return;
+            }
+
+            gridView.forceActiveFocus()
+
+            var cPos = mapToItem(gridView.contentItem, mouse.x, mouse.y)
+            var tempItem = gridView.itemAt(cPos.x, cPos.y);
+            if (tempItem)
+                pressedItem = tempItem;
+            else
+                pressedItem = null;
+
+            if (mouse.source === Qt.MouseEventSynthesizedByQt) {
+                if (indexItem && indexItem.image) {
+                    gridView.currentIndex = index;
+                    pressedItem = indexItem;
+                } else {
+                    pressedItem = null;
+                }
+            }
+
+            pressX = mouse.x;
+            pressY = mouse.y;
+
+            if (!pressedItem || pressedItem.blank) {
+                if (!gridView.ctrlPressed && !global.windowDisActived) {
+                    gridView.currentIndex = -1;
+                    thumbnailModel.clearSelection();
+                }
+            } else {
+                var pos = mapToItem(pressedItem, mouse.x, mouse.y);
+
+                if (pos.x <= pressedItem.width && pos.y <= pressedItem.height) {
+                    if (gridView.shiftPressed && gridView.currentIndex != -1) {
+                        positioner.setRangeSelected(gridView.anchorIndex, pressedItem.index);
+                    } else {
+                        if (!gridView.ctrlPressed && !thumbnailModel.isSelected(positioner.map(pressedItem.index))) {
+                            thumbnailModel.clearSelection();
+                        }
+
+                        if (gridView.ctrlPressed) {
+                            thumbnailModel.toggleSelected(positioner.map(pressedItem.index));
+                        } else {
+                            thumbnailModel.setSelected(positioner.map(pressedItem.index));
+                        }
+                    }
+
+                    gridView.currentIndex = pressedItem.index;
+                }
+            }
+
+            if (mouse.buttons & Qt.RightButton) {
+                clearPressState();
+                if (global.currentViewIndex !== GlobalVar.ThumbnailViewType.Device && haveSelect)
+                    thumbnailMenu.popup(mouse.x, mouse.y)
+
+                mouse.accepted = false;
+            }
+        }
+
+        onCanceled: pressCanceled()
+
+        onReleased: {
+            // 多选后，单选逻辑处理
+            if (pressedItem && !pressedItem.blank && mouse.button !== Qt.RightButton && !main.rubberBand) {
+                var pos = mapToItem(pressedItem, mouse.x, mouse.y);
+                if ((pos.x <= pressedItem.width && pos.y <= pressedItem.height)
+                        && (!(gridView.shiftPressed && gridView.currentIndex != -1) && !gridView.ctrlPressed) && haveSelectCount > 1) {
+                    thumbnailModel.clearSelection();
+                    thumbnailModel.setSelected(positioner.map(pressedItem.index));
+                }
+            } else {
+                if (!main.rubberBand && !global.windowDisActived && !(Qt.ControlModifier & mouse.modifiers))
+                    thumbnailModel.clearSelection()
+                global.windowDisActived = false
+            }
+
+            pressCanceled();
+        }
+
+        onPressAndHold: {
+            if (mouse.source === Qt.MouseEventSynthesizedByQt) {
+                clearPressState();
+                if (haveSelect) {
+                    thumbnailMenu.popup(mouse.x, mouse.y)
+                }
+            }
+        }
+
+        onClicked: {
+            clearPressState();
+
+            var cPos = mapToItem(gridView.contentItem, mouse.x, mouse.y);
+            var clickedItem = gridView.itemAt(cPos.x, cPos.y)
+            if (!clickedItem || clickedItem.blank || gridView.currentIndex == -1 || gridView.ctrlPressed || gridView.shiftPressed) {
+                eventGenerator.sendMouseEvent(root, Album.EventGenerator.MouseButtonPress, mouse.x, mouse.y, mouse.button, mouse.buttons, mouse.modifiers);
+                return;
+            }
+
+            var pos = mapToItem(clickedItem, mouse.x, mouse.y);
+            if (pos.x < 0 || pos.x > clickedItem.width || pos.y < 0 || pos.y > clickedItem.height) {
+                thumbnailModel.clearSelection();
+
+                return;
+            }
+
+            // 单击模式点击/双击模式双击打开图片
+            if (Qt.styleHints.singleClickActivation || bDbClicked || mouse.source === Qt.MouseEventSynthesizedByQt) {
+                ThumbnailTools.executeViewImage()
+            }
+            else {
+                bDbClicked = true;
+                dbClickTimer.interval = Qt.styleHints.mouseDoubleClickInterval;
+                dbClickTimer.start();
+            }
+        }
+
+        onPositionChanged: {
+            gridView.ctrlPressed = (mouse.modifiers & Qt.ControlModifier);
+            gridView.shiftPressed = (mouse.modifiers & Qt.ShiftModifier);
+
+            var cPos = mapToItem(gridView.contentItem, mouse.x, mouse.y);
+            var item = gridView.itemAt(cPos.x, cPos.y);
+            var leftEdge = Math.min(gridView.contentX, gridView.originX);
+
+            // 触发自动滚动框选
+            if (pressX != -1) {
+                gridView.scrollUp = (mouse.y <= 0 && gridView.contentY > 0);
+                gridView.scrollDown = (mouse.y >= gridView.height
+                    && gridView.contentY < gridView.contentItem.height - gridView.height);
+            }
+
+            // 更新框选区域
+            if (main.rubberBand) {
+                var rB = main.rubberBand;
+                var ceil = 0;
+                if (cPos.x < cPress.x) {
+                    rB.x = Math.max(leftEdge, cPos.x);
+                    rB.width = Math.abs(rB.x - cPress.x);
+                } else {
+                    rB.x = cPress.x;
+                    ceil = Math.max(gridView.width - global.thumbnailListRightMargin - global.thumbnialListCellSpace, gridView.contentItem.width - global.thumbnailListRightMargin - global.thumbnialListCellSpace) + leftEdge;
+                    rB.width = Math.min(ceil - rB.x, Math.abs(rB.x - cPos.x));
+                }
+
+                if (cPos.y < cPress.y) {
+                    rB.y = Math.max(0, cPos.y);
+                    rB.height = Math.abs(rB.y - cPress.y);
+                } else {
+                    rB.y = cPress.y;
+                    ceil = Math.max(gridView.height, gridView.contentItem.height);
+                    rB.height = Math.min(ceil - rB.y, Math.abs(rB.y - cPos.y));
+                }
+
+                // 确保宽高至少1像素
+                rB.width = Math.max(1, rB.width);
+                rB.height = Math.max(1, rB.height);
+
+                //console.log("rb x:", rB.x, "y:", rB.y, "width:",rB.width, "height:", rB.height)
+                gridView.rectangleSelect(rB.x, rB.y, rB.width, rB.height);
+                return;
+            }
+
+            // 鼠标正在拖动，构建和显示框选框
+            if (pressX != -1 && global.isDrag(pressX, pressY, mouse.x, mouse.y)) {
+                thumbnailModel.pinSelection();
+                main.rubberBand = rubberBandObject.createObject(gridView.contentItem, {x: cPress.x, y: cPress.y})
+                gridView.interactive = false;
+            }
+        }
+
+        Component {
+            id: rubberBandObject
+
+            Album.RubberBand {
+                id: rubberBand
+
+                width: 0
+                height: 0
+                z: 99999
+
+                function close() {
+                    opacityAnimation.restart()
+                }
+
+                OpacityAnimator {
+                    id: opacityAnimation
+                    target: rubberBand
+                    to: 0
+                    from: 1
+                    duration: 200 * 0.5
+
+                    easing {
+                        bezierCurve: [0.4, 0.0, 1, 1]
+                        type: Easing.Bezier
+                    }
+
+                    onStopped: {
+                        rubberBand.visible = false
+                        rubberBand.enabled = false
+                        rubberBand.destroy()
+                    }
+                }
+            }
+        }
+
+        function pressCanceled() {
+            if (main.rubberBand) {
+                main.rubberBand.close()
+                main.rubberBand = null
+
+                gridView.interactive = true;
+                gridView.rectSelIndexes = null;
+                thumbnailModel.unpinSelection();
+            }
+
+            clearPressState();
+            gridView.cancelAutoscroll();
+        }
+
+        function clearPressState() {
+            pressedItem = null;
+            pressX = -1;
+            pressY = -1;
+        }
+
+        Timer {
+            id: dbClickTimer
+
+            onTriggered: {
+                listener.bDbClicked = false;
+            }
+        }
+
+        GridView {
+            id: gridView
+            anchors.fill: parent
+            clip: true
+            interactive: enableMouse
+
+            property int iconSize: 40
+
+            property int anchorIndex: 0
+            property bool ctrlPressed: false
+            property bool shiftPressed: false
+
+            property bool scrollUp: false
+            property bool scrollDown: false
+
+            property bool bRefresh: false
+            property variant rectSelIndexes: null
+            // 滚动滑块Delta值
+            property int scrollDelta: 60
+            currentIndex: -1
+
+            keyNavigationWraps: false
+            boundsBehavior: Flickable.StopAtBounds
+            flickDeceleration: 10000
+
+            //激活滚动条
+            ScrollBar.vertical: ScrollBar {
+                id: vbar
+                active: false
+                onPositionChanged: {
+                    totalTimeScope()
+                }
+            }
+
+            cellWidth: itemWidth
+            cellHeight: itemHeight
+
+            delegate: ThumbnailListDelegate2 {
+                id: thumbnailListDelegate
+                modelData: model
+                m_index: index
+                width: gridView.cellWidth - global.thumbnialListCellSpace
+                height: gridView.cellHeight - global.thumbnialListCellSpace
+
+                onBHoveredChanged: {
+                    listener.bDbClicked = false
+                }
+            }
+
+            // qml子控件消化鼠标移动事件，以便平台插件能够正常处理鼠标拖动事件，解决拖拽列表空隙或空白处，会拖动主界面的问题
+            MouseArea {
+                anchors.fill: parent
+                propagateComposedEvents: true
+                onPositionChanged: {
+                    mouse.accepted = true
+                }
+
+                onWheel: {
+                    if (!enableMouse) {
+                        wheel.accepted = false
+                    }
+
+                    var datla = wheel.angleDelta.y / 2
+                    if (Qt.ControlModifier & wheel.modifiers) {
+                        // 按住ctrl，缩放缩略图
+                        var curValue = statusBar.sliderValue
+                        if (datla > 0)
+                            statusBar.setSliderWidgetValue(curValue + 1)
+                        else
+                            statusBar.setSliderWidgetValue(curValue - 1)
+                        wheel.accepted = true
+                    } else {
+                        gridView.executeScrollBar(datla)
+                        wheel.accepted = false
+                    }
+                }
+            }
+
+            onContentYChanged: {
+
+                vbar.active = true;
+
+                if (contentY == 0) {
+                    scrollUp = false;
+                }
+
+                if (contentY == contentItem.height - height) {
+                    scrollDown = false;
+                }
+
+                // 更新框选框区域
+                if (main.rubberBand) {
+                    var rB = main.rubberBand;
+
+                    if (scrollUp) {
+                        rB.y = 0;
+                        rB.height = listener.cPress.y;
+                    }
+
+                    if (scrollDown) {
+                        var lastRow = gridView.contentY + gridView.height;
+                        rB.height = lastRow - rB.y;
+                    }
+
+                    gridView.rectangleSelect(rB.x, rB.y, rB.width, rB.height);
+                }
+            }
+
+            onScrollUpChanged: {
+                if (scrollUp && gridView.visibleArea.heightRatio < 1.0) {
+                    smoothY.enabled = true;
+                    contentY = 0;
+                } else {
+                    contentY = contentY;
+                    smoothY.enabled = false;
+                }
+            }
+
+            onScrollDownChanged: {
+                if (scrollDown && gridView.visibleArea.heightRatio < 1.0) {
+                    smoothY.enabled = true;
+                    contentY = contentItem.height - height;
+                } else {
+                    contentY = contentY;
+                    smoothY.enabled = false;
+                }
+            }
+
+            onCurrentIndexChanged: {
+                positionViewAtIndex(currentIndex, GridView.Contain);
+            }
+
+            onRectSelIndexesChanged: {
+                if (rectSelIndexes == null) {
+                    return;
+                }
+
+                if (rectSelIndexes.length) {
+                    currentIndex = rectSelIndexes[0];
+                }
+
+                thumbnailModel.updateSelection(rectSelIndexes.map(positioner.map), gridView.ctrlPressed);
+            }
+
+            function updateSelection(modifier) {
+                if (modifier & Qt.ShiftModifier) {
+                    positioner.setRangeSelected(anchorIndex, currentIndex);
+                } else {
+                    thumbnailModel.clearSelection();
+                    thumbnailModel.setSelected(positioner.map(currentIndex));
+                }
+            }
+
+            function cancelAutoscroll() {
+                scrollUp = false;
+                scrollDown = false;
+            }
+
+            // 框选指定区域内容的项目
+            function rectangleSelect(x, y, width, height) {
+                gridView.rectSelIndexes = rectIndexes(x, y, width, height);
+            }
+
+            // 获取指定矩形区域内项目索引
+            function rectIndexes(x, y, w, h) {
+                var rB = null
+                if (main.rubberBand)
+                    rB = main.rubberBand
+                else {
+                    var topleft = mapToItem(gridView.contentItem, x, y)
+                    rB = rubberBandObject.createObject(gridView.contentItem, {x: topleft.x, y: topleft.y})
+                    rB.visible = false
+                    rB.width = w
+                    rB.height = h
+                }
+
+                var rows = (gridView.flow == GridView.FlowLeftToRight);
+                var axis = rows ? gridView.width : gridView.height;
+                var step = rows ? cellWidth : cellHeight;
+                var perStripe = Math.floor(axis / step);
+                var stripes = Math.ceil(gridView.count / perStripe);
+                var cWidth = gridView.cellWidth;
+                var cHeight = gridView.cellHeight;
+                var midWidth = gridView.cellWidth / 2;
+                var midHeight = gridView.cellHeight / 2;
+                var indices = [];
+
+                for (var s = 0; s < stripes; s++) {
+                    for (var i = 0; i < perStripe; i++) {
+                        var index = (s * perStripe) + i;
+
+                        if (index >= gridView.count) {
+                            break;
+                        }
+
+                        if (positioner.isBlank(index)) {
+                            continue;
+                        }
+
+                        var itemX = ((rows ? i : s) * gridView.cellWidth);
+                        var itemY = ((rows ? s : i) * gridView.cellHeight);
+
+                        if (gridView.effectiveLayoutDirection == Qt.RightToLeft) {
+                            itemX -= (rows ? gridView.contentX : gridView.originX);
+                            itemX += cWidth;
+                            itemX = (rows ? gridView.width : gridView.contentItem.width) - itemX;
+                        }
+
+                        // 框选框与item项相交，即认为选中
+                        if (rB.intersects(Qt.rect(itemX, itemY,
+                                                  cWidth, cHeight))) {
+                            var item = gridView.contentItem.childAt(itemX + midWidth, itemY + midHeight);
+
+                            indices.push(index);
+                        }
+                    }
+                }
+
+                if (main.rubberBand == null)
+                    rB.close()
+
+                return indices
+            }
+
+            function executeScrollBar(delta) {
+                if (enableMouse && visible) {
+                    if (gridView.contentHeight <= gridView.height)
+                        return
+
+                    vbar.active = true
+                    gridView.contentY -= delta
+                    if(gridView.contentY < 0) {
+                        gridView.contentY = 0
+                    } else if(gridView.contentY > gridView.contentHeight - gridView.height) {
+                        gridView.contentY = gridView.contentHeight - gridView.height
+                    }
+                } else {
+                    vbar.active = false
+                }
+            }
+
+            Behavior on contentY { id: smoothY; enabled: false; SmoothedAnimation { velocity: 700 } }
+
+            Keys.onPressed: {
+                switch (event.key) {
+                case Qt.Key_Return:
+                case Qt.Key_Enter:
+                    if (menuItemStates.canView)
+                        ThumbnailTools.executeViewImage()
+                    break
+                case Qt.Key_Home:
+                    currentIndex = 0
+                    updateSelection(event.modifiers)
+                    break
+                case Qt.Key_End:
+                    currentIndex = count - 1
+                    updateSelection(event.modifiers)
+                    break
+                case Qt.Key_Period:
+                    if (!menuItemStates.isInTrash && !menuItemStates.isInDevice) {
+                        if (menuItemStates.canFavorite)
+                            ThumbnailTools.executeFavorite()
+                        else
+                            ThumbnailTools.executeUnFavorite()
+                    }
+                    break
+                case Qt.Key_Shift:
+                    shiftPressed = true
+                    if(currentIndex != -1)
+                        anchorIndex = currentIndex
+                    break
+                default:
+                    break
+                }
+            }
+
+            Keys.onReleased: {
+                switch (event.key) {
+                case Qt.Key_Shift:
+                    shiftPressed = false
+                    anchorIndex = 0
+                    break
+                default:
+                    break       
+                }
+            }
+        }
+
+        Album.ThumbnailModel {
+            id: thumbnailModel
+
+            onSrcModelReseted: {
+                if (!gridView.model) {
+                    gridView.model = positioner;
+                    gridView.currentIndex = -1;
+                }
+            }
+        }
+
+        Album.Positioner {
+            id: positioner
+
+            enabled: true
+
+            thumbnailModel: thumbnailModel
+
+            perStripe: Math.floor(((gridView.flow == GridView.FlowLeftToRight)
+                ? gridView.width : gridView.height) / ((gridView.flow == GridView.FlowLeftToRight)
+                ? gridView.cellWidth : gridView.cellHeight));
+        }
+
+        Album.ItemViewAdapter {
+            id: viewAdapter
+
+            adapterView: gridView
+            adapterModel: positioner
+            adapterIconSize: gridView.iconSize * 2
+            adapterVisibleArea: Qt.rect(gridView.contentX, gridView.contentY, gridView.contentWidth, gridView.contentHeight)
+
+            Component.onCompleted: {
+                gridView.movementStarted.connect(viewAdapter.viewScrolled);
+                thumbnailModel.viewAdapter = viewAdapter;
+            }
+        }
+    }
+
+    Connections {
+        target: global
+        onSigSelectAll: {
+            if (gridView.visible)
+                selectAll(bSel)
+        }
+
+        onSigPageUp: {
+            if (gridView.visible) {
+                gridView.executeScrollBar(gridView.scrollDelta)
+            }
+        }
+
+        onSigPageDown: {
+            if (gridView.visible) {
+                gridView.executeScrollBar(-gridView.scrollDelta)
+            }
+        }
+    }
+
+    //缩略图菜单
+    //注意：涉及界面切换的，需要做到从哪里进来，就退出到哪里
+    //菜单显隐逻辑有点绕，建议头脑清醒的时候再处理
+    Menu {
+        id: thumbnailMenu
+
+        //显示大图预览
+        RightMenuItem {
+            text: qsTr("View")
+            visible: menuItemStates.canView
+            onTriggered: {
+                ThumbnailTools.executeViewImage()
+            }
+        }
+
+        //全屏预览
+        RightMenuItem {
+            text: qsTr("Fullscreen")
+            visible:  menuItemStates.canFullScreen
+            onTriggered: {
+                ThumbnailTools.executeFullScreen()
+            }
+            Shortcut {
+                enabled: gridView.activeFocus && menuItemStates.canFullScreen
+                autoRepeat: false
+                sequence : "F11"
+                onActivated : {
+                    ThumbnailTools.executeFullScreen()
+                }
+            }
+        }
+
+        //调起打印接口
+        RightMenuItem {
+            text: qsTr("Print")
+            visible: menuItemStates.canPrint
+
+            onTriggered: {
+                ThumbnailTools.executePrint()
+            }
+
+            Shortcut {
+                enabled: gridView.activeFocus && menuItemStates.canPrint
+                autoRepeat: false
+                sequence : "Ctrl+P"
+                onActivated : {
+                    ThumbnailTools.executePrint()
+                }
+            }
+        }
+
+        //幻灯片
+        RightMenuItem {
+            text: qsTr("Slide show")
+            visible: menuItemStates.canSlideShow
+            onTriggered: {
+                ThumbnailTools.excuteSlideShow()
+            }
+
+            Shortcut {
+                enabled: gridView.activeFocus && menuItemStates.canSlideShow
+                autoRepeat: false
+                sequence : "F5"
+                onActivated : {
+                    ThumbnailTools.excuteSlideShow()
+                }
+            }
+        }
+
+        MenuSeparator {
+            visible: thumnailListType !== GlobalVar.ThumbnailType.Trash
+            height: visible ? GlobalVar.rightMenuSeparatorHeight : 0
+        }
+
+        //添加到相册子菜单
+        //隐藏交给后面的Component.onCompleted解决
+        Menu {
+            enabled: thumnailListType !== GlobalVar.ThumbnailType.Trash
+            id: addToAlbum
+            title: qsTr("Add to album")
+
+            RightMenuItem {
+                text: qsTr("New album")
+                onTriggered: {
+                    newAlbum.isChangeView = false
+                    newAlbum.importSelected = true
+                    newAlbum.setNormalEdit()
+                    newAlbum.show()
+                }
+            }
+
+            MenuSeparator {
+            }
+
+            Repeater {
+                id: recentFilesInstantiator
+                property bool bRreshEnableState: false
+                model: albumControl.getAllCustomAlbumId(global.albumChangeList).length
+                delegate: RightMenuItem {
+                    text: albumControl.getAllCustomAlbumName(global.albumChangeList)[index]
+                    enabled: albumControl.canAddToCustomAlbum(albumControl.getAllCustomAlbumId()[index], global.selectedPaths, recentFilesInstantiator.bRreshEnableState)
+                    onTriggered:{
+                        // 获取所选自定义相册的Id，根据Id添加到对应自定义相册
+                        var customAlbumId = albumControl.getAllCustomAlbumId()[index]
+                        albumControl.insertIntoAlbum(customAlbumId , global.selectedPaths)
+                        DTK.sendMessage(thumbnailImage, qsTr("Successfully added to “%1”").arg(albumControl.getAllCustomAlbumName(global.albumChangeList)[index]), "notify_checked")
+                        recentFilesInstantiator.bRreshEnableState = !recentFilesInstantiator.bRreshEnableState
+                    }
+                }
+            }
+        }
+
+        //导出图片为其它格式
+        RightMenuItem {
+            text: qsTr("Export")
+            visible: thumnailListType !== GlobalVar.ThumbnailType.Trash
+                     && ((selectedUrls.length === 1 && fileControl.pathExists(selectedUrls[0]) && menuItemStates.haveImage) || !menuItemStates.haveVideo)
+            onTriggered: {
+                ThumbnailTools.excuteExport()
+            }
+
+            Shortcut {
+                enabled: gridView.activeFocus && menuItemStates.canExport
+                autoRepeat: false
+                sequence : "Ctrl+E"
+                onActivated : {
+                    ThumbnailTools.excuteExport()
+                }
+            }
+        }
+
+        //复制图片
+        RightMenuItem {
+            text: qsTr("Copy")
+            visible: menuItemStates.canCopy
+            onTriggered: {
+                ThumbnailTools.executeCopy()
+            }
+        }
+
+        //删除图片
+        RightMenuItem {
+            text: qsTr("Delete")
+            visible: menuItemStates.canDelete && !menuItemStates.isInDevice
+            onTriggered: {
+                deleteDialog.setDisplay(thumnailListType === GlobalVar.ThumbnailType.Trash ? GlobalVar.FileDeleteType.TrashSel : GlobalVar.FileDeleteType.Normal, selectedPaths.length)
+                deleteDialog.show()
+            }
+        }
+
+        //从相册移除（只在自定义相册中显示）
+        RightMenuItem {
+            text: qsTr("Remove from album")
+            visible: thumnailListType === GlobalVar.ThumbnailType.CustomAlbum
+            onTriggered: {
+                ThumbnailTools.executeRemoveFromAlbum()
+            }
+        }
+
+        MenuSeparator {
+            visible: thumnailListType !== GlobalVar.ThumbnailType.Trash
+            height: visible ? GlobalVar.rightMenuSeparatorHeight : 0
+        }
+
+        //添加到我的收藏
+        RightMenuItem {
+            id: favoriteAction
+            text: qsTr("Favorite")
+            visible: !menuItemStates.isInTrash && !menuItemStates.isInDevice && menuItemStates.canFavorite
+            onTriggered: {
+                ThumbnailTools.executeFavorite()
+            }
+        }
+
+        //从我的收藏中移除
+        RightMenuItem {
+            id: unFavoriteAction
+            text: qsTr("Unfavorite")
+            visible: !menuItemStates.isInTrash && !menuItemStates.isInDevice && !menuItemStates.canFavorite
+            onTriggered: {
+                ThumbnailTools.executeUnFavorite()
+            }
+        }
+
+        MenuSeparator {
+            visible: menuItemStates.canRotate
+            height: visible ? GlobalVar.rightMenuSeparatorHeight : 0
+        }
+
+        //顺时针旋转
+        RightMenuItem {
+            text: qsTr("Rotate clockwise")
+            visible: menuItemStates.canRotate
+            onTriggered: {
+                ThumbnailTools.executeRotate(90)
+            }
+        }
+
+        //逆时针旋转
+        RightMenuItem {
+            text: qsTr("Rotate counterclockwise")
+            visible: menuItemStates.canRotate
+            onTriggered: {
+                ThumbnailTools.executeRotate(-90)
+            }
+        }
+
+        MenuSeparator {
+            visible: !menuItemStates.isInTrash
+                     && (setAsWallpaperAction.visible || displayInFileManagerAction.visible || photoInfoAction.visible || videoInfoAction.visible)
+            height: visible ? GlobalVar.rightMenuSeparatorHeight : 0
+        }
+
+        //设置为壁纸
+        RightMenuItem {
+            text: qsTr("Set as wallpaper")
+            id: setAsWallpaperAction
+            visible: menuItemStates.canWallpaper
+            onTriggered: {
+                ThumbnailTools.executeSetWallpaper()
+            }
+
+            Shortcut {
+                enabled: gridView.activeFocus && menuItemStates.canWallpaper
+                autoRepeat: false
+                sequence : "Ctrl+F9"
+                onActivated : {
+                    ThumbnailTools.executeSetWallpaper()
+                }
+            }
+        }
+
+        //在文件管理器中显示
+        RightMenuItem {
+            text: qsTr("Display in file manager")
+            id: displayInFileManagerAction
+            visible: menuItemStates.canDisplayInFolder
+            onTriggered: {
+                ThumbnailTools.executeDisplayInFileManager()
+            }
+
+            Shortcut {
+                enabled: gridView.activeFocus && menuItemStates.canDisplayInFolder
+                autoRepeat: false
+                sequence : "Alt+D"
+                onActivated : {
+                    ThumbnailTools.executeDisplayInFileManager()
+                }
+            }
+        }
+
+        //恢复
+        RightMenuItem {
+            text: qsTr("Restore")
+            visible: thumnailListType === GlobalVar.ThumbnailType.Trash
+            onTriggered: {
+                ThumbnailTools.executeRestore()
+            }
+        }
+
+        //照片信息
+        RightMenuItem {
+            text: qsTr("Photo info")
+            id: photoInfoAction
+            visible: menuItemStates.canViewPhotoInfo
+            onTriggered: {
+                ThumbnailTools.executeViewPhotoInfo()
+            }
+
+            Shortcut {
+                enabled: gridView.activeFocus && menuItemStates.canViewPhotoInfo
+                autoRepeat: false
+                sequence : "Ctrl+I"
+                onActivated : {
+                    ThumbnailTools.executeViewPhotoInfo()
+                }
+            }
+        }
+
+        //视频信息
+        RightMenuItem {
+            text: qsTr("Video info")
+            id: videoInfoAction
+            visible: menuItemStates.canViewVideoInfo
+            onTriggered: {
+                ThumbnailTools.executeViewVideoInfo()
+            }
+
+            Shortcut {
+                enabled: gridView.activeFocus && menuItemStates.canViewVideoInfo
+                autoRepeat: false
+                sequence : "Ctrl+I"
+                onActivated : {
+                    ThumbnailTools.executeViewVideoInfo()
+                }
+            }
+        }
+
+        Component.onCompleted: {
+            //最近删除界面下隐藏添加到相册的子菜单
+            if(thumnailListType === GlobalVar.ThumbnailType.Trash) {
+                var item = itemAt(5)
+                item.visible = false
+                item.height = 0
+            }
+        }
+    }
+
+    Component.onCompleted: {
+        global.sigThumbnailStateChange.connect(fouceUpdate)
+        deleteDialog.sigDoDeleteImg.connect(ThumbnailTools.executeDelete)
+
+        // 缩略图列表模型选中内容有变化，向外发送选中内容改变信号，以便外部维护全局选中队列global.selectedPaths
+        thumbnailModel.selectedIndexesChanged.connect(selectedChanged)
+    }
+
+    onRealCellWidthChanged: {
+        totalTimeScope()
+    }
+
+}

--- a/src/qml/Control/ListView/ThumbnailListView2.qml
+++ b/src/qml/Control/ListView/ThumbnailListView2.qml
@@ -969,12 +969,6 @@ FocusScope {
             }
         }
 
-        MenuSeparator {
-            visible: !menuItemStates.isInTrash
-                     && (setAsWallpaperAction.visible || displayInFileManagerAction.visible || photoInfoAction.visible || videoInfoAction.visible)
-            height: visible ? GlobalVar.rightMenuSeparatorHeight : 0
-        }
-
         //设置为壁纸
         RightMenuItem {
             text: qsTr("Set as wallpaper")

--- a/src/qml/Control/ListView/ThumbnailListView2.qml
+++ b/src/qml/Control/ListView/ThumbnailListView2.qml
@@ -603,37 +603,38 @@ FocusScope {
                 var midHeight = gridView.cellHeight / 2;
                 var indices = [];
 
-                for (var s = 0; s < stripes; s++) {
-                    for (var i = 0; i < perStripe; i++) {
-                        var index = (s * perStripe) + i;
+                if (gridView.width > 0) {
+                    for (var s = 0; s < stripes; s++) {
+                        for (var i = 0; i < perStripe; i++) {
+                            var index = (s * perStripe) + i;
 
-                        if (index >= gridView.count) {
-                            break;
-                        }
+                            if (index >= gridView.count) {
+                                break;
+                            }
 
-                        if (positioner.isBlank(index)) {
-                            continue;
-                        }
+                            if (positioner.isBlank(index)) {
+                                continue;
+                            }
 
-                        var itemX = ((rows ? i : s) * gridView.cellWidth);
-                        var itemY = ((rows ? s : i) * gridView.cellHeight);
+                            var itemX = ((rows ? i : s) * gridView.cellWidth);
+                            var itemY = ((rows ? s : i) * gridView.cellHeight);
 
-                        if (gridView.effectiveLayoutDirection == Qt.RightToLeft) {
-                            itemX -= (rows ? gridView.contentX : gridView.originX);
-                            itemX += cWidth;
-                            itemX = (rows ? gridView.width : gridView.contentItem.width) - itemX;
-                        }
+                            if (gridView.effectiveLayoutDirection == Qt.RightToLeft) {
+                                itemX -= (rows ? gridView.contentX : gridView.originX);
+                                itemX += cWidth;
+                                itemX = (rows ? gridView.width : gridView.contentItem.width) - itemX;
+                            }
 
-                        // 框选框与item项相交，即认为选中
-                        if (rB.intersects(Qt.rect(itemX, itemY,
-                                                  cWidth, cHeight))) {
-                            var item = gridView.contentItem.childAt(itemX + midWidth, itemY + midHeight);
+                            // 框选框与item项相交，即认为选中
+                            if (rB.intersects(Qt.rect(itemX, itemY,
+                                                      cWidth, cHeight))) {
+                                var item = gridView.contentItem.childAt(itemX + midWidth, itemY + midHeight);
 
-                            indices.push(index);
+                                indices.push(index);
+                            }
                         }
                     }
                 }
-
                 if (main.rubberBand == null)
                     rB.close()
 

--- a/src/qml/Control/ListView/ThumbnailListViewTools.js
+++ b/src/qml/Control/ListView/ThumbnailListViewTools.js
@@ -5,12 +5,12 @@
 // 执行图片查看操作
 function executeViewImage() {
     if (thumnailListType !== GlobalVar.ThumbnailType.Trash) {
-        var indexes = dir.selectedIndexes
+        var indexes = thumbnailModel.selectedIndexes
         if (indexes.length > 0) {
-            if (fileControl.isVideo(dir.data(indexes[0], "url").toString())) {
-                albumControl.openDeepinMovie(dir.data(indexes[0], url).toString())
+            if (fileControl.isVideo(thumbnailModel.data(indexes[0], "url").toString())) {
+                albumControl.openDeepinMovie(thumbnailModel.data(indexes[0], url).toString())
             } else {
-                var allUrls = dir.allUrls()
+                var allUrls = thumbnailModel.allUrls()
                 mainStack.sourcePaths = allUrls
                 mainStack.currentIndex = -1
                 mainStack.currentIndex = indexes[0]
@@ -37,9 +37,9 @@ function executeFullScreen() {
     if (root.visibility !== Window.FullScreen && selectedUrls.length > 0) {
         showFullScreen()
 
-        mainStack.sourcePaths = dir.allUrls()
+        mainStack.sourcePaths = thumbnailModel.allUrls()
         mainStack.currentIndex = -1
-        mainStack.currentIndex = dir.allUrls().indexOf(selectedUrls[0])
+        mainStack.currentIndex = thumbnailModel.allUrls().indexOf(selectedUrls[0])
         mainStack.currentWidgetIndex = 1
         global.stackControlLastCurrent = global.stackControlCurrent
         global.stackControlCurrent = 1
@@ -55,7 +55,7 @@ function executePrint() {
 // 执行幻灯片放映
 function excuteSlideShow() {
     if (selectedUrls.length > 0) {
-        var allUrls = dir.allUrls()
+        var allUrls = thumbnailModel.allUrls()
         stackControl.startMainSliderShow(allUrls, allUrls.indexOf(selectedUrls[0]))
     }
 }
@@ -69,7 +69,7 @@ function excuteExport() {
         else
             DTK.sendMessage(thumbnailImage, qsTr("Export failed"), "warning")
     } else {
-        exportdig.setParameter(model.data(dir.selectedIndexes[0], "url").toString(), thumbnailImage)
+        exportdig.setParameter(model.data(thumbnailModel.selectedIndexes[0], "url").toString(), thumbnailImage)
         exportdig.show()
     }
 }

--- a/src/qml/Control/ListView/ThumbnailListViewTools.js
+++ b/src/qml/Control/ListView/ThumbnailListViewTools.js
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 执行图片查看操作
+function executeViewImage() {
+    if (thumnailListType !== GlobalVar.ThumbnailType.Trash) {
+        var indexes = dir.selectedIndexes
+        if (indexes.length > 0) {
+            if (fileControl.isVideo(dir.data(indexes[0], "url").toString())) {
+                albumControl.openDeepinMovie(dir.data(indexes[0], url).toString())
+            } else {
+                var allUrls = dir.allUrls()
+                mainStack.sourcePaths = allUrls
+                mainStack.currentIndex = -1
+                mainStack.currentIndex = indexes[0]
+                mainStack.currentWidgetIndex = 1
+                global.stackControlCurrent = 1
+            }
+        }
+    }
+}
+
+// 执行图片删除操作
+function executeDelete() {
+    if ( thumnailListType !== GlobalVar.ThumbnailType.Trash ){
+        albumControl.insertTrash(global.selectedPaths)
+    } else {
+        albumControl.deleteImgFromTrash(selectedPaths)
+        selectAll(false)
+        global.sigFlushRecentDelView()
+    }
+}
+
+// 执行全屏预览
+function executeFullScreen() {
+    if (root.visibility !== Window.FullScreen && selectedUrls.length > 0) {
+        showFullScreen()
+
+        mainStack.sourcePaths = dir.allUrls()
+        mainStack.currentIndex = -1
+        mainStack.currentIndex = dir.allUrls().indexOf(selectedUrls[0])
+        mainStack.currentWidgetIndex = 1
+        global.stackControlLastCurrent = global.stackControlCurrent
+        global.stackControlCurrent = 1
+
+    }
+}
+
+// 执行图片打印
+function executePrint() {
+    fileControl.showPrintDialog(global.selectedPaths)
+}
+
+// 执行幻灯片放映
+function excuteSlideShow() {
+    if (selectedUrls.length > 0) {
+        var allUrls = dir.allUrls()
+        stackControl.startMainSliderShow(allUrls, allUrls.indexOf(selectedUrls[0]))
+    }
+}
+
+// 执行导出图片
+function excuteExport() {
+    if (global.selectedPaths.length > 1) {
+        var bRet = albumControl.getFolders(global.selectedPaths)
+        if (bRet)
+            DTK.sendMessage(thumbnailImage, qsTr("Export successful"), "notify_checked")
+        else
+            DTK.sendMessage(thumbnailImage, qsTr("Export failed"), "warning")
+    } else {
+        exportdig.setParameter(model.data(dir.selectedIndexes[0], "url").toString(), thumbnailImage)
+        exportdig.show()
+    }
+}
+
+// 执行图片复制
+function executeCopy() {
+    if (global.selectedPaths.length > 0)
+        fileControl.copyImage(global.selectedPaths)
+}
+
+// 执行从相册移除
+function executeRemoveFromAlbum() {
+    if (selectedUrls.length > 0) {
+        albumControl.removeFromAlbum(global.currentCustomAlbumUId, selectedUrls)
+        global.sigFlushCustomAlbumView(global.currentCustomAlbumUId)
+    }
+}
+
+// 执行收藏操作
+function executeFavorite() {
+    albumControl.insertIntoAlbum(0, global.selectedPaths)
+    global.bRefreshFavoriteIconFlag = !global.bRefreshFavoriteIconFlag
+
+    // 若当前视图为我的收藏，需要实时刷新我的收藏列表内容
+    if (global.currentViewIndex === GlobalVar.ThumbnailViewType.Favorite && global.currentCustomAlbumUId === 0) {
+        global.sigFlushCustomAlbumView(global.currentCustomAlbumUId)
+    }
+}
+
+// 执行取消收藏操作
+function executeUnFavorite() {
+    albumControl.removeFromAlbum(0, global.selectedPaths)
+    global.bRefreshFavoriteIconFlag = !global.bRefreshFavoriteIconFlag
+
+    // 若当前视图为我的收藏，需要实时刷新我的收藏列表内容
+    if (global.currentViewIndex === GlobalVar.ThumbnailViewType.Favorite && global.currentCustomAlbumUId === 0) {
+        global.sigFlushCustomAlbumView(global.currentCustomAlbumUId)
+    }
+}
+
+// 执行旋转操作
+function executeRotate(angle) {
+    if (global.selectedPaths.length > 0) {
+        fileControl.rotateFile(global.selectedPaths, angle)
+    }
+}
+
+// 执行设置壁纸操作
+function executeSetWallpaper() {
+    if (global.selectedPaths.length > 0)
+        fileControl.setWallpaper(global.selectedPaths[0])
+}
+
+// 执行在文管中显示操作
+function executeDisplayInFileManager() {
+    if (global.selectedPaths.length > 0)
+        fileControl.displayinFileManager(global.selectedPaths[0])
+}
+
+// 执行图片恢复操作
+function executeRestore() {
+    if (selectedPaths.length > 0) {
+        albumControl.recoveryImgFromTrash(selectedPaths)
+        selectAll(false)
+        global.sigFlushRecentDelView()
+    }
+}
+
+// 执行照片信息查看
+function executeViewPhotoInfo() {
+    albumInfomationDig.filePath = global.selectedPaths[0]
+    albumInfomationDig.show()
+}
+
+
+// 执行视频信息查看
+function executeViewVideoInfo() {
+    videoInfomationDig.filePath = global.selectedPaths[0]
+    videoInfomationDig.show()
+}

--- a/src/qml/GlobalVar.qml
+++ b/src/qml/GlobalVar.qml
@@ -46,6 +46,7 @@ Item {
     property int thumbnailSizeLevel: 0 //缩略图缩放等级
     property real cellBaseWidth: thumbnailSizeLevel >= 0 && thumbnailSizeLevel <= 9 ? 80 + thumbnailSizeLevel * 10 : 80
     property int thumbnailListRightMargin: 10
+    property int thumbnialListCellSpace: 4
     property string statusBarNumText: "" //状态栏显示的总数文本内容
     property string searchEditText: ""
 
@@ -59,10 +60,17 @@ Item {
     property string deviceCurrentPath: "" //设备当前P
     property bool windowDisActived: false
 
+    readonly property int hoverActivateDelay: 750
+
     function objIsEmpty(obj) {
         var ret = (String(obj) === "undefined" || String(obj) === "null")
         //console.log("obj is", ret ? "empty." : "not empty.", "objStr:", String(obj))
         return ret
+    }
+
+    function isDrag(fromX, fromY, toX, toY) {
+        var length = Math.abs(fromX - toX) + Math.abs(fromY - toY);
+        return length >= Qt.styleHints.startDragDistance;
     }
 
     signal sigWindowStateChange()
@@ -71,7 +79,7 @@ Item {
     signal sigFlushAllCollectionView()   // 刷新合集所有项目视图内容
     signal sigFlushHaveImportedView()   // 刷新已导入视图内容
     signal sigFlushRecentDelView()      // 刷新最近删除视图内容
-    signal sigFlushCustomAlbumView(int customAlbumUId)    //刷新我的收藏/自定义相册视图内容 customAlbumUId: >= 0 刷新指定视图，-1: 默认刷新所有视图
+    signal sigFlushCustomAlbumView(int UID)    //刷新我的收藏/自定义相册视图内容 UID: >= 0 刷新指定视图，-1: 默认刷新所有视图
     signal sigCollectionViewIndexChanged(int index) //合集页面发生改变
     signal sigFlushSearchView() // 刷新搜索结果视图内容
     signal sigThumbnailSizeLevelChanged()
@@ -102,7 +110,8 @@ Item {
         Trash,        //最近删除
         CustomAlbum,  //自定义相册
         AutoImport,   //自动导入路径
-        AllCollection //合集模式
+        AllCollection,//合集模式
+        Device        //设备列表
     }
 
     // 框选超出边界朝向类型
@@ -203,7 +212,7 @@ Item {
         //QML的翻译不支持%n的特性，只能拆成这种代码
         var photoCount = ret[0]
         var videoCount = ret[1]
-        var selectedNumText
+        var selectedNumText = ""
         if(paths.length === 0) {
             selectedNumText = text
         } else if(paths.length === 1 && photoCount === 1) {
@@ -214,6 +223,8 @@ Item {
             selectedNumText = qsTr("%1 items selected (%1 photos)").arg(photoCount)
         } else if(videoCount > 1 && photoCount === 0) {
             selectedNumText = qsTr("%1 items selected (%1 videos)").arg(videoCount)
+        } else if (photoCount === 1 && videoCount === 1) {
+            selectedNumText = qsTr("%1 item selected (1 photo, 1 video)").arg(photoCount + videoCount)
         } else if (photoCount === 1 && videoCount > 1) {
             selectedNumText = qsTr("%1 items selected (1 photo, %2 videos)").arg(photoCount + videoCount).arg(videoCount)
         } else if (videoCount === 1 && photoCount > 1) {

--- a/src/qml/GlobalVar.qml
+++ b/src/qml/GlobalVar.qml
@@ -182,6 +182,22 @@ Item {
         }
     }
 
+    // 导入不支持文件提示
+    Connections {
+        target: albumControl
+        onSigInvalidFormat: {
+            DTK.sendMessage(stackControl, qsTr("The file format is not supported"), "warning")
+        }
+    }
+
+    // 导入不支持文件提示
+    Connections {
+        target: fileControl
+        onInvalidFormat: {
+            DTK.sendMessage(stackControl, qsTr("The file format is not supported"), "warning")
+        }
+    }
+
     onCurrentViewIndexChanged: {
         console.log("currentViewIndex   :", currentViewIndex)
         if(albumControl.getAllCount() <= 0) {

--- a/src/qml/GlobalVar.qml
+++ b/src/qml/GlobalVar.qml
@@ -60,6 +60,8 @@ Item {
     property string deviceCurrentPath: "" //设备当前P
     property bool windowDisActived: false
 
+    property bool loading: true
+
     readonly property int hoverActivateDelay: 750
 
     function objIsEmpty(obj) {

--- a/src/qml/GlobalVar.qml
+++ b/src/qml/GlobalVar.qml
@@ -31,6 +31,8 @@ Item {
     property int sideBarWidth: 200 // 侧边栏宽度
     property int statusBarHeight: 30 //状态栏高度
 
+    property int collectionTopMargin: 25 //合集年月视图上边距
+
     property int thumbnailViewTitleHieght: 85 // 缩略图视图区域标题显示区域高度
     property int verticalScrollBarWidth: 15 // 垂直滚动条宽度
 

--- a/src/qml/MainAlbumView.qml
+++ b/src/qml/MainAlbumView.qml
@@ -96,7 +96,7 @@ Rectangle {
     ThumbnailImage{
         id: thumbnailImage
         clip: true
-        anchors.top: titleAlubmRect.bottom
+        anchors.top: parent.top
         anchors.left: leftSidebar.right
         anchors.leftMargin: 0
         width: parent.width - leftSidebar.x - global.sideBarWidth

--- a/src/qml/MenuItemStates.qml
+++ b/src/qml/MenuItemStates.qml
@@ -7,6 +7,7 @@ import QtQuick.Controls 2.4
 
 Item {
     property bool isInTrash: global.currentViewIndex === GlobalVar.ThumbnailViewType.RecentlyDeleted
+    property bool isInDevice: global.currentViewIndex === GlobalVar.ThumbnailViewType.Device
     //菜单项状态检查
     property bool haveImage: false
     property bool haveVideo: false

--- a/src/qml/PreviewImageViewer/ImageViewer.qml
+++ b/src/qml/PreviewImageViewer/ImageViewer.qml
@@ -23,9 +23,9 @@ Rectangle {
     property int currentRotate: 0
 
     // Indicates the current image path
-    property var source
+    property string source: ""
     /*: showImg.source*/
-    property var sourcePaths
+    property var sourcePaths: []
 
     // 当前源图片宽度
     property int currentSourceWidth : 0;

--- a/src/qml/PreviewImageViewer/ImageViewer.qml
+++ b/src/qml/PreviewImageViewer/ImageViewer.qml
@@ -890,8 +890,8 @@ Rectangle {
                 }
 
                 onDoubleClicked: {
-                    if (!thumbnailListView.contains(msArea.mapToItem(thumbnailListView, mouse.x, mouse.y))) {
-                        view.exitLiveText()
+                    if (!toolBarthumbnailListView.contains(msArea.mapToItem(toolBarthumbnailListView, mouse.x, mouse.y))) {
+                        //view.exitLiveText()
                         infomationDig.hide()
                         showFulltimer.start()
                     }
@@ -902,7 +902,7 @@ Rectangle {
                     // 通过Keys缓存的状态可能不准确，在焦点移出时release事件没有正确捕获，
                     // 修改为通过当前事件传入的按键按下信息判断
                     if (Qt.ControlModifier & wheel.modifiers)
-                        datla > 0 ? thumbnailListView.previous() : thumbnailListView.next()
+                        datla > 0 ? toolBarthumbnailListView.previous() : toolBarthumbnailListView.next()
                     else {
                         // 缓存当前的坐标信息
                         var targetItem = drag.target

--- a/src/qml/PreviewImageViewer/ImageViewer.qml
+++ b/src/qml/PreviewImageViewer/ImageViewer.qml
@@ -653,7 +653,7 @@ Rectangle {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
                 text: qsTr("You have no permission to view the image")
-                visible: (showImg.status === Image.Error || flickableL.curSourceIsNullImage) && flickableL.curSourceIsExist && !flickableL.curSourceIsReadalbe && fileControl.isAlbum()
+                visible: ((showImg.status === Image.Error)  || (flickableL.curSourceIsNullImage && flickableL.curSourceIsExist && !flickableL.curSourceIsReadalbe)) && fileControl.isAlbum()
             }
 
             // 图片丢失视图，当图片未发现时触发

--- a/src/qml/PreviewImageViewer/ImageViewer.qml
+++ b/src/qml/PreviewImageViewer/ImageViewer.qml
@@ -1191,7 +1191,7 @@ Rectangle {
 
                 // 静态组件source改变，对应item的source也需要跟着改变，才能成功刷新预览图内容
                 onCurItemSourceChanged: {
-                    if (curItemSource !== "" && !curItemIsMultiImage) {
+                    if (curItemSource !== "" && !curItemIsMultiImage && status == Loader.Ready) {
                         item.curImageSource = curItemSource
                     }
                 }

--- a/src/qml/PreviewImageViewer/OpenImageWidget.qml
+++ b/src/qml/PreviewImageViewer/OpenImageWidget.qml
@@ -135,7 +135,7 @@ Item {
         }
 
         // 若在文管菜单使用相册打开图片文件，并且数据库中未导入该图片，应该将选择的图片导入相册中
-        if (fileControl.isAlbum() && tempPath !== "" && !balbumControl.checkRepeatUrls(albumControl.getAllUrlPaths(), paths, false)) {
+        if (fileControl.isAlbum() && tempPath !== "" && !albumControl.checkRepeatUrls(albumControl.getAllUrlPaths(), paths, false)) {
             albumControl.importAllImagesAndVideos(paths)
         }
     }

--- a/src/qml/PreviewImageViewer/OpenImageWidget.qml
+++ b/src/qml/PreviewImageViewer/OpenImageWidget.qml
@@ -107,6 +107,9 @@ Item {
 
     //打开看图查看图片
     function openAndImportImages(paths) {
+        if (paths.length === 0)
+            return
+
         var tempPath = ""
 
         if (paths.length > 0)

--- a/src/qml/PreviewImageViewer/ToolBarThumbnailListView.qml
+++ b/src/qml/PreviewImageViewer/ToolBarThumbnailListView.qml
@@ -112,8 +112,8 @@ Item {
         onClicked: {
             showNormal()
             global.stackControlCurrent = 0
-            mainView.sourcePaths=""
-            mainView.source=""
+            mainView.sourcePaths = []
+            mainView.source = ""
         }
 
         ToolTip.delay: 500
@@ -130,8 +130,8 @@ Item {
             onActivated: {
                 showNormal()
                 global.stackControlCurrent = 0
-                mainView.sourcePaths=""
-                mainView.source=""
+                mainView.sourcePaths = []
+                mainView.source = ""
             }
         }
     }

--- a/src/qml/SideBar/Sidebar.qml
+++ b/src/qml/SideBar/Sidebar.qml
@@ -33,7 +33,7 @@ ScrollView {
         deviceListModel.clear()
         for (var i = 0; i < devicePaths.length; i++) {
             var tempDevice = {}
-            tempDevice.checked = i === 0
+            tempDevice.checked = false
             tempDevice.icon = "iphone"
             tempDevice.displayName = albumControl.getDeviceNames()[i]
             tempDevice.uuid = String(i)
@@ -234,8 +234,8 @@ ScrollView {
 
             onItemCheckedChanged: {
                 if (checked) {
-                    global.currentViewIndex = GlobalVar.ThumbnailViewType.Device
                     global.deviceCurrentPath = deviceListModel.get(index).path
+                    global.currentViewIndex = GlobalVar.ThumbnailViewType.Device
                     global.searchEditText = ""
                     forceActiveFocus()
                 }

--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -8,6 +8,9 @@ import QtQuick.Layouts 1.11
 import QtQuick.Controls 2.4
 import QtQuick.Dialogs 1.3
 import org.deepin.dtk 1.0
+
+import org.deepin.album 1.0 as Album
+
 import "../../Control"
 import "../../Control/ListView"
 import "../../"
@@ -37,8 +40,8 @@ Item {
 
     // 刷新所有项目视图内容
     function flushAllCollectionView() {
-        loadAllCollectionItems()
-        global.selectedPaths = theView.selectedPaths
+        theView.proxyModel.refresh(filterType)
+        global.selectedPaths = theView.selectedUrls
         getNumLabelText()
         totalTimepScopeTimer.start()
     }
@@ -96,28 +99,11 @@ Item {
         return selectedNumText
     }
 
-    // 加载所有项目数据
-    function loadAllCollectionItems()
-    {
-        console.info("all collection model has refreshed... filterType:", filterType)
-        theView.selectAll(false)
-        theView.thumbnailListModel.clear();
-        var allCollections = albumControl.getAlbumAllInfos(filterType);
-        console.info("all collection model has refreshed... filterType:", filterType, " done...")
-        for (var i = 0; i < allCollections.length; i++) {
-            theView.thumbnailListModel.append(allCollections[i])
-        }
-
-        return true
-    }
-
     Connections {
         target: albumControl
         onSigRepeatUrls: {
             if (visible && collecttionView.currentViewIndex === 3) {
-                theView.selectAll(false)
-                selectedPaths = urls
-                global.selectedPaths = selectedPaths
+                theView.selectUrls(urls)
             }
         }
     }
@@ -160,13 +146,14 @@ Item {
         }
     }
 
-    ThumbnailListView {
+    ThumbnailListView2 {
         id: theView
         anchors.top: allCollectionTitleRect.bottom
         anchors.topMargin: m_topMargin
         width: parent.width
         height: parent.height - allCollectionTitleRect.height - m_topMargin - statusBar.height
         thumnailListType: GlobalVar.ThumbnailType.AllCollection
+        proxyModel.sourceModel: Album.ImageDataModel { modelType: Album.Types.AllCollection }
 
         visible: numLabelText !== ""
         property int m_topMargin: 10
@@ -176,7 +163,7 @@ Item {
             target: theView
             onSelectedChanged: {
                 selectedPaths = []
-                selectedPaths = theView.selectedPaths
+                selectedPaths = theView.selectedUrls
 
                 if (parent.visible)
                     global.selectedPaths = selectedPaths

--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -43,21 +43,7 @@ Item {
         theView.proxyModel.refresh(filterType)
         global.selectedPaths = theView.selectedUrls
         getNumLabelText()
-        totalTimepScopeTimer.start()
-    }
-
-    function flushTotalTimeScope() {
         theView.totalTimeScope()
-    }
-
-    // 筛选相册内容后，使用定时器延迟刷新时间范围标签内容
-    Timer {
-        id: totalTimepScopeTimer
-        interval: 100
-        repeat: false
-        onTriggered: {
-            theView.totalTimeScope()
-        }
     }
 
     // 刷新总数标签

--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -122,7 +122,7 @@ Item {
             anchors.left: parent.left
             height: 30
             font: DTK.fontManager.t3
-            //text: qsTr(albumControl.getCustomAlbumByUid(customAlbumUId))
+            visible: numLabelText !== ""
         }
 
         // 筛选下拉框

--- a/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
@@ -9,7 +9,7 @@ import "../../"
 
 Rectangle {
     id: root
-    property int currentViewIndex: 0
+    property int currentViewIndex: 3
 
     // 通知日视图刷新状态栏提示信息
     signal flushDayViewStatusText()
@@ -26,22 +26,12 @@ Rectangle {
         allCollection.clearSelecteds()
 
         if (visible) {
-            flushTimeScopetimer.start(10)
             global.selectedPaths = []
 
             //年月视图不显示底栏数量
             if (currentViewIndex === 0 || currentViewIndex ===1) {
                 global.statusBarNumText = ""
             }
-        }
-    }
-
-    Timer {
-        id: flushTimeScopetimer
-        running: false
-        repeat: false
-        onTriggered: {
-            allCollection.flushTotalTimeScope()
         }
     }
 
@@ -75,8 +65,6 @@ Rectangle {
             dayCollection.visible = currentViewIndex === 2
             allCollection.clearSelecteds()
             allCollection.visible = currentViewIndex === 3
-
-            allCollection.flushTotalTimeScope()
 
             //年月视图不显示底栏数量
             if (currentViewIndex === 0 || currentViewIndex ===1) {

--- a/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
@@ -133,7 +133,9 @@ Item {
         theModel.selectedPathObjs = []
         dayHeights = []
         //1.获取日期
-        var days = albumControl.getDays()
+        var days = []
+        if (Number(fileControl.getConfigValue("", "loadDayView", 1)))
+            days = albumControl.getDays()
 
         //2.构建model
         var dayHeight = 0

--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -7,6 +7,7 @@ import QtQuick.Window 2.11
 import QtQuick.Layouts 1.11
 import QtQuick.Controls 2.4
 import QtQuick.Dialogs 1.3
+import QtGraphicalEffects 1.0
 import org.deepin.dtk 1.0
 import "../../Control"
 import "../../Control/ListView"
@@ -74,7 +75,7 @@ Item {
         Rectangle {
             width: theView.width
             height: theView.height / 3 * 2
-            radius: 18
+            color: Qt.rgba(0, 0, 0, 0)
 
             //圆角遮罩Rectangle
             Rectangle {
@@ -102,7 +103,7 @@ Item {
                 anchors.fill: parent
                 width: parent.width
                 height: parent.height
-                fillMode: Image.PreserveAspectCrop
+                fillMode: Image.Stretch
                 visible: false
             }
 
@@ -114,18 +115,24 @@ Item {
                 maskSource: maskRec
             }
 
-            //渐变阴影
-            //颜色格式为ARGB
-            Rectangle {
-                anchors.top: image.top
-                anchors.left: image.left
-                radius: 18
-                width: image.width
-                height: monthLabel.height + monthLabel.anchors.topMargin + itemCountLabel.height + itemCountLabel.anchors.topMargin + 5
-                gradient: Gradient {
-                    GradientStop { position: 0.0; color: "#61000000" }
-                    GradientStop { position: 1.0; color: "#00000000" }
-                }
+            // 边框阴影立体效果
+            DropShadow {
+                anchors.fill: mask
+                z: 0
+
+                verticalOffset: 1
+
+                radius: 5
+                samples: radius * 2 + 1
+                spread: 0.3
+
+                color: "black"
+
+                opacity: 0.3
+
+                source: mask
+
+                visible: true
             }
 
             Label {

--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -62,8 +62,9 @@ Item {
         spacing: 20
 
         width: parent.width / 3 * 2
-        height: parent.height
+        height: parent.height + global.statusBarHeight - global.collectionTopMargin
         anchors.top: parent.top
+        anchors.topMargin: global.collectionTopMargin
         anchors.horizontalCenter: parent.horizontalCenter
     }
 

--- a/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
@@ -7,6 +7,7 @@ import QtQuick.Window 2.11
 import QtQuick.Layouts 1.11
 import QtQuick.Controls 2.4
 import QtQuick.Dialogs 1.3
+import QtGraphicalEffects 1.0
 import org.deepin.dtk 1.0
 import "../../Control"
 import "../../Control/ListView"
@@ -58,6 +59,7 @@ Item {
             width: theView.width
             height: theView.height / 3 * 2
             radius: 18
+            color: Qt.rgba(0, 0, 0, 0)
 
             //圆角遮罩Rectangle
             Rectangle {
@@ -85,7 +87,7 @@ Item {
                 anchors.fill: parent
                 width: parent.width
                 height: parent.height
-                fillMode: Image.PreserveAspectCrop
+                fillMode: Image.Stretch
                 visible: false
             }
 
@@ -97,18 +99,24 @@ Item {
                 maskSource: maskRec
             }
 
-            //渐变阴影
-            //颜色格式为ARGB
-            Rectangle {
-                anchors.top: image.top
-                anchors.left: image.left
-                radius: 18
-                width: image.width
-                height: yearLabel.height + yearLabel.anchors.topMargin + itemCountLabel.height + itemCountLabel.anchors.topMargin + 5
-                gradient: Gradient {
-                    GradientStop { position: 0.0; color: "#61000000" }
-                    GradientStop { position: 1.0; color: "#00000000" }
-                }
+            // 边框阴影立体效果
+            DropShadow {
+                anchors.fill: mask
+                z: 0
+
+                verticalOffset: 1
+
+                radius: 5
+                samples: radius * 2 + 1
+                spread: 0.3
+
+                color: "black"
+
+                opacity: 0.3
+
+                source: mask
+
+                visible: true
             }
 
             Label {

--- a/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
@@ -45,8 +45,9 @@ Item {
         spacing: 20
 
         width: parent.width / 3 * 2
-        height: parent.height
+        height: parent.height + global.statusBarHeight - global.collectionTopMargin
         anchors.top: parent.top
+        anchors.topMargin: global.collectionTopMargin
         anchors.horizontalCenter: parent.horizontalCenter
     }
 

--- a/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
+++ b/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
@@ -27,7 +27,6 @@ Rectangle {
 
     onVisibleChanged: {
         if (visible) {
-            console.log("device show...")
             flushDeviceAlbumView()
         }
     }
@@ -39,8 +38,8 @@ Rectangle {
 
     // 设备之间切换，需要重载数据
     onDevicePathChanged: {
-        console.log("onDevicePathChanged...")
-        flushDeviceAlbumView()
+        if (visible)
+            flushDeviceAlbumView()
     }
 
     // 刷新设备视图内容
@@ -90,25 +89,6 @@ Rectangle {
         if (visible)
             global.statusBarNumText = selectedNumText
         return selectedNumText
-    }
-
-    // 加载设备相册数据
-    function loadDeviceAlbumItems()
-    {
-        console.info("device album model has refreshed... filterType:", filterType)
-        theView.selectAll(false)
-        theView.thumbnailListModel.clear();
-        var customAlbumInfos = albumControl.getDeviceAlbumInfos(devicePath, filterType);
-        console.info("device album model has refreshed... filterType:", filterType, " done...")
-        for (var key in customAlbumInfos) {
-            var customAlbumItems = customAlbumInfos[key]
-            for (var i = 0; i < customAlbumItems.length; i++) {
-                theView.thumbnailListModel.append(customAlbumItems[i])
-            }
-            break;
-        }
-
-        return true
     }
 
     DeviceLoadDialog {

--- a/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
+++ b/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
@@ -215,7 +215,7 @@ Rectangle {
                     if(global.selectedPaths.length > 0){
                     	albumControl.importFromMountDevice(global.selectedPaths,albumControl.getAllCustomAlbumId(global.albumChangeList)[currentImportIndex])
                     }else{
-                        albumControl.importFromMountDevice(theView.allOriginUrls(),albumControl.getAllCustomAlbumId(global.albumChangeList)[currentImportIndex])
+                        albumControl.importFromMountDevice(theView.allUrls(),albumControl.getAllCustomAlbumId(global.albumChangeList)[currentImportIndex])
                     }
                     DTK.sendMessage(thumbnailImage, qsTr("Import successful"), "notify_checked")
                 }

--- a/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
+++ b/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
@@ -5,8 +5,13 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.4
 import org.deepin.dtk 1.0
+
+import org.deepin.album 1.0 as Album
+
 import "../../Control"
 import "../../Control/ListView"
+import "../../"
+
 Rectangle {
     width: parent.width
     height: parent.height
@@ -40,8 +45,9 @@ Rectangle {
 
     // 刷新设备视图内容
     function flushDeviceAlbumView() {
-        loadDeviceAlbumItems()
-        global.selectedPaths = theView.selectedPaths
+        dataModel.devicePath = devicePath
+        theView.proxyModel.refresh(filterType)
+        global.selectedPaths = theView.selectedUrls
         getNumLabelText()
     }
 
@@ -227,24 +233,25 @@ Rectangle {
     }
 
     // 缩略图列表控件
-    ThumbnailListView {
+    ThumbnailListView2 {
         id: theView
         anchors.top: deviceAlbumTitleRect.bottom
         anchors.topMargin: 10
         width: parent.width
         height: parent.height - deviceAlbumTitleRect.height - m_topMargin - statusBar.height
         visible: numLabelText !== ""
+        thumnailListType: GlobalVar.ThumbnailType.Device
+
+        proxyModel.sourceModel: Album.ImageDataModel { id: dataModel; modelType: Album.Types.Device}
+
         property int m_topMargin: 10
 
         // 监听缩略图列表选中状态，一旦改变，更新globalVar所有选中路径
         Connections {
             target: theView
             onSelectedChanged: {
-                var selectedPaths = []
-                selectedPaths = theView.selectedPaths
-
                 if (parent.visible)
-                    global.selectedPaths = selectedPaths
+                    global.selectedPaths = theView.selectedUrls
             }
         }
     }

--- a/src/qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml
@@ -412,7 +412,6 @@ Item {
             //缩略图网格表
             ThumbnailListView {
                 id: importedGridView
-                viewTitle: theViewTitle
                 anchors.left: parent.left
                 anchors.top: importedCheckBox.bottom
                 anchors.topMargin: importedListView.listMargin

--- a/src/qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml
@@ -41,7 +41,9 @@ Item {
             theModel.selectedPathObjs = []
             theModel.dayHeights = []
             // 从后台获取所有已导入数据,倒序
-            var titleInfos = albumControl.getImportTimelinesTitleInfosReverse(filterCombo.currentIndex);
+            var titleInfos = []
+            if (Number(fileControl.getConfigValue("", "loadImport", 1)))
+                titleInfos = albumControl.getImportTimelinesTitleInfosReverse(filterCombo.currentIndex);
             console.log("imported model has refreshed.. filterType:", filterCombo.currentIndex, " done...")    
             var i = 0
             var dayHeight = 0

--- a/src/qml/ThumbnailImageView/ThumbnailImage.qml
+++ b/src/qml/ThumbnailImageView/ThumbnailImage.qml
@@ -143,7 +143,7 @@ Rectangle{
     }
 
     Shortcut {
-        enabled: visible && menuItemStates.canDelete
+        enabled: visible && menuItemStates.canDelete && global.currentViewIndex !== GlobalVar.ThumbnailViewType.Device
         autoRepeat: false
         sequence : "Delete"
         onActivated : {          
@@ -157,7 +157,7 @@ Rectangle{
     }
 
     Shortcut {
-        enabled: visible && menuItemStates.canRotate
+        enabled: visible && menuItemStates.canRotate && global.currentViewIndex !== GlobalVar.ThumbnailViewType.Device
         autoRepeat: false
         sequence : "Ctrl+R"
         onActivated : {
@@ -166,7 +166,7 @@ Rectangle{
     }
 
     Shortcut {
-        enabled: visible && menuItemStates.canRotate
+        enabled: visible && menuItemStates.canRotate && global.currentViewIndex !== GlobalVar.ThumbnailViewType.Device
         autoRepeat: false
         sequence : "Ctrl+Shift+R"
         onActivated : {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -10,8 +10,8 @@ import QtQuick.Controls 2.4
 import QtQuick.Dialogs 1.3
 import Qt.labs.folderlistmodel 2.11
 
-import org.deepin.dtk 1.0 as D
 import org.deepin.dtk 1.0
+import org.deepin.album 1.0 as Album
 
 ApplicationWindow {
     GlobalVar{
@@ -23,11 +23,11 @@ ApplicationWindow {
 
     signal sigTitlePress
     // 设置 dtk 风格窗口
-    D.DWindow.enabled: true
+    DWindow.enabled: true
     id: root
     title: ""
     header: AlbumTitle {id: titleAlubmRect}
-    D.MessageManager.layout: Column {
+    MessageManager.layout: Column {
         anchors {
             bottom: parent.bottom
             bottomMargin: global.statusBarHeight + 5
@@ -94,5 +94,9 @@ ApplicationWindow {
 
     StackControl{
         id: stackControl
+    }
+
+    Album.EventGenerator {
+        id: eventGenerator
     }
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -99,4 +99,11 @@ ApplicationWindow {
     Album.EventGenerator {
         id: eventGenerator
     }
+
+    Connections {
+        target: albumControl
+        onSigActiveApplicationWindow: {
+            root.requestActivate()
+        }
+    }
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -45,6 +45,8 @@ ApplicationWindow {
     Component.onCompleted: {
         setX(screen.width / 2 - width / 2);
         setY(screen.height / 2 - height / 2);
+
+        loading = false
     }
 
     onWindowStateChanged: {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -46,7 +46,7 @@ ApplicationWindow {
         setX(screen.width / 2 - width / 2);
         setY(screen.height / 2 - height / 2);
 
-        loading = false
+        global.loading = false
     }
 
     onWindowStateChanged: {

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -2661,4 +2661,6 @@ void AlbumControl::onNewAPPOpen(qint64 pid, const QStringList &arguments)
             emit sigOpenImageFromFiles(paths);
         }
     }
+
+    emit sigActiveApplicationWindow();
 }

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -2641,6 +2641,7 @@ void AlbumControl::onNewAPPOpen(qint64 pid, const QStringList &arguments)
     qDebug() << __FUNCTION__ << "---";
     Q_UNUSED(pid);
     QStringList paths;
+    QStringList validPaths;
     if (arguments.length() > 1) {
         //arguments第1个参数是进程名，图片paths参数需要从下标1开始
         for (int i = 1; i < arguments.size(); ++i) {
@@ -2654,11 +2655,20 @@ void AlbumControl::onNewAPPOpen(qint64 pid, const QStringList &arguments)
             if (QUrl::fromUserInput(qpath).isLocalFile()) {
                 qpath = "file://" + qpath;
             }
+
+            if (LibUnionImage_NameSpace::isImage(QUrl(qpath).toLocalFile())
+                    || LibUnionImage_NameSpace::isVideo(QUrl(qpath).toLocalFile())) {
+                validPaths.append(qpath);
+            }
             paths.append(qpath);
         }
 
-        if (paths.count() > 0) {
-            emit sigOpenImageFromFiles(paths);
+        if (!paths.isEmpty() > 0) {
+            if (validPaths.count() > 0) {
+                emit sigOpenImageFromFiles(validPaths);
+            } else {
+                emit sigInvalidFormat();
+            }
         }
     }
 

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -977,8 +977,7 @@ void AlbumControl::sltLoadMountFileList(const QString &path)
         QStringList allfiles;
         while (dir_iterator.hasNext()) {
             dir_iterator.next();
-            QFileInfo fileInfo = dir_iterator.fileInfo();
-            allfiles << fileInfo.filePath();
+            allfiles << dir_iterator.filePath();
         }
         //重置标志位，可以执行线程
         m_PhonePicFileMap[strPath] = allfiles;

--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -442,6 +442,9 @@ signals:
     //发送打开看图查看图片信号
     void sigOpenImageFromFiles(const QStringList &paths);
 
+    // 激活应用主窗口
+    void sigActiveApplicationWindow();
+
 private :
     static AlbumControl *m_instance;
     DBImgInfoList m_infoList;  //全部已导入

--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -207,6 +207,8 @@ public:
     //useAI为保留参数，false:不使用AI，只根据文件路径搜索；true:使用AI进行分析，根据关键字含义和图片内容进行搜索
     Q_INVOKABLE QVariant searchPicFromAlbum(int UID, const QString &keywords, bool useAI);
 
+    Q_INVOKABLE DBImgInfoList searchPicFromAlbum2(int UID, const QString &keywords, bool useAI);
+
     //输入一张图片，获得可以导出的格式
     Q_INVOKABLE QStringList imageCanExportFormat(const QString &path);
 
@@ -257,6 +259,8 @@ public:
 
     //获得device路径
     Q_INVOKABLE QVariantMap getDeviceAlbumInfos(const QString &devicePath, const int &filterType = 0);
+
+    Q_INVOKABLE DBImgInfoList getDeviceAlbumInfos2(const QString &devicePath, const int &filterType = 0);
 
     //获得设备相册的图片和视频数量
     Q_INVOKABLE int getDeviceAlbumInfoConut(const QString &devicePath, const int &filterType);
@@ -331,6 +335,9 @@ public:
 
     //获得最近删除的文件
     DBImgInfoList getTrashInfos(const int &filterType = 0);
+
+    //获得最近删除的文件
+    DBImgInfoList getTrashInfos2(const int &filterType = 0);
 
     //获得收藏文件
     DBImgInfoList getCollectionInfos();

--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -445,6 +445,9 @@ signals:
     // 激活应用主窗口
     void sigActiveApplicationWindow();
 
+    // 通知打开了非图片/视频文件的格式
+    void sigInvalidFormat();
+
 private :
     static AlbumControl *m_instance;
     DBImgInfoList m_infoList;  //全部已导入

--- a/src/src/albumgloabl.h
+++ b/src/src/albumgloabl.h
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ALBUMGLOBAL_H
+#define ALBUMGLOBAL_H
+
+#include <QPixmap>
+#include <QList>
+#include <QPixmap>
+#include <QIcon>
+#include <QFileInfo>
+#include <QSize>
+#include <QBuffer>
+#include <QPointer>
+#include <QDateTime>
+#include <QDebug>
+#include <QStandardPaths>
+#include <QDir>
+#include <QTime>
+
+namespace albumGlobal {
+
+//图片缓存文件夹
+const QString CACHE_PATH = QDir::homePath() + "/.local/share/deepin/deepin-album";
+
+//图片删除文件夹
+const QString DELETE_PATH = QDir::homePath() + "/.local/share/deepin/deepin-album-delete";
+}
+
+//数据库存储的文件类型
+enum DbFileType {
+    DbFileTypeNull = 0,
+    DbFileTypePic,      //图片
+    DbFileTypeVideo     //视频
+};
+
+struct DBAlbumInfo {
+    QString name;
+//    int count;
+    QDateTime beginTime;
+    QDateTime endTime;
+};
+
+enum ItemType {
+    ItemTypeNull = 1,
+    ItemTypeBlank,         //空白项，列表上方，悬浮控件下方高度
+    ItemTypePic,
+    ItemTypeVideo,
+    ItemTypeTimeLineTitle, //时间线标题
+    ItemTypeImportTimeLineTitle, //已导入时间线标题
+    ItemTypeMountImg //设备图片
+};
+
+//注意内部数据的摆放顺序，可以依靠64位程序的8字节对齐以节省空间
+struct DBImgInfo {
+    //数据库
+    QString filePath;
+    QDateTime time;        // 图片创建时间
+    QDateTime changeTime;  // 文件修改时间
+    QDateTime importTime;  // 导入时间 Or 删除时间
+    //QString albumUID;      // 图片所属相册UID，以","分隔，用于恢复，有需要再放开
+    QString pathHash;      // 用于应付频繁的hash，但不一定每个DBImgInfo都装载了它
+
+    ItemType itemType = ItemTypePic;//类型，空白，图片，视频
+
+    //显示
+    int imgWidth = 0;
+    int imgHeight = 0;
+    int remainDays = 30;
+    bool bNotSupportedOrDamaged = false;
+    bool bNeedDelete = false;//删除时间线与已导入标题时使用
+    bool isSelected = false;
+    QPixmap image;
+    QString date;
+    QString num;
+
+    friend QDebug operator<<(QDebug &dbg, const DBImgInfo &info)
+    {
+        dbg << "(DBImgInfo)["
+            << " Path:" << info.filePath
+            << " Name:" << info.getFileNameFromFilePath()
+            << " Time:" << info.time
+            << " ChangeTime:" <<  info.changeTime
+            << " ImportTime:" << info.importTime
+            //<< " UID:" << info.albumUID
+            << "]";
+        return dbg;
+    }
+
+    bool operator==(const DBImgInfo &info)
+    {
+        return this->filePath == info.filePath;
+    }
+
+    //辅助函数，在需要的时候调用
+
+    //反hex，用于将toHex后的32字节hash值反向提取成标准16字节hash值，用于从数据库读取数据用
+    //后续版本注意不要在非界面展示上使用toHex后的数据以节省内存和拷贝时间
+    static QByteArray deHex(const QString &hexString)
+    {
+        QByteArray result;
+        if (hexString.size() != 32) {
+            return result;
+        }
+        auto srcData = hexString.toStdString();
+        for (size_t i = 0; i < 32; i += 2) {
+            quint8 highHelf = static_cast<quint8>(srcData[i]);
+            quint8 lowHelf = static_cast<quint8>(srcData[i + 1]);
+            result.push_back(static_cast<char>(highHelf << 4 | lowHelf));
+        }
+        return result;
+    }
+
+    //根据filepath获取filename
+    //由于目标只是filePath.split('/').last()，所以直接从后向前搜索'/'以节省时间
+    static QString getFileNameFromFilePath(const QString &filePath)
+    {
+        auto rIter = std::find(filePath.crbegin(), filePath.crend(), '/');
+        if (rIter != filePath.crend()) {
+            auto iter = rIter.base();
+            QString result;
+            std::copy(iter, filePath.cend(), std::back_inserter(result));
+            return result;
+        } else {
+            return QString();
+        }
+    }
+
+    QString getFileNameFromFilePath() const
+    {
+        return getFileNameFromFilePath(filePath);
+    }
+};
+typedef QList<DBImgInfo> DBImgInfoList;
+
+enum OpenImgViewType {
+    VIEW_MAINWINDOW_ALLPIC = 0,
+    VIEW_MAINWINDOW_TIMELINE = 1,
+    VIEW_MAINWINDOW_ALBUM = 2 //
+};
+
+enum OpenImgAdditionalOperation {
+    Operation_NoOperation = 0,
+    Operation_FullScreen,
+    Operation_StartSliderShow
+};
+
+Q_DECLARE_METATYPE(DBImgInfo)
+#endif // ALBUMGLOBAL_H

--- a/src/src/configsetter.cpp
+++ b/src/src/configsetter.cpp
@@ -39,6 +39,13 @@ void LibConfigSetter::loadConfig(imageViewerSpace::ImgViewerType type)
     m_viewType = type;
     m_settings = new QSettings(imageViewerSpace::ImgViewerTypeAlbum == type ? CONFIG_PATH_ALBUM : CONFIG_PATH_IMAGE_VIEWER, QSettings::IniFormat, this);
 
+    if (imageViewerSpace::ImgViewerTypeAlbum == type) {
+        if (!contains("", "loadDayView"))
+            setValue("", "loadDayView", 1);
+        if (!contains("", "loadImport"))
+            setValue("", "loadImport", 1);
+    }
+
 //    if (imageViewerSpace::ImgViewerTypeAlbum == m_viewType) {
 //        if (!m_settings->contains("album-zoomratio")) {
 //            m_settings->setValue("album-zoomratio", 4);
@@ -69,4 +76,17 @@ QVariant LibConfigSetter::value(const QString &group, const QString &key,
     m_settings->endGroup();
 
     return value;
+}
+
+bool LibConfigSetter::contains(const QString &group, const QString &key)
+{
+    QMutexLocker locker(&m_mutex);
+
+    bool bContains = false;
+    QVariant value;
+    m_settings->beginGroup(group);
+    bContains = m_settings->contains(key);
+    m_settings->endGroup();
+
+    return bContains;
 }

--- a/src/src/configsetter.h
+++ b/src/src/configsetter.h
@@ -22,6 +22,7 @@ public:
                   const QVariant &value);
     QVariant value(const QString &group, const QString &key,
                    const QVariant &defaultValue = QVariant());
+    bool contains(const QString &group, const QString &key);
 //    QStringList keys(const QString group);
 
 signals:

--- a/src/src/dbmanager/dbmanager.h
+++ b/src/src/dbmanager/dbmanager.h
@@ -114,7 +114,7 @@ public:
     //确认目标UID对应的默认监控路径是否存在
     static bool defaultNotifyPathExists(int UID);
     const QStringList       getPathsByAlbum(int UID) const;
-    const DBImgInfoList     getInfosByAlbum(int UID, bool needTimeData) const;
+    const DBImgInfoList     getInfosByAlbum(int UID, bool needTimeData, ItemType itemType = ItemTypeNull) const;
     int                     getItemsCountByAlbum(int UID, const ItemType &type) const;
 //    int                     getAlbumsCount() const;
     bool                    isAlbumExistInDB(int UID, AlbumDBType atype = AlbumDBType::Custom) const;
@@ -151,6 +151,7 @@ public:
     QStringList             getMonths();
     int                     getMonthCount(const QString &year, const QString &month);
     //日聚合数据
+    DBImgInfoList           getInfosByDay(const QString &day);
     QStringList             getDayPaths(const QString &day);
     QStringList             getDays();
 private:

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -877,6 +877,11 @@ void FileControl::setConfigValue(const QString &group, const QString &key, const
     m_config->setValue(group, key, value);
 }
 
+bool FileControl::containsConfigValue(const QString &group, const QString &key)
+{
+    return m_config->contains(group, key);
+}
+
 int FileControl::getlastWidth()
 {
     int reWidth = 0;

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -541,7 +541,7 @@ QStringList FileControl::parseCommandlineGetPaths()
         QString path = UrlInfo(arguments[i]).toLocalFile();
         if (QFileInfo(path).isFile()) {
             QString filepath = QUrl::fromLocalFile(path).toString();
-            if (isImage(path) || isVideo(path)) {
+            if (isImage(filepath) || isVideo(filepath)) {
                 validPaths.push_back(filepath);
             }
             paths.push_back(filepath);

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -491,7 +491,8 @@ bool FileControl::isCanDelete(const QString &path)
 {
     bool bRet = false;
     bool isAlbum = false;
-    QString localPath = QUrl(path).toLocalFile();
+    QUrl url(path);
+    QString localPath = url.isLocalFile() ? url.toLocalFile() : path;
     QFileInfo info(localPath);
     bool isWritable = info.isWritable() && QFileInfo(info.dir(), info.dir().path()).isWritable(); //是否可写
     bool isReadable = info.isReadable() ; //是否可读

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -218,18 +218,7 @@ QString FileControl::getNamePath(const  QString &oldPath, const QString &newName
 
 bool FileControl::isImage(const QString &path)
 {
-    bool bRet = false;
-    //路径为空直接跳出
-    if (!path.isEmpty()) {
-        QMimeDatabase db;
-        QMimeType mt = db.mimeTypeForFile(path, QMimeDatabase::MatchContent);
-        QMimeType mt1 = db.mimeTypeForFile(path, QMimeDatabase::MatchExtension);
-        if (mt.name().startsWith("image/") || mt.name().startsWith("video/x-mng") ||
-                mt1.name().startsWith("image/") || mt1.name().startsWith("video/x-mng")) {
-            bRet = true;
-        }
-    }
-    return bRet;
+    return LibUnionImage_NameSpace::isImage(QUrl(path).toLocalFile());
 }
 
 bool FileControl::isVideo(const QString &path)
@@ -545,19 +534,24 @@ void FileControl::ocrImage(const QString &path)
 QStringList FileControl::parseCommandlineGetPaths()
 {
     QStringList paths;
+    QStringList validPaths;
     QString filepath = "";
     QStringList arguments = QCoreApplication::arguments();
-    for (QString path : arguments) {
-        path = UrlInfo(path).toLocalFile();
+    for (int i = 1; i < arguments.size(); ++i) {
+        QString path = UrlInfo(arguments[i]).toLocalFile();
         if (QFileInfo(path).isFile()) {
             QString filepath = QUrl::fromLocalFile(path).toString();
             if (isImage(path) || isVideo(path)) {
-                paths.push_back(filepath);
+                validPaths.push_back(filepath);
             }
+            paths.push_back(filepath);
         }
     }
 
-    return paths;
+    if (validPaths.empty() && !paths.isEmpty())
+        emit invalidFormat();
+
+    return validPaths;
 }
 
 bool FileControl::isDynamicImage(const QString &path)

--- a/src/src/filecontrol.h
+++ b/src/src/filecontrol.h
@@ -241,6 +241,9 @@ signals:
     // 通知相册刷新缩略图内容
     void callSavePicDone(const QString &path);
 
+    // 通知打开了非图片/视频文件的格式
+    void invalidFormat();
+
 private:
     // 当处理的图片文件被移动、替换、删除时触发
     void onImageFileChanged(const QString &file);

--- a/src/src/filecontrol.h
+++ b/src/src/filecontrol.h
@@ -175,6 +175,9 @@ public:
     Q_INVOKABLE void setConfigValue(const QString &group, const QString &key,
                                     const QVariant &value);
 
+    //查看配置文件是否有配置相关值
+    Q_INVOKABLE bool containsConfigValue(const QString &group, const QString &key);
+
     Q_INVOKABLE int getlastWidth();
 
     Q_INVOKABLE int getlastHeight();

--- a/src/src/imageengine/imagedataservice.cpp
+++ b/src/src/imageengine/imagedataservice.cpp
@@ -1,0 +1,442 @@
+/*
+ * Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     ZhangYong <zhangyong@uniontech.com>
+ *
+ * Maintainer: ZhangYong <ZhangYong@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "imagedataservice.h"
+#include "unionimage/unionimage.h"
+#include "unionimage/baseutils.h"
+#include "unionimage/unionimage_global.h"
+#include "dbmanager/dbmanager.h"
+#include "configsetter.h"
+#include "movieservice.h"
+
+#include <QMetaType>
+#include <QDirIterator>
+#include <QStandardPaths>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
+
+const QString SETTINGS_GROUP = "Thumbnail";
+const QString SETTINGS_DISPLAY_MODE = "ThumbnailMode";
+
+ImageDataService *ImageDataService::s_ImageDataService = nullptr;
+
+ImageDataService *ImageDataService::instance(QObject *parent)
+{
+    Q_UNUSED(parent);
+    if (!s_ImageDataService) {
+        s_ImageDataService = new ImageDataService();
+    }
+    return s_ImageDataService;
+}
+
+bool ImageDataService::pathInMap(const QString &path)
+{
+    QString loadModePath = getLoadModePath(path);
+    auto iter = std::find_if(m_AllImageMap.begin(), m_AllImageMap.end(), [loadModePath](const std::pair<QString, QImage> &pr) {
+        return pr.first == loadModePath;
+    });
+    return iter != m_AllImageMap.end();
+}
+
+std::pair<QImage, bool> ImageDataService::getImageFromMap(const QString &path)
+{
+    QMutexLocker locker(&m_imgDataMutex);
+
+    QString loadModePath = getLoadModePath(path);
+
+    auto iter = std::find_if(m_AllImageMap.begin(), m_AllImageMap.end(), [loadModePath](const std::pair<QString, QImage> &pr) {
+        return pr.first == loadModePath;
+    });
+    if (iter != m_AllImageMap.end()) {
+        return std::make_pair(iter->second, true);
+    } else {
+        return std::make_pair(QImage(), false);
+    }
+}
+
+void ImageDataService::removePathFromMap(const QString &path)
+{
+    QMutexLocker locker(&m_imgDataMutex);
+
+    auto iter = std::find_if(m_AllImageMap.begin(), m_AllImageMap.end(), [path](const std::pair<QString, QImage> &pr) {
+        return pr.first == path;
+    });
+    if (iter != m_AllImageMap.end()) {
+        m_AllImageMap.erase(iter);
+    }
+
+    QString scalPath = getScaledPath(path);
+    iter = std::find_if(m_AllImageMap.begin(), m_AllImageMap.end(), [scalPath](const std::pair<QString, QImage> &pr) {
+        return pr.first == scalPath;
+    });
+    if (iter != m_AllImageMap.end()) {
+        m_AllImageMap.erase(iter);
+    }
+}
+
+void ImageDataService::removeThumbnailFile(const QString &path)
+{
+    if (path.isEmpty())
+        return;
+
+    QString thumbnailPath = Libutils::base::filePathToThumbnailPath(path);
+    QString thumbnailScalePath = ImageDataService::instance()->getLoadModePath(thumbnailPath);
+    if (QFile::exists(thumbnailPath))
+        QFile::remove(thumbnailPath);
+    if (QFile::exists(thumbnailScalePath))
+        QFile::remove(thumbnailScalePath);
+}
+
+QString ImageDataService::getLoadModePath(const QString &path)
+{
+    if (m_loadMode == 0)
+        return path;
+
+    return getScaledPath(path);
+}
+
+QString ImageDataService::getScaledPath(const QString &path)
+{
+    QFileInfo fi(path);
+    QString tmpPath = fi.absolutePath() + "/" + fi.fileName().left(fi.fileName().lastIndexOf('.')) + "_scale" + fi.fileName().mid(fi.fileName().lastIndexOf('.'));
+    return tmpPath;
+}
+
+void ImageDataService::addImage(const QString &path, const QImage &image)
+{
+    QMutexLocker locker(&m_imgDataMutex);
+
+    QString loadModePath = getLoadModePath(path);
+
+    auto iter = std::find_if(m_AllImageMap.begin(), m_AllImageMap.end(), [loadModePath](const std::pair<QString, QImage> &pr) {
+        if (pr.first != loadModePath) {
+            return false;
+        }
+        return true;
+    });
+//    QImage m_image = addPadAndScaled(image);
+//    m_image.save("/home/houchengqiu/Desktop/text1.png");
+    if (iter != m_AllImageMap.end()) {
+        iter->second = image;
+    } else {
+        m_AllImageMap.push_back(std::make_pair(loadModePath, image));
+        if (m_AllImageMap.size() > 500) {
+            m_AllImageMap.pop_front();
+        }
+    }
+}
+
+void ImageDataService::addMovieDurationStr(const QString &path, const QString &durationStr)
+{
+    QMutexLocker locker(&m_imgDataMutex);
+    m_movieDurationStrMap[path] = durationStr;
+}
+
+QString ImageDataService::getMovieDurationStrByPath(const QString &path)
+{
+    QMutexLocker locker(&m_imgDataMutex);
+    return m_movieDurationStrMap.contains(path) ? m_movieDurationStrMap[path] : QString() ;
+}
+
+bool ImageDataService::imageIsLoaded(const QString &path, bool isTrashFile)
+{
+    QMutexLocker locker(&m_imgDataMutex);
+
+    if (isTrashFile) {
+        QString realPath = Libutils::base::getDeleteFullPath(Libutils::base::hashByString(path), DBImgInfo::getFileNameFromFilePath(path));
+        return pathInMap(realPath) || pathInMap(path);
+    } else {
+        return pathInMap(path);
+    }
+}
+
+ImageDataService::ImageDataService(QObject *parent) : QObject(parent)
+{
+    m_loadMode = 1;
+    readThumbnailManager = new ReadThumbnailManager;
+    readThread = new QThread;
+    readThumbnailManager->moveToThread(readThread);
+    readThread->start();
+    connect(this, &ImageDataService::startImageLoad, readThumbnailManager, &ReadThumbnailManager::readThumbnail);
+
+    //初始化的时候读取上次退出时的状态
+    m_loadMode = LibConfigSetter::instance()->value(SETTINGS_GROUP, SETTINGS_DISPLAY_MODE, 0).toInt();
+
+    //connect(dApp->signalM, &SignalManager::needReflushThumbnail, this, &ImageDataService::onNeedReflushThumbnail, Qt::QueuedConnection);
+}
+
+void ImageDataService::stopFlushThumbnail()
+{
+    readThumbnailManager->stopRead();
+}
+
+void ImageDataService::waitFlushThumbnailFinish()
+{
+    while (ImageDataService::instance()->readThumbnailManager->isRunning());
+}
+
+bool ImageDataService::readerIsRunning()
+{
+    return readThumbnailManager->isRunning();
+}
+
+void ImageDataService::switchLoadMode()
+{
+    switch (m_loadMode) {
+    case 0:
+        m_loadMode = 1;
+        break;
+    case 1:
+        m_loadMode = 0;
+        break;
+    default:
+        m_loadMode = 0;
+        break;
+    }
+
+    //切完以后保存状态
+    LibConfigSetter::instance()->setValue(SETTINGS_GROUP, SETTINGS_DISPLAY_MODE, m_loadMode.load());
+    qDebug() << "ImageDataService::switchLoadMode m_loadMode:" << m_loadMode;
+}
+
+int ImageDataService::getLoadMode()
+{
+    return m_loadMode;
+}
+
+QImage ImageDataService::getThumnailImageByPathRealTime(const QString &path, bool isTrashFile, bool bReload/* = false*/)
+{
+    QString realPath;
+
+    if (!isTrashFile) {
+        realPath = path;
+        if (!QFile::exists(realPath)) {
+            return QImage();
+        }
+    } else {
+        realPath = Libutils::base::getDeleteFullPath(Libutils::base::hashByString(path), DBImgInfo::getFileNameFromFilePath(path));
+        if (!QFile::exists(realPath)) {
+            if (!QFile::exists(path)) {
+                return QImage();
+            } else {
+                realPath = path;
+            }
+        }
+    }
+
+    // 重新加载缩略图，清楚缓存对应缩略图
+    if (bReload) {
+        removePathFromMap(realPath);
+        removeThumbnailFile(realPath);
+    }
+
+    //尝试在缓存里面找图
+    auto bufferImage = getImageFromMap(realPath);
+    if (bufferImage.second) {
+        return bufferImage.first;
+    }
+
+    //缓存没找到则加入图片到加载队列
+    readThumbnailManager->addLoadPath(realPath);
+
+    //如果加载队列正在休眠，则发信号唤醒，反之不去反复发信号激活队列
+    if (!readThumbnailManager->isRunning()) {
+        emit startImageLoad();
+    }
+
+    return QImage();
+}
+
+ReadThumbnailManager::ReadThumbnailManager(QObject *parent)
+    : QObject(parent)
+    , runningFlag(false)
+    , stopFlag(false)
+{
+}
+
+void ReadThumbnailManager::addLoadPath(const QString &path)
+{
+    mutex.lock();
+    needLoadPath.push_back(path);
+    if (needLoadPath.size() > 100) {
+        needLoadPath.pop_front();
+    }
+    mutex.unlock();
+}
+
+void ReadThumbnailManager::readThumbnail()
+{
+    int sendCounter = 0; //刷新上层界面指示
+    runningFlag = true;  //告诉外面加载队列处于激活状态
+
+    while (1) {
+        //尝试读取队列数据
+        mutex.lock();
+
+        if (needLoadPath.empty() || stopFlag) {
+            mutex.unlock();
+            break;
+        }
+
+        //锁定文件操作权限
+        DBManager::m_fileMutex.lockForRead();
+
+        auto path = needLoadPath[needLoadPath.size() - 1];
+        needLoadPath.pop_back();
+
+        mutex.unlock();
+
+        sendCounter++;
+        if (sendCounter == 5) { //每加载5张图，就让上层界面主动刷新一次
+            sendCounter = 0;
+            emit ImageDataService::instance()->sigeUpdateListview();
+        }
+
+        if (!QFileInfo(path).exists()) {
+            DBManager::m_fileMutex.unlock();
+            continue;
+        }
+        using namespace LibUnionImage_NameSpace;
+        QImage tImg;
+        QString srcPath = path;
+        QString thumbnailPath = Libutils::base::filePathToThumbnailPath(path);
+        thumbnailPath = ImageDataService::instance()->getLoadModePath(thumbnailPath);
+
+        QFileInfo thumbnailFile(thumbnailPath);
+        QString errMsg;
+        if (thumbnailFile.exists()) {
+            if (!loadStaticImageFromFile(thumbnailPath, tImg, errMsg, "PNG")) {
+                qDebug() << errMsg;
+                //不正常退出导致的缩略图损坏，删除原文件后重新尝试制作
+                QFile::remove(thumbnailPath);
+                if (!loadStaticImageFromFile(srcPath, tImg, errMsg)) {
+                    qDebug() << errMsg;
+                }
+            }
+
+            if (isVideo(srcPath)) {
+                //获取视频信息 demo
+                MovieInfo mi = MovieService::instance()->getMovieInfo(QUrl::fromLocalFile(srcPath));
+                ImageDataService::instance()->addMovieDurationStr(srcPath, mi.duration);
+            }
+        } else {
+            //读图
+            if (isVideo(srcPath)) {
+                tImg = MovieService::instance()->getMovieCover(QUrl::fromLocalFile(srcPath));
+
+                //获取视频信息 demo
+                MovieInfo mi = MovieService::instance()->getMovieInfo(QUrl::fromLocalFile(srcPath));
+                ImageDataService::instance()->addMovieDurationStr(path, mi.duration);
+            } else {
+                if (!loadStaticImageFromFile(srcPath, tImg, errMsg)) {
+                    qDebug() << errMsg;
+                    ImageDataService::instance()->addImage(srcPath, tImg);
+                    DBManager::m_fileMutex.unlock();
+                    continue;
+                }
+            }
+
+            //裁切
+            if (ImageDataService::instance()->getLoadMode() == 0)
+                tImg = clipToRect(tImg);
+            else if (ImageDataService::instance()->getLoadMode() == 1)
+                tImg = addPadAndScaled(tImg);
+
+            Libutils::base::mkMutiDir(thumbnailPath.mid(0, thumbnailPath.lastIndexOf('/')));
+        }
+
+        if (!tImg.isNull() && !thumbnailFile.exists()) {
+            tImg.save(thumbnailPath, "PNG"); //保存裁好的缩略图，下次读的时候直接刷进去
+        }
+
+        ImageDataService::instance()->addImage(path, tImg);
+
+        // 成功加载缩略图，通知上层界面刷新
+        emit ImageDataService::instance()->gotImage(path);
+
+        DBManager::m_fileMutex.unlock();
+    }
+
+    if (!stopFlag) {
+        emit ImageDataService::instance()->sigeUpdateListview(); //最后让上层界面刷新
+    }
+
+    runningFlag = false; //告诉外面加载队列处于休眠状态
+}
+
+QImage ReadThumbnailManager::clipToRect(const QImage &src)
+{
+    auto tImg = src;
+
+    if (!tImg.isNull() && 0 != tImg.height() && 0 != tImg.width() && (tImg.height() / tImg.width()) < 10 && (tImg.width() / tImg.height()) < 10) {
+        bool cache_exist = false;
+        if (tImg.height() != 200 && tImg.width() != 200) {
+            if (tImg.height() >= tImg.width()) {
+                cache_exist = true;
+                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
+            } else if (tImg.height() <= tImg.width()) {
+                cache_exist = true;
+                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
+            }
+        }
+        if (!cache_exist) {
+            if ((static_cast<float>(tImg.height()) / (static_cast<float>(tImg.width()))) > 3) {
+                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
+            } else {
+                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
+            }
+        }
+    }
+
+    if (!tImg.isNull()) {
+        int width = tImg.width();
+        int height = tImg.height();
+        if (abs((width - height) * 10 / width) >= 1) {
+            QRect rect = tImg.rect();
+            int x = rect.x() + width / 2;
+            int y = rect.y() + height / 2;
+            if (width > height) {
+                x = x - height / 2;
+                y = 0;
+                tImg = tImg.copy(x, y, height, height);
+            } else {
+                y = y - width / 2;
+                x = 0;
+                tImg = tImg.copy(x, y, width, width);
+            }
+        }
+    }
+
+    return tImg;
+}
+
+QImage ReadThumbnailManager::addPadAndScaled(const QImage &src)
+{
+    auto result = src.convertToFormat(QImage::Format_RGBA8888);
+
+    if (result.height() > result.width()) {
+        result = result.scaledToHeight(200, Qt::SmoothTransformation);
+    } else {
+        result = result.scaledToWidth(200, Qt::SmoothTransformation);
+    }
+
+    return result;
+}

--- a/src/src/imageengine/imagedataservice.h
+++ b/src/src/imageengine/imagedataservice.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
+ *
+ * Author:     ZhangYong <zhangyong@uniontech.com>
+ *
+ * Maintainer: ZhangYong <ZhangYong@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef IMAGEDATASERVICE_H
+#define IMAGEDATASERVICE_H
+
+#include <QObject>
+#include <QMap>
+#include <QUrl>
+#include <QMutex>
+#include <QThread>
+#include <QQueue>
+#include <deque>
+
+class readThumbnailThread;
+class ReadThumbnailManager;
+class ImageDataService: public QObject
+{
+    Q_OBJECT
+public:
+    static ImageDataService *instance(QObject *parent = nullptr);
+    explicit ImageDataService(QObject *parent = nullptr);
+
+    void addImage(const QString &path, const QImage &image);
+    QImage getThumnailImageByPathRealTime(const QString &path, bool isTrashFile, bool bReload = false);
+    bool imageIsLoaded(const QString &path, bool isTrashFile);
+
+    void addMovieDurationStr(const QString &path, const QString &durationStr);
+    QString getMovieDurationStrByPath(const QString &path);
+
+    void stopFlushThumbnail();
+    void waitFlushThumbnailFinish();
+
+    bool readerIsRunning();
+
+    //切换图片显示状态
+    Q_INVOKABLE void switchLoadMode();
+
+    //获得当前图片显示的状态
+    Q_INVOKABLE int getLoadMode();
+
+    // 根据加载模式获取对应加载图片路径
+    QString getLoadModePath(const QString &path);
+
+    // 获取等比例缩略图存放路径
+    QString getScaledPath(const QString &path);
+
+private slots:
+signals:
+    void sigeUpdateListview();
+    void gotImage(const QString path);
+    void startImageLoad();
+public:
+private:
+    bool pathInMap(const QString &path);
+
+    //QImage:图片，bool:是否是从缓存加载
+    std::pair<QImage, bool> getImageFromMap(const QString &path);
+    // 从缓存清除图片信息
+    void removePathFromMap(const QString &path);
+
+    // 清除图片文件对应缩略图文件
+    void removeThumbnailFile(const QString &path);
+
+private:
+    static ImageDataService *s_ImageDataService;
+
+    //图片数据锁
+    QMutex m_imgDataMutex;
+    //QString:原图路径 QImage:缩略图
+    std::deque<std::pair<QString, QImage>> m_AllImageMap;
+    QMap<QString, QString> m_movieDurationStrMap;
+
+    //加载模式控制
+    std::atomic_int m_loadMode;
+
+    ReadThumbnailManager *readThumbnailManager;
+    QThread *readThread;
+};
+
+//缩略图读取类
+class ReadThumbnailManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ReadThumbnailManager(QObject *parent = nullptr);
+    void addLoadPath(const QString &path);
+
+    bool isRunning()
+    {
+        return runningFlag;
+    }
+
+    void stopRead()
+    {
+        stopFlag = true;
+    }
+
+public slots:
+    void readThumbnail();
+
+private:
+    // 将图片裁剪为方图
+    QImage clipToRect(const QImage &src);
+    // 将图片按比例缩小
+    QImage addPadAndScaled(const QImage &src);
+private:
+    std::deque<QString> needLoadPath;
+    QMutex mutex;
+    std::atomic_bool runningFlag;
+    std::atomic_bool stopFlag;
+};
+
+#endif // IMAGEDATASERVICE_H

--- a/src/src/imageengine/imageenginethread.cpp
+++ b/src/src/imageengine/imageenginethread.cpp
@@ -156,20 +156,24 @@ void ImportImagesThread::runDetail()
         dbInfo.albumUID = QString::number(m_UID);
         dbInfos << dbInfo;
 
-        //导入图片数据库ImageTable3
-        DBManager::instance()->insertImgInfos(dbInfos);
+        emit sigImportProgress(i++, size);
+    }
 
-        //导入图片数据库AlbumTable3
-        if (m_UID >= 0) {
-            AlbumDBType atype = AlbumDBType::AutoImport;
-            if (m_UID == 0) {
-                atype = AlbumDBType::Favourite;
-            }
+    std::sort(dbInfos.begin(), dbInfos.end(), [](const DBImgInfo & lhs, const DBImgInfo & rhs) {
+        return lhs.changeTime > rhs.changeTime;
+    });
 
-            DBManager::instance()->insertIntoAlbum(m_UID, QStringList(path), atype);
+    //导入图片数据库ImageTable3
+    DBManager::instance()->insertImgInfos(dbInfos);
+
+    //导入图片数据库AlbumTable3
+    if (m_UID >= 0) {
+        AlbumDBType atype = AlbumDBType::AutoImport;
+        if (m_UID == 0) {
+            atype = AlbumDBType::Favourite;
         }
 
-        emit sigImportProgress(i++, size);
+        DBManager::instance()->insertIntoAlbum(m_UID, m_filePaths, atype);
     }
 
     //原createNewCustomAutoImportAlbum逻辑

--- a/src/src/thumbnailload.cpp
+++ b/src/src/thumbnailload.cpp
@@ -11,6 +11,7 @@
 
 const QString SETTINGS_GROUP = "Thumbnail";
 const QString SETTINGS_DISPLAY_MODE = "ThumbnailMode";
+const int LINE_SPACE = 2;
 
 ThumbnailLoad::ThumbnailLoad()
     : QQuickImageProvider(QQuickImageProvider::Image)
@@ -802,15 +803,18 @@ QImage CollectionPublisher::createMonth_2(const std::vector<QImage> &images)
     QImage result(outputWidth, outputHeight, QImage::Format_RGB888);
     result.fill(Qt::white);
 
+    // 图片显示区域实际宽度值（除开分割线间隙）
+    constexpr int nImageRegionWidth = outputWidth - LINE_SPACE;
+
     //初始化原始图片
-    QImage images_0 = clipHelper(images[0], outputWidth / 2, outputHeight);
-    QImage images_1 = clipHelper(images[1], outputWidth / 2, outputHeight);
+    QImage images_0 = clipHelper(images[0], nImageRegionWidth / 2, outputHeight);
+    QImage images_1 = clipHelper(images[1], nImageRegionWidth / 2, outputHeight);
 
     //绘制
     QPainter painter;
     painter.begin(&result);
     painter.drawImage(0, 0, images_0);
-    painter.drawImage(outputWidth / 2, 0, images_1);
+    painter.drawImage(nImageRegionWidth / 2 + LINE_SPACE, 0, images_1);
     painter.end();
 
     return result;
@@ -824,17 +828,21 @@ QImage CollectionPublisher::createMonth_3(const std::vector<QImage> &images)
     QImage result(outputWidth, outputHeight, QImage::Format_RGB888);
     result.fill(Qt::white);
 
+    // 图片显示区域实际宽、高度值（除开分割线间隙）
+    constexpr int nImageRegionWidth = outputWidth - LINE_SPACE;
+    constexpr int nImageRegionHeight = outputHeight - LINE_SPACE;
+
     //初始化原始图片
-    QImage images_0 = clipHelper(images[0], outputWidth / 2, outputHeight);
-    QImage images_1 = clipHelper(images[1], outputWidth / 2, outputHeight / 2);
-    QImage images_2 = clipHelper(images[2], outputWidth / 2, outputHeight / 2);
+    QImage images_0 = clipHelper(images[0], nImageRegionWidth / 2, outputHeight);
+    QImage images_1 = clipHelper(images[1], nImageRegionWidth / 2, nImageRegionHeight / 2);
+    QImage images_2 = clipHelper(images[2], nImageRegionWidth / 2, nImageRegionHeight / 2);
 
     //绘制
     QPainter painter;
     painter.begin(&result);
     painter.drawImage(0, 0, images_0);
-    painter.drawImage(outputWidth / 2, 0, images_1);
-    painter.drawImage(outputWidth / 2, outputHeight / 2, images_2);
+    painter.drawImage(nImageRegionWidth / 2 + LINE_SPACE, 0, images_1);
+    painter.drawImage(nImageRegionWidth / 2 + LINE_SPACE, nImageRegionHeight / 2 + 1 + LINE_SPACE, images_2);
     painter.end();
 
     return result;
@@ -848,19 +856,23 @@ QImage CollectionPublisher::createMonth_4(const std::vector<QImage> &images)
     QImage result(outputWidth, outputHeight, QImage::Format_RGB888);
     result.fill(Qt::white);
 
+    // 图片显示区域实际宽、高度值（除开分割线间隙）
+    constexpr int nImageRegionWidth = outputWidth - LINE_SPACE;
+    constexpr int nImageRegionHeight = outputHeight - LINE_SPACE;
+
     //初始化原始图片
-    QImage images_0 = clipHelper(images[0], outputWidth / 2, outputHeight / 2);
-    QImage images_1 = clipHelper(images[1], outputWidth / 2, outputHeight / 2);
-    QImage images_2 = clipHelper(images[2], outputWidth / 2, outputHeight / 2);
-    QImage images_3 = clipHelper(images[3], outputWidth / 2, outputHeight / 2);
+    QImage images_0 = clipHelper(images[0], nImageRegionWidth / 2, nImageRegionHeight / 2);
+    QImage images_1 = clipHelper(images[1], nImageRegionWidth / 2, nImageRegionHeight / 2);
+    QImage images_2 = clipHelper(images[2], nImageRegionWidth / 2, nImageRegionHeight / 2);
+    QImage images_3 = clipHelper(images[3], nImageRegionWidth / 2, nImageRegionHeight / 2);
 
     //绘制
     QPainter painter;
     painter.begin(&result);
     painter.drawImage(0, 0, images_0);
-    painter.drawImage(outputWidth / 2, 0, images_1);
-    painter.drawImage(0, outputHeight / 2, images_2);
-    painter.drawImage(outputWidth / 2, outputHeight / 2, images_3);
+    painter.drawImage(nImageRegionWidth / 2 + LINE_SPACE, 0, images_1);
+    painter.drawImage(0, nImageRegionHeight / 2 + 1 + LINE_SPACE, images_2);
+    painter.drawImage(nImageRegionWidth / 2 + LINE_SPACE, nImageRegionHeight / 2 + 1 + LINE_SPACE, images_3);
     painter.end();
 
     return result;
@@ -876,21 +888,25 @@ QImage CollectionPublisher::createMonth_5(const std::vector<QImage> &images)
     constexpr int splitPos = static_cast<int>(outputHeight * 0.618);
     constexpr int splitPos_2 = static_cast<int>(outputHeight * (1 - 0.618));
 
+
+    // 图片显示区域实际宽度值（除开分割线间隙）
+    constexpr int nImageRegionWidth = outputWidth - LINE_SPACE * 3;
+
     //初始化原始图片
     QImage images_0 = clipHelper(images[0], outputWidth, splitPos);
-    QImage images_1 = clipHelper(images[1], outputWidth / 4, splitPos_2);
-    QImage images_2 = clipHelper(images[2], outputWidth / 4, splitPos_2);
-    QImage images_3 = clipHelper(images[3], outputWidth / 4, splitPos_2);
-    QImage images_4 = clipHelper(images[4], outputWidth / 4, splitPos_2);
+    QImage images_1 = clipHelper(images[1], nImageRegionWidth / 4, splitPos_2);
+    QImage images_2 = clipHelper(images[2], nImageRegionWidth / 4, splitPos_2);
+    QImage images_3 = clipHelper(images[3], nImageRegionWidth / 4, splitPos_2);
+    QImage images_4 = clipHelper(images[4], nImageRegionWidth / 4 + 1, splitPos_2);
 
     //绘制
     QPainter painter;
     painter.begin(&result);
     painter.drawImage(0, 0, images_0);
-    painter.drawImage(0, splitPos, images_1);
-    painter.drawImage(outputWidth / 4 * 1, splitPos, images_2);
-    painter.drawImage(outputWidth / 4 * 2, splitPos, images_3);
-    painter.drawImage(outputWidth / 4 * 3, splitPos, images_4);
+    painter.drawImage(0, splitPos + LINE_SPACE, images_1);
+    painter.drawImage((nImageRegionWidth / 4 + LINE_SPACE) * 1, splitPos + LINE_SPACE, images_2);
+    painter.drawImage((nImageRegionWidth / 4 + LINE_SPACE) * 2, splitPos + LINE_SPACE, images_3);
+    painter.drawImage((nImageRegionWidth / 4 + LINE_SPACE) * 3, splitPos + LINE_SPACE, images_4);
     painter.end();
 
     return result;
@@ -906,23 +922,26 @@ QImage CollectionPublisher::createMonth_6(const std::vector<QImage> &images)
     constexpr int splitPos = static_cast<int>(outputHeight * 0.618);
     constexpr int splitPos_2 = static_cast<int>(outputHeight * (1 - 0.618));
 
+    // 图片显示区域实际宽度值（除开分割线间隙）
+    constexpr int nImageRegionWidth = outputWidth - LINE_SPACE * 4;
+
     //初始化原始图片
     QImage images_0 = clipHelper(images[0], outputWidth, splitPos);
-    QImage images_1 = clipHelper(images[1], outputWidth / 5, splitPos_2);
-    QImage images_2 = clipHelper(images[2], outputWidth / 5, splitPos_2);
-    QImage images_3 = clipHelper(images[3], outputWidth / 5, splitPos_2);
-    QImage images_4 = clipHelper(images[4], outputWidth / 5, splitPos_2);
-    QImage images_5 = clipHelper(images[5], outputWidth / 5, splitPos_2);
+    QImage images_1 = clipHelper(images[1], nImageRegionWidth / 5, splitPos_2);
+    QImage images_2 = clipHelper(images[2], nImageRegionWidth / 5, splitPos_2);
+    QImage images_3 = clipHelper(images[3], nImageRegionWidth / 5, splitPos_2);
+    QImage images_4 = clipHelper(images[4], nImageRegionWidth / 5, splitPos_2);
+    QImage images_5 = clipHelper(images[5], nImageRegionWidth / 5 + 1, splitPos_2);
 
     //绘制
     QPainter painter;
     painter.begin(&result);
     painter.drawImage(0, 0, images_0);
-    painter.drawImage(0, splitPos, images_1);
-    painter.drawImage(outputWidth / 5 * 1, splitPos, images_2);
-    painter.drawImage(outputWidth / 5 * 2, splitPos, images_3);
-    painter.drawImage(outputWidth / 5 * 3, splitPos, images_4);
-    painter.drawImage(outputWidth / 5 * 4, splitPos, images_5);
+    painter.drawImage(0, splitPos + LINE_SPACE, images_1);
+    painter.drawImage((nImageRegionWidth / 5 + LINE_SPACE) * 1, splitPos + LINE_SPACE, images_2);
+    painter.drawImage((nImageRegionWidth / 5 + LINE_SPACE) * 2, splitPos + LINE_SPACE, images_3);
+    painter.drawImage((nImageRegionWidth / 5 + LINE_SPACE) * 3, splitPos + LINE_SPACE, images_4);
+    painter.drawImage((nImageRegionWidth / 5 + LINE_SPACE) * 4, splitPos + LINE_SPACE, images_5);
     painter.end();
 
     return result;

--- a/src/src/thumbnailview/eventgenerator.cpp
+++ b/src/src/thumbnailview/eventgenerator.cpp
@@ -1,0 +1,156 @@
+/*
+    SPDX-FileCopyrightText: 2015 Eike Hein <hein@kde.org>
+    SPDX-FileCopyrightText: 2015 Marco Martin <notmart@gmail.com>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+
+#include "eventgenerator.h"
+
+#include <QGuiApplication>
+#include <QQuickItem>
+#include <QQuickWindow>
+
+EventGenerator::EventGenerator(QObject *parent)
+    : QObject(parent)
+{
+}
+
+EventGenerator::~EventGenerator()
+{
+}
+
+void EventGenerator::sendMouseEvent(QQuickItem *item,
+                                    EventGenerator::MouseEvent type,
+                                    int x,
+                                    int y,
+                                    int button,
+                                    Qt::MouseButtons buttons,
+                                    Qt::KeyboardModifiers modifiers)
+{
+    if (!item) {
+        return;
+    }
+
+    QEvent::Type eventType;
+    switch (type) {
+    case MouseButtonPress:
+        eventType = QEvent::MouseButtonPress;
+        break;
+    case MouseButtonRelease:
+        eventType = QEvent::MouseButtonRelease;
+        break;
+    case MouseMove:
+        eventType = QEvent::MouseMove;
+        break;
+    default:
+        return;
+    }
+    QMouseEvent ev(eventType, QPointF(x, y), static_cast<Qt::MouseButton>(button), buttons, modifiers);
+
+    QGuiApplication::sendEvent(item, &ev);
+}
+
+void EventGenerator::sendMouseEventRecursive(QQuickItem *parentItem,
+                                             EventGenerator::MouseEvent type,
+                                             int x,
+                                             int y,
+                                             int button,
+                                             Qt::MouseButtons buttons,
+                                             Qt::KeyboardModifiers modifiers)
+{
+    if (!parentItem) {
+        return;
+    }
+
+    const QList<QQuickItem *> items = allChildItemsRecursive(parentItem);
+
+    for (QQuickItem *item : items) {
+        sendMouseEvent(item, type, x, y, button, buttons, modifiers);
+    }
+}
+
+void EventGenerator::sendWheelEvent(QQuickItem *item,
+                                    int x,
+                                    int y,
+                                    const QPoint &pixelDelta,
+                                    const QPoint &angleDelta,
+                                    Qt::MouseButtons buttons,
+                                    Qt::KeyboardModifiers modifiers)
+{
+    if (!item || !item->window()) {
+        return;
+    }
+
+    QPointF pos(x, y);
+    QPointF globalPos(item->window()->mapToGlobal(item->mapToScene(pos).toPoint()));
+    //QWheelEvent ev(pos, globalPos, pixelDelta, angleDelta, buttons, modifiers, Qt::ScrollUpdate, false /*not inverted*/);
+    QWheelEvent ev(pos, globalPos, pixelDelta, angleDelta, 0, Qt::Vertical, buttons, modifiers, Qt::ScrollUpdate);
+    QGuiApplication::sendEvent(item, &ev);
+}
+
+void EventGenerator::sendWheelEventRecursive(QQuickItem *parentItem,
+                                             int x,
+                                             int y,
+                                             const QPoint &pixelDelta,
+                                             const QPoint &angleDelta,
+                                             Qt::MouseButtons buttons,
+                                             Qt::KeyboardModifiers modifiers)
+{
+    if (!parentItem) {
+        return;
+    }
+
+    const QList<QQuickItem *> items = allChildItemsRecursive(parentItem);
+
+    for (QQuickItem *item : items) {
+        sendWheelEvent(item, x, y, pixelDelta, angleDelta, buttons, modifiers);
+    }
+}
+
+void EventGenerator::sendGrabEvent(QQuickItem *item, EventGenerator::GrabEvent type)
+{
+    if (!item) {
+        return;
+    }
+
+    switch (type) {
+    case GrabMouse:
+        item->grabMouse();
+        break;
+    case UngrabMouse: {
+        QEvent ev(QEvent::UngrabMouse);
+        QGuiApplication::sendEvent(item, &ev);
+        return;
+    }
+    default:
+        return;
+    }
+}
+
+void EventGenerator::sendGrabEventRecursive(QQuickItem *parentItem, EventGenerator::GrabEvent type)
+{
+    if (!parentItem) {
+        return;
+    }
+
+    const QList<QQuickItem *> items = allChildItemsRecursive(parentItem);
+
+    for (QQuickItem *item : items) {
+        sendGrabEvent(item, type);
+    }
+}
+
+QList<QQuickItem *> EventGenerator::allChildItemsRecursive(QQuickItem *parentItem)
+{
+    QList<QQuickItem *> itemList;
+
+    const auto childsItems = parentItem->childItems();
+    itemList.append(childsItems);
+
+    for (QQuickItem *childItem : childsItems) {
+        itemList.append(allChildItemsRecursive(childItem));
+    }
+
+    return itemList;
+}

--- a/src/src/thumbnailview/eventgenerator.h
+++ b/src/src/thumbnailview/eventgenerator.h
@@ -1,0 +1,93 @@
+/*
+    SPDX-FileCopyrightText: 2015 Eike Hein <hein@kde.org>
+    SPDX-FileCopyrightText: 2015 Marco Martin <notmart@gmail.com>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+
+#ifndef EventGenerator_H
+#define EventGenerator_H
+
+#include <QObject>
+
+class QQuickItem;
+
+class EventGenerator : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum MouseEvent {
+        MouseButtonPress,
+        MouseButtonRelease,
+        MouseMove,
+    };
+    Q_ENUM(MouseEvent)
+
+    enum GrabEvent {
+        GrabMouse,
+        UngrabMouse,
+    };
+    Q_ENUM(GrabEvent)
+
+    EventGenerator(QObject *parent = nullptr);
+    ~EventGenerator() override;
+
+    /**
+     * Send a mouse event of @type to the given @item
+     */
+    Q_INVOKABLE void
+    sendMouseEvent(QQuickItem *item, EventGenerator::MouseEvent type, int x, int y, int button, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers);
+
+    /**
+     * Send a mouse event of @type to the given @item, all its children and descendants
+     */
+    Q_INVOKABLE void sendMouseEventRecursive(QQuickItem *item,
+                                             EventGenerator::MouseEvent type,
+                                             int x,
+                                             int y,
+                                             int button,
+                                             Qt::MouseButtons buttons,
+                                             Qt::KeyboardModifiers modifiers);
+
+    /**
+     * Send a wheel event to the given @item
+     *
+     * @since 5.16
+     */
+    Q_INVOKABLE void sendWheelEvent(QQuickItem *item,
+                                    int x,
+                                    int y,
+                                    const QPoint &pixelDelta,
+                                    const QPoint &angleDelta,
+                                    Qt::MouseButtons buttons,
+                                    Qt::KeyboardModifiers modifiers);
+
+    /**
+     * Send a wheel event to the given @item, all its children and descendants
+     *
+     * @since 5.16
+     */
+    Q_INVOKABLE void sendWheelEventRecursive(QQuickItem *item,
+                                             int x,
+                                             int y,
+                                             const QPoint &pixelDelta,
+                                             const QPoint &angleDelta,
+                                             Qt::MouseButtons buttons,
+                                             Qt::KeyboardModifiers modifiers);
+
+    /**
+     * Send a mouse grab event of @type (grab or ungrab) to the given @item
+     */
+    Q_INVOKABLE void sendGrabEvent(QQuickItem *item, EventGenerator::GrabEvent type);
+
+    /**
+     * Send a mouse grab event of @type (grab or ungrab) to the given @item, all its children and descendants
+     */
+    Q_INVOKABLE void sendGrabEventRecursive(QQuickItem *item, EventGenerator::GrabEvent type);
+
+private:
+    static QList<QQuickItem *> allChildItemsRecursive(QQuickItem *parentItem);
+};
+
+#endif

--- a/src/src/thumbnailview/imagedatamodel.cpp
+++ b/src/src/thumbnailview/imagedatamodel.cpp
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "imagedatamodel.h"
+#include "roles.h"
+#include "dbmanager/dbmanager.h"
+#include "albumControl.h"
+
+#include <QUrl>
+
+ImageDataModel::ImageDataModel(QObject *parent)
+    : QAbstractListModel(parent)
+    , m_modelType(Types::ModelType::Normal)
+    , m_albumID(-1)
+    , m_keyWord("")
+    , m_dayToken("")
+{
+
+}
+
+QHash<int, QByteArray> ImageDataModel::roleNames() const
+{
+    auto hash = QAbstractItemModel::roleNames();
+    // the url role returns the url of the cover image of the collection
+    hash.insert(Roles::ItemTypeRole, "itemType");
+
+    hash.insert(Roles::FileNameRole, "fileName");
+    hash.insert(Roles::UrlRole, "url");
+    hash.insert(Roles::FilePathRole, "filePath");
+    hash.insert(Roles::PathHashRole, "pathHash");
+    hash.insert(Roles::RemainDaysRole, "remainDays");
+
+    return hash;
+}
+
+QVariant ImageDataModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid()) {
+        return {};
+    }
+
+    const DBImgInfo &info = m_infoList.at(index.row());
+
+    switch (role) {
+    case Qt::DisplayRole: {
+        return QVariant::fromValue(info);
+    }
+
+    case Roles::FileNameRole: {
+        return QUrl::fromLocalFile(info.filePath).fileName();
+    }
+
+    case Roles::UrlRole: {
+        QString filePath = "";
+        if (Types::RecentlyDeleted == m_modelType) {
+            filePath = AlbumControl::instance()->getDeleteFullPath(LibUnionImage_NameSpace::hashByString(info.filePath), DBImgInfo::getFileNameFromFilePath(info.filePath));
+        } else
+            filePath = info.filePath;
+        return QUrl::fromLocalFile(filePath).toString();
+    }
+
+    case Roles::FilePathRole: {
+        return info.filePath;
+    }
+
+    case Roles::PathHashRole: {
+        return info.pathHash;
+    }
+
+    case Roles::RemainDaysRole: {
+        return info.remainDays;
+    }
+
+    case Roles::ItemTypeRole: {
+        if (info.itemType == ItemTypePic) {
+            return "pciture";
+        } else if (info.itemType == ItemTypeVideo) {
+            return "video";
+        } else {
+            return "other";
+        }
+    }
+    }
+
+    return {};
+}
+
+int ImageDataModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid()) {
+        return 0;
+    }
+
+    return m_infoList.size();
+}
+
+Types::ModelType ImageDataModel::modelType() const
+{
+    return m_modelType;
+}
+
+void ImageDataModel::setModelType(Types::ModelType modelType)
+{
+    beginResetModel();
+    m_modelType = modelType;
+    endResetModel();
+
+    emit modelTypeChanged();
+}
+
+int ImageDataModel::albumId() const
+{
+    return m_albumID;
+}
+
+void ImageDataModel::setAlbumId(int albumId)
+{
+    if (albumId != m_albumID)
+        emit albumIdChanged();
+
+    m_albumID = albumId;
+}
+
+QString ImageDataModel::keyWord()
+{
+    return m_keyWord;
+}
+
+void ImageDataModel::setKeyWord(QString keyWord)
+{
+    if (keyWord != m_keyWord)
+        emit keyWordChanged();
+
+    m_keyWord = keyWord;
+}
+
+QString ImageDataModel::devicePath()
+{
+    return m_devicePath;
+}
+
+void ImageDataModel::setDevicePath(QString devicePath)
+{
+    if (m_devicePath != devicePath)
+        emit devicePathChanged();
+
+    m_devicePath = devicePath;
+}
+
+QString ImageDataModel::dayToken()
+{
+    return m_dayToken;
+}
+
+void ImageDataModel::setDayToken(QString dayToken)
+{
+    if (m_dayToken != dayToken)
+        emit dayTokenChanged();
+
+    m_dayToken = dayToken;
+}
+
+DBImgInfo ImageDataModel::dataForIndex(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return DBImgInfo();
+
+    return m_infoList.at(index.row());
+}
+
+void ImageDataModel::loadData(Types::ItemType type)
+{
+    ItemType itemType = ItemTypeNull;
+    if (type == Types::All)
+        itemType = ItemTypeNull;
+    else if (type == Types::Picture)
+        itemType = ItemTypePic;
+    else if (type == Types::Video)
+        itemType = ItemTypeVideo;
+
+    beginResetModel();
+    if (m_modelType == Types::AllCollection)
+        m_infoList = DBManager::instance()->getAllInfosSort(itemType);
+    else if (m_modelType == Types::CustomAlbum)
+        m_infoList = DBManager::instance()->getInfosByAlbum(m_albumID, false, itemType);
+    else if (m_modelType == Types::RecentlyDeleted) {
+        m_infoList = AlbumControl::instance()->getTrashInfos2(itemType);
+    } else if (m_modelType == Types::Device) {
+        m_infoList = AlbumControl::instance()->getDeviceAlbumInfos2(m_devicePath, itemType);
+    } else if (m_modelType == Types::SearchResult) {
+        m_infoList = AlbumControl::instance()->searchPicFromAlbum2(m_albumID, m_keyWord, false);
+    } else if (m_modelType == Types::DayCollecttion) {
+        m_infoList = DBManager::instance()->getInfosByDay(m_dayToken);
+    }
+    endResetModel();
+}

--- a/src/src/thumbnailview/imagedatamodel.cpp
+++ b/src/src/thumbnailview/imagedatamodel.cpp
@@ -171,6 +171,8 @@ DBImgInfo ImageDataModel::dataForIndex(const QModelIndex &index) const
 
 void ImageDataModel::loadData(Types::ItemType type)
 {
+    QTime time;
+    time.start();
     ItemType itemType = ItemTypeNull;
     if (type == Types::All)
         itemType = ItemTypeNull;
@@ -194,4 +196,5 @@ void ImageDataModel::loadData(Types::ItemType type)
         m_infoList = DBManager::instance()->getInfosByDay(m_dayToken);
     }
     endResetModel();
+    qDebug() << QString("loadData modelType:[%1] cost [%2]ms..").arg(m_modelType).arg(time.elapsed());
 }

--- a/src/src/thumbnailview/imagedatamodel.h
+++ b/src/src/thumbnailview/imagedatamodel.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef IMAGELOCATIONMODEL_H
+#define IMAGELOCATIONMODEL_H
+
+#include "types.h"
+
+#include <QAbstractListModel>
+#include <QStringList>
+
+class ImageDataModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(Types::ModelType modelType READ modelType WRITE setModelType NOTIFY modelTypeChanged)
+    Q_PROPERTY(int albumId READ albumId WRITE setAlbumId NOTIFY albumIdChanged)
+    Q_PROPERTY(QString keyWord READ keyWord WRITE setKeyWord NOTIFY keyWordChanged)
+    Q_PROPERTY(QString devicePath READ devicePath WRITE setDevicePath NOTIFY devicePathChanged)
+    Q_PROPERTY(QString dayToken READ dayToken WRITE setDayToken NOTIFY dayTokenChanged)
+public:
+    explicit ImageDataModel(QObject *parent = nullptr);
+
+    QHash<int, QByteArray> roleNames() const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    Types::ModelType modelType() const;
+    void setModelType(Types::ModelType modelType);
+
+    int albumId() const;
+    void setAlbumId(int albumId);
+
+    QString keyWord();
+    void setKeyWord(QString keyWord);
+
+    QString devicePath();
+    void setDevicePath(QString devicePath);
+
+    QString dayToken();
+    void setDayToken(QString dayToken);
+
+    DBImgInfo dataForIndex(const QModelIndex &index) const;
+
+    Q_INVOKABLE void loadData(Types::ItemType type = Types::All);
+
+signals:
+    void modelTypeChanged();
+    void albumIdChanged();
+    void keyWordChanged();
+    void devicePathChanged();
+    void dayTokenChanged();
+
+private:
+    Types::ModelType m_modelType;
+    int m_albumID;
+    QString m_devicePath;
+    QString m_keyWord;
+    QString m_dayToken;
+
+    QList<QPair<QByteArray, QString>> m_locations;
+    DBImgInfoList m_infoList;
+};
+
+#endif // IMAGELOCATIONMODEL_H

--- a/src/src/thumbnailview/itemviewadapter.cpp
+++ b/src/src/thumbnailview/itemviewadapter.cpp
@@ -1,0 +1,113 @@
+/*
+    SPDX-FileCopyrightText: 2008 Fredrik Höglund <fredrik@kde.org>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+
+#include "itemviewadapter.h"
+
+#include <QModelIndex>
+#include <QPalette>
+#include <QSize>
+
+ItemViewAdapter::ItemViewAdapter(QObject *parent)
+    : QObject(parent)
+    , m_adapterView(nullptr)
+    , m_adapterModel(nullptr)
+    , m_adapterIconSize(-1)
+{
+}
+
+QAbstractItemModel *ItemViewAdapter::model() const
+{
+    return m_adapterModel;
+}
+
+QSize ItemViewAdapter::iconSize() const
+{
+    return QSize(m_adapterIconSize, m_adapterIconSize);
+}
+
+QPalette ItemViewAdapter::palette() const
+{
+    return QPalette();
+}
+
+QRect ItemViewAdapter::visibleArea() const
+{
+    return m_adapterVisibleArea;
+}
+
+QRect ItemViewAdapter::visualRect(const QModelIndex &index) const
+{
+    // FIXME TODO: Implemented on DND branch.
+
+    Q_UNUSED(index)
+
+    return QRect();
+}
+
+void ItemViewAdapter::connect(Signal signal, QObject *receiver, const char *slot)
+{
+    if (signal == ScrollBarValueChanged) {
+        QObject::connect(this, SIGNAL(viewScrolled()), receiver, slot);
+    } else if (signal == IconSizeChanged) {
+        QObject::connect(this, SIGNAL(adapterIconSizeChanged()), receiver, slot);
+    }
+}
+
+QAbstractItemModel *ItemViewAdapter::adapterModel() const
+{
+    return m_adapterModel;
+}
+
+QObject *ItemViewAdapter::adapterView() const
+{
+    return m_adapterView;
+}
+
+void ItemViewAdapter::setAdapterView(QObject *view)
+{
+    if (m_adapterView != view) {
+        m_adapterView = view;
+
+        Q_EMIT adapterViewChanged();
+    }
+}
+
+void ItemViewAdapter::setAdapterModel(QAbstractItemModel *model)
+{
+    if (m_adapterModel != model) {
+        m_adapterModel = model;
+
+        Q_EMIT adapterModelChanged();
+    }
+}
+
+int ItemViewAdapter::adapterIconSize() const
+{
+    return m_adapterIconSize;
+}
+
+void ItemViewAdapter::setAdapterIconSize(int size)
+{
+    if (m_adapterIconSize != size) {
+        m_adapterIconSize = size;
+
+        Q_EMIT adapterIconSizeChanged();
+    }
+}
+
+QRect ItemViewAdapter::adapterVisibleArea() const
+{
+    return m_adapterVisibleArea;
+}
+
+void ItemViewAdapter::setAdapterVisibleArea(QRect rect)
+{
+    if (m_adapterVisibleArea != rect) {
+        m_adapterVisibleArea = rect;
+
+        Q_EMIT adapterVisibleAreaChanged();
+    }
+}

--- a/src/src/thumbnailview/itemviewadapter.h
+++ b/src/src/thumbnailview/itemviewadapter.h
@@ -1,0 +1,64 @@
+/*
+    SPDX-FileCopyrightText: 2014 Eike Hein <hein@kde.org>
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef ITEMVIEWADAPTER_H
+#define ITEMVIEWADAPTER_H
+
+#include <QObject>
+#include <QRect>
+
+class QAbstractItemModel;
+class QModelIndex;
+class QPalette;
+class QSize;
+class ItemViewAdapter : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QObject *adapterView READ adapterView WRITE setAdapterView NOTIFY adapterViewChanged)
+    Q_PROPERTY(QAbstractItemModel *adapterModel READ adapterModel WRITE setAdapterModel NOTIFY adapterModelChanged)
+    Q_PROPERTY(int adapterIconSize READ adapterIconSize WRITE setAdapterIconSize NOTIFY adapterIconSizeChanged)
+    Q_PROPERTY(QRect adapterVisibleArea READ adapterVisibleArea WRITE setAdapterVisibleArea NOTIFY adapterVisibleAreaChanged)
+
+public:
+    enum Signal { ScrollBarValueChanged, IconSizeChanged };
+
+    explicit ItemViewAdapter(QObject *parent = nullptr);
+
+    QAbstractItemModel *model() const;
+    QSize iconSize() const;
+    QPalette palette() const;
+    QRect visibleArea() const;
+    QRect visualRect(const QModelIndex &index) const;
+    void connect(Signal signal, QObject *receiver, const char *slot);
+
+    QObject *adapterView() const;
+    void setAdapterView(QObject *view);
+
+    QAbstractItemModel *adapterModel() const;
+    void setAdapterModel(QAbstractItemModel *model);
+
+    int adapterIconSize() const;
+    void setAdapterIconSize(int size);
+
+    QRect adapterVisibleArea() const;
+    void setAdapterVisibleArea(QRect rect);
+
+Q_SIGNALS:
+    void viewScrolled() const;
+    void adapterViewChanged() const;
+    void adapterModelChanged() const;
+    void adapterIconSizeChanged() const;
+    void adapterVisibleAreaChanged() const;
+
+private:
+    QObject *m_adapterView;
+    QAbstractItemModel *m_adapterModel;
+    int m_adapterIconSize;
+    QRect m_adapterVisibleArea;
+};
+
+#endif

--- a/src/src/thumbnailview/mouseeventlistener.cpp
+++ b/src/src/thumbnailview/mouseeventlistener.cpp
@@ -1,0 +1,532 @@
+/*
+    SPDX-FileCopyrightText: 2011 Marco Martin <notmart@gmail.com>
+    SPDX-FileCopyrightText: 2013 Sebastian Kügler <sebas@kde.org>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+
+    SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+
+    SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "mouseeventlistener.h"
+
+#include <QDebug>
+#include <QEvent>
+#include <QGuiApplication>
+#include <QMouseEvent>
+#include <QQuickWindow>
+#include <QScreen>
+#include <QStyleHints>
+#include <QTimer>
+
+MouseEventListener::MouseEventListener(QQuickItem *parent)
+    : QQuickItem(parent)
+    , m_pressed(false)
+    , m_pressAndHoldEvent(nullptr)
+    , m_lastEvent(nullptr)
+    , m_containsMouse(false)
+    , m_enableMouse(true)
+    , m_acceptedButtons(Qt::LeftButton)
+{
+    m_pressAndHoldTimer = new QTimer(this);
+    m_pressAndHoldTimer->setSingleShot(true);
+    connect(m_pressAndHoldTimer, &QTimer::timeout, this, &MouseEventListener::handlePressAndHold);
+    setFiltersChildMouseEvents(true);
+    setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton | Qt::MiddleButton | Qt::XButton1 | Qt::XButton2);
+}
+
+MouseEventListener::~MouseEventListener()
+{
+}
+
+Qt::MouseButtons MouseEventListener::acceptedButtons() const
+{
+    return m_acceptedButtons;
+}
+
+Qt::CursorShape MouseEventListener::cursorShape() const
+{
+    return cursor().shape();
+}
+
+void MouseEventListener::setCursorShape(Qt::CursorShape shape)
+{
+    if (cursor().shape() == shape || !m_enableMouse) {
+        return;
+    }
+
+    setCursor(shape);
+
+    Q_EMIT cursorShapeChanged();
+}
+
+bool MouseEventListener::enableMouse()
+{
+    return m_enableMouse;
+}
+
+void MouseEventListener::setEnableMouse(bool enable)
+{
+    m_enableMouse = enable;
+}
+
+void MouseEventListener::setAcceptedButtons(Qt::MouseButtons buttons)
+{
+    if (buttons == m_acceptedButtons) {
+        return;
+    }
+
+    m_acceptedButtons = buttons;
+    Q_EMIT acceptedButtonsChanged();
+}
+
+void MouseEventListener::setHoverEnabled(bool enable)
+{
+    if (enable == acceptHoverEvents()) {
+        return;
+    }
+
+    setAcceptHoverEvents(enable);
+    Q_EMIT hoverEnabledChanged(enable);
+}
+
+bool MouseEventListener::hoverEnabled() const
+{
+    return acceptHoverEvents();
+}
+
+bool MouseEventListener::isPressed() const
+{
+    return m_pressed;
+}
+
+void MouseEventListener::hoverEnterEvent(QHoverEvent *event)
+{
+    Q_UNUSED(event);
+
+    if (!m_enableMouse)
+        return;
+
+    m_containsMouse = true;
+    Q_EMIT containsMouseChanged(true);
+}
+
+void MouseEventListener::hoverLeaveEvent(QHoverEvent *event)
+{
+    Q_UNUSED(event);
+
+    if (!m_enableMouse)
+        return;
+
+    m_containsMouse = false;
+    Q_EMIT containsMouseChanged(false);
+}
+
+void MouseEventListener::hoverMoveEvent(QHoverEvent *event)
+{
+    if (m_lastEvent == event || !m_enableMouse) {
+        return;
+    }
+
+    QQuickWindow *w = window();
+    QPoint screenPos;
+    if (w) {
+        screenPos = w->mapToGlobal(event->pos());
+    }
+
+    KDeclarativeMouseEvent dme(event->pos().x(),
+                               event->pos().y(),
+                               screenPos.x(),
+                               screenPos.y(),
+                               Qt::NoButton,
+                               Qt::NoButton,
+                               event->modifiers(),
+                               nullptr,
+                               Qt::MouseEventNotSynthesized);
+    Q_EMIT positionChanged(&dme);
+}
+
+bool MouseEventListener::containsMouse() const
+{
+    return m_containsMouse;
+}
+
+void MouseEventListener::mousePressEvent(QMouseEvent *me)
+{
+    if (m_lastEvent == me || !(me->buttons() & m_acceptedButtons) || !m_enableMouse) {
+        me->setAccepted(false);
+        return;
+    }
+
+    // FIXME: when a popup window is visible: a click anywhere hides it: but the old qquickitem will continue to think it's under the mouse
+    // doesn't seem to be any good way to properly reset this.
+    // this msolution will still caused a missed click after the popup is gone, but gets the situation unblocked.
+    QPoint viewPosition;
+    if (window()) {
+        viewPosition = window()->position();
+    }
+
+    if (!QRectF(mapToScene(QPoint(0, 0)) + viewPosition, QSizeF(width(), height())).contains(me->screenPos())) {
+        me->ignore();
+        return;
+    }
+    m_buttonDownPos = me->screenPos();
+
+    KDeclarativeMouseEvent dme(me->pos().x(),
+                               me->pos().y(),
+                               me->screenPos().x(),
+                               me->screenPos().y(),
+                               me->button(),
+                               me->buttons(),
+                               me->modifiers(),
+                               screenForGlobalPos(me->globalPos()),
+                               me->source());
+    if (!m_pressAndHoldEvent) {
+        m_pressAndHoldEvent = new KDeclarativeMouseEvent(me->pos().x(),
+                                                         me->pos().y(),
+                                                         me->screenPos().x(),
+                                                         me->screenPos().y(),
+                                                         me->button(),
+                                                         me->buttons(),
+                                                         me->modifiers(),
+                                                         screenForGlobalPos(me->globalPos()),
+                                                         me->source());
+    }
+
+    m_pressed = true;
+    Q_EMIT pressed(&dme);
+    Q_EMIT pressedChanged();
+
+    if (dme.isAccepted()) {
+        me->setAccepted(true);
+        return;
+    }
+
+    m_pressAndHoldTimer->start(QGuiApplication::styleHints()->mousePressAndHoldInterval());
+}
+
+void MouseEventListener::mouseMoveEvent(QMouseEvent *me)
+{
+    if (m_lastEvent == me || !(me->buttons() & m_acceptedButtons) || !m_enableMouse) {
+        me->setAccepted(false);
+        return;
+    }
+
+    if (QPointF(me->screenPos() - m_buttonDownPos).manhattanLength() > QGuiApplication::styleHints()->startDragDistance() && m_pressAndHoldTimer->isActive()) {
+        m_pressAndHoldTimer->stop();
+    }
+
+    KDeclarativeMouseEvent dme(me->pos().x(),
+                               me->pos().y(),
+                               me->screenPos().x(),
+                               me->screenPos().y(),
+                               me->button(),
+                               me->buttons(),
+                               me->modifiers(),
+                               screenForGlobalPos(me->globalPos()),
+                               me->source());
+    Q_EMIT positionChanged(&dme);
+
+    if (dme.isAccepted()) {
+        me->setAccepted(true);
+    }
+}
+
+void MouseEventListener::mouseReleaseEvent(QMouseEvent *me)
+{
+    if (m_lastEvent == me || !m_enableMouse) {
+        me->setAccepted(false);
+        return;
+    }
+
+    KDeclarativeMouseEvent dme(me->pos().x(),
+                               me->pos().y(),
+                               me->screenPos().x(),
+                               me->screenPos().y(),
+                               me->button(),
+                               me->buttons(),
+                               me->modifiers(),
+                               screenForGlobalPos(me->globalPos()),
+                               me->source());
+    m_pressed = false;
+    Q_EMIT released(&dme);
+    Q_EMIT pressedChanged();
+
+    if (boundingRect().contains(me->pos()) && m_pressAndHoldTimer->isActive()) {
+        Q_EMIT clicked(&dme);
+        m_pressAndHoldTimer->stop();
+    }
+
+    if (dme.isAccepted()) {
+        me->setAccepted(true);
+    }
+}
+
+void MouseEventListener::wheelEvent(QWheelEvent *we)
+{
+    if (m_lastEvent == we || !m_enableMouse) {
+        we->setAccepted(false);
+        return;
+    }
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5,15,2))
+    KDeclarativeWheelEvent dwe(we->position().toPoint(),
+                               we->globalPosition().toPoint(),
+                               we->angleDelta(),
+                               we->buttons(),
+                               we->modifiers(),
+                               Qt::Vertical /* HACK, deprecated, remove */);
+#elif (QT_VERSION <= QT_VERSION_CHECK(5,11,3))
+    KDeclarativeWheelEvent dwe(we->pos(),
+                               we->globalPos(),
+                               we->angleDelta(),
+                               we->buttons(),
+                               we->modifiers(),
+                               Qt::Vertical /* HACK, deprecated, remove */);
+#endif
+    Q_EMIT wheelMoved(&dwe);
+}
+
+void MouseEventListener::handlePressAndHold()
+{
+    if (!m_enableMouse)
+        return;
+
+    if (m_pressed) {
+        Q_EMIT pressAndHold(m_pressAndHoldEvent);
+
+        delete m_pressAndHoldEvent;
+        m_pressAndHoldEvent = nullptr;
+    }
+}
+
+bool MouseEventListener::childMouseEventFilter(QQuickItem *item, QEvent *event)
+{
+    if (!isEnabled() || !m_enableMouse) {
+        return false;
+    }
+
+    // don't filter other mouseeventlisteners
+    if (qobject_cast<MouseEventListener *>(item)) {
+        return false;
+    }
+
+    switch (event->type()) {
+    case QEvent::MouseButtonPress: {
+        m_lastEvent = event;
+        QMouseEvent *me = static_cast<QMouseEvent *>(event);
+
+        if (!(me->buttons() & m_acceptedButtons)) {
+            break;
+        }
+
+        // the parent will receive events in its own coordinates
+        const QPointF myPos = mapFromScene(me->windowPos());
+
+        KDeclarativeMouseEvent dme(myPos.x(),
+                                   myPos.y(),
+                                   me->screenPos().x(),
+                                   me->screenPos().y(),
+                                   me->button(),
+                                   me->buttons(),
+                                   me->modifiers(),
+                                   screenForGlobalPos(me->globalPos()),
+                                   me->source());
+        delete m_pressAndHoldEvent;
+        m_pressAndHoldEvent = new KDeclarativeMouseEvent(myPos.x(),
+                                                         myPos.y(),
+                                                         me->screenPos().x(),
+                                                         me->screenPos().y(),
+                                                         me->button(),
+                                                         me->buttons(),
+                                                         me->modifiers(),
+                                                         screenForGlobalPos(me->globalPos()),
+                                                         me->source());
+
+        // qDebug() << "pressed in sceneEventFilter";
+        m_buttonDownPos = me->screenPos();
+        m_pressed = true;
+        Q_EMIT pressed(&dme);
+        Q_EMIT pressedChanged();
+
+        if (dme.isAccepted()) {
+            return true;
+        }
+
+        m_pressAndHoldTimer->start(QGuiApplication::styleHints()->mousePressAndHoldInterval());
+
+        break;
+    }
+    case QEvent::HoverMove: {
+        if (!acceptHoverEvents()) {
+            break;
+        }
+        m_lastEvent = event;
+        QHoverEvent *he = static_cast<QHoverEvent *>(event);
+        const QPointF myPos = item->mapToItem(this, he->pos());
+
+        QQuickWindow *w = window();
+        QPoint screenPos;
+        if (w) {
+            screenPos = w->mapToGlobal(myPos.toPoint());
+        }
+
+        KDeclarativeMouseEvent
+        dme(myPos.x(), myPos.y(), screenPos.x(), screenPos.y(), Qt::NoButton, Qt::NoButton, he->modifiers(), nullptr, Qt::MouseEventNotSynthesized);
+        // qDebug() << "positionChanged..." << dme.x() << dme.y();
+        Q_EMIT positionChanged(&dme);
+
+        if (dme.isAccepted()) {
+            return true;
+        }
+        break;
+    }
+    case QEvent::MouseMove: {
+        m_lastEvent = event;
+        QMouseEvent *me = static_cast<QMouseEvent *>(event);
+        if (!(me->buttons() & m_acceptedButtons)) {
+            break;
+        }
+
+        const QPointF myPos = mapFromScene(me->windowPos());
+        KDeclarativeMouseEvent dme(myPos.x(),
+                                   myPos.y(),
+                                   me->screenPos().x(),
+                                   me->screenPos().y(),
+                                   me->button(),
+                                   me->buttons(),
+                                   me->modifiers(),
+                                   screenForGlobalPos(me->globalPos()),
+                                   me->source());
+        // qDebug() << "positionChanged..." << dme.x() << dme.y();
+
+        // stop the pressandhold if mouse moved enough
+        if (QPointF(me->screenPos() - m_buttonDownPos).manhattanLength() > QGuiApplication::styleHints()->startDragDistance()
+                && m_pressAndHoldTimer->isActive()) {
+            m_pressAndHoldTimer->stop();
+
+            // if the mouse moves and we are waiting to emit a press and hold event, update the coordinates
+            // as there is no update function, delete the old event and create a new one
+        } else if (m_pressAndHoldEvent) {
+            delete m_pressAndHoldEvent;
+            m_pressAndHoldEvent = new KDeclarativeMouseEvent(myPos.x(),
+                                                             myPos.y(),
+                                                             me->screenPos().x(),
+                                                             me->screenPos().y(),
+                                                             me->button(),
+                                                             me->buttons(),
+                                                             me->modifiers(),
+                                                             screenForGlobalPos(me->globalPos()),
+                                                             me->source());
+        }
+        Q_EMIT positionChanged(&dme);
+
+        if (dme.isAccepted()) {
+            return true;
+        }
+        break;
+    }
+    case QEvent::MouseButtonRelease: {
+        m_lastEvent = event;
+        QMouseEvent *me = static_cast<QMouseEvent *>(event);
+
+        const QPointF myPos = mapFromScene(me->windowPos());
+        KDeclarativeMouseEvent dme(myPos.x(),
+                                   myPos.y(),
+                                   me->screenPos().x(),
+                                   me->screenPos().y(),
+                                   me->button(),
+                                   me->buttons(),
+                                   me->modifiers(),
+                                   screenForGlobalPos(me->globalPos()),
+                                   me->source());
+        m_pressed = false;
+
+        Q_EMIT released(&dme);
+        Q_EMIT pressedChanged();
+
+        if (QPointF(me->screenPos() - m_buttonDownPos).manhattanLength() <= QGuiApplication::styleHints()->startDragDistance()
+                && m_pressAndHoldTimer->isActive()) {
+            Q_EMIT clicked(&dme);
+            m_pressAndHoldTimer->stop();
+        }
+
+        if (dme.isAccepted()) {
+            return true;
+        }
+        break;
+    }
+    case QEvent::UngrabMouse: {
+        m_lastEvent = event;
+        handleUngrab();
+        break;
+    }
+    case QEvent::Wheel: {
+        m_lastEvent = event;
+        QWheelEvent *we = static_cast<QWheelEvent *>(event);
+#if (QT_VERSION >= QT_VERSION_CHECK(5,15,2))
+        KDeclarativeWheelEvent dwe(we->position().toPoint(),
+                                   we->globalPosition().toPoint(),
+                                   we->angleDelta(),
+                                   we->buttons(),
+                                   we->modifiers(),
+                                   Qt::Vertical /* HACK, deprecated, remove */);
+#elif (QT_VERSION <= QT_VERSION_CHECK(5,11,3))
+        KDeclarativeWheelEvent dwe(we->pos(),
+                                   we->globalPos(),
+                                   we->angleDelta(),
+                                   we->buttons(),
+                                   we->modifiers(),
+                                   Qt::Vertical /* HACK, deprecated, remove */);
+#endif
+        Q_EMIT wheelMoved(&dwe);
+        break;
+    }
+    default:
+        break;
+    }
+
+    return QQuickItem::childMouseEventFilter(item, event);
+    //    return false;
+}
+
+QScreen *MouseEventListener::screenForGlobalPos(const QPoint &globalPos)
+{
+    const auto screens = QGuiApplication::screens();
+    for (QScreen *screen : screens) {
+        if (screen->geometry().contains(globalPos)) {
+            return screen;
+        }
+    }
+    return nullptr;
+}
+
+void MouseEventListener::mouseUngrabEvent()
+{
+    handleUngrab();
+
+    QQuickItem::mouseUngrabEvent();
+}
+
+void MouseEventListener::touchUngrabEvent()
+{
+    handleUngrab();
+
+    QQuickItem::touchUngrabEvent();
+}
+
+void MouseEventListener::handleUngrab()
+{
+    if (!m_enableMouse)
+        return;
+
+    if (m_pressed) {
+        m_pressAndHoldTimer->stop();
+
+        m_pressed = false;
+        Q_EMIT pressedChanged();
+
+        Q_EMIT canceled();
+    }
+}

--- a/src/src/thumbnailview/mouseeventlistener.h
+++ b/src/src/thumbnailview/mouseeventlistener.h
@@ -1,0 +1,318 @@
+/*
+    SPDX-FileCopyrightText: 2011 Marco Martin <notmart@gmail.com>
+    SPDX-FileCopyrightText: 2013 Sebastian Kügler <sebas@kde.org>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+
+    SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+
+    SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef MOUSEEVENTLISTENER_H
+#define MOUSEEVENTLISTENER_H
+
+#include <QQuickItem>
+
+/**
+ * This item spies on mouse events from all child objects including child MouseAreas regardless
+ * of whether the child MouseArea propagates events. It does not accept the event.
+ *
+ * In addition unlike MouseArea events include the mouse position in global coordinates and provides
+ * the screen the mouse is in.
+ */
+
+class QScreen;
+class KDeclarativeMouseEvent : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int x READ x)
+    Q_PROPERTY(int y READ y)
+    Q_PROPERTY(int screenX READ screenX)
+    Q_PROPERTY(int screenY READ screenY)
+    Q_PROPERTY(int button READ button)
+    Q_PROPERTY(Qt::MouseButtons buttons READ buttons)
+    Q_PROPERTY(Qt::KeyboardModifiers modifiers READ modifiers)
+    Q_PROPERTY(QScreen *screen READ screen CONSTANT)
+    Q_PROPERTY(bool accepted READ isAccepted WRITE setAccepted NOTIFY acceptedChanged)
+    Q_PROPERTY(int source READ source)
+
+public:
+    KDeclarativeMouseEvent(int x,
+                           int y,
+                           int screenX,
+                           int screenY,
+                           Qt::MouseButton button,
+                           Qt::MouseButtons buttons,
+                           Qt::KeyboardModifiers modifiers,
+                           QScreen *screen,
+                           Qt::MouseEventSource source)
+        : m_x(x)
+        , m_y(y)
+        , m_screenX(screenX)
+        , m_screenY(screenY)
+        , m_button(button)
+        , m_buttons(buttons)
+        , m_modifiers(modifiers)
+        , m_screen(screen)
+        , m_source(source)
+    {
+    }
+
+    int x() const
+    {
+        return m_x;
+    }
+    int y() const
+    {
+        return m_y;
+    }
+    int screenX() const
+    {
+        return m_screenX;
+    }
+    int screenY() const
+    {
+        return m_screenY;
+    }
+    int button() const
+    {
+        return m_button;
+    }
+    Qt::MouseButtons buttons() const
+    {
+        return m_buttons;
+    }
+    Qt::KeyboardModifiers modifiers() const
+    {
+        return m_modifiers;
+    }
+    QScreen *screen() const
+    {
+        return m_screen;
+    }
+    int source() const
+    {
+        return m_source;
+    }
+
+    bool isAccepted() const
+    {
+        return m_accepted;
+    }
+    void setAccepted(bool accepted)
+    {
+        if (m_accepted != accepted) {
+            m_accepted = accepted;
+            Q_EMIT acceptedChanged();
+        }
+    }
+
+    // only for internal usage
+    void setX(int x)
+    {
+        m_x = x;
+    }
+    void setY(int y)
+    {
+        m_y = y;
+    }
+
+Q_SIGNALS:
+    void acceptedChanged();
+
+private:
+    int m_x;
+    int m_y;
+    int m_screenX;
+    int m_screenY;
+    Qt::MouseButton m_button;
+    Qt::MouseButtons m_buttons;
+    Qt::KeyboardModifiers m_modifiers;
+    QScreen *m_screen;
+    bool m_accepted = false;
+    int m_source;
+};
+
+class KDeclarativeWheelEvent : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int x READ x CONSTANT)
+    Q_PROPERTY(int y READ y CONSTANT)
+    Q_PROPERTY(int screenX READ screenX CONSTANT)
+    Q_PROPERTY(int screenY READ screenY CONSTANT)
+    Q_PROPERTY(int deltaX READ deltaX CONSTANT)
+    Q_PROPERTY(int deltaY READ deltaY CONSTANT)
+    Q_PROPERTY(int delta READ deltaY CONSTANT) // deprecated in favor of deltaY. TODO KF6: remove
+    Q_PROPERTY(Qt::MouseButtons buttons READ buttons CONSTANT)
+    Q_PROPERTY(Qt::KeyboardModifiers modifiers READ modifiers CONSTANT)
+    Q_PROPERTY(Qt::Orientation orientation READ orientation CONSTANT) // deprecated. TODO KF6: remove
+
+public:
+    KDeclarativeWheelEvent(QPointF pos,
+                           QPoint screenPos,
+                           QPoint angleDelta,
+                           Qt::MouseButtons buttons,
+                           Qt::KeyboardModifiers modifiers,
+                           Qt::Orientation orientation)
+        : m_x(pos.x())
+        , m_y(pos.y())
+        , m_screenX(screenPos.x())
+        , m_screenY(screenPos.y())
+        , m_angleDelta(angleDelta)
+        , m_buttons(buttons)
+        , m_modifiers(modifiers)
+        , m_orientation(orientation)
+    {
+    }
+
+    int x() const
+    {
+        return m_x;
+    }
+    int y() const
+    {
+        return m_y;
+    }
+    int screenX() const
+    {
+        return m_screenX;
+    }
+    int screenY() const
+    {
+        return m_screenY;
+    }
+    int deltaX() const
+    {
+        return m_angleDelta.x();
+    }
+    int deltaY() const
+    {
+        return m_angleDelta.y();
+    }
+    Qt::MouseButtons buttons() const
+    {
+        return m_buttons;
+    }
+    Qt::KeyboardModifiers modifiers() const
+    {
+        return m_modifiers;
+    }
+    Qt::Orientation orientation()
+    {
+        return m_orientation;
+    } // TODO KF6: remove
+
+    // only for internal usage
+    void setX(int x)
+    {
+        m_x = x;
+    }
+    void setY(int y)
+    {
+        m_y = y;
+    }
+
+private:
+    int m_x;
+    int m_y;
+    int m_screenX;
+    int m_screenY;
+    QPoint m_angleDelta;
+    Qt::MouseButtons m_buttons;
+    Qt::KeyboardModifiers m_modifiers;
+    Qt::Orientation m_orientation;
+};
+
+class MouseEventListener : public QQuickItem
+{
+    Q_OBJECT
+    /**
+     * This property holds whether hover events are handled.
+     * By default hover events are disabled
+     */
+    Q_PROPERTY(bool hoverEnabled READ hoverEnabled WRITE setHoverEnabled NOTIFY hoverEnabledChanged)
+
+    /**
+     * True if this MouseEventListener or any of its children contains the mouse cursor:
+     * this property will change only when the mouse button is pressed if hoverEnabled is false.
+     */
+    Q_PROPERTY(bool containsMouse READ containsMouse NOTIFY containsMouseChanged)
+
+    Q_PROPERTY(Qt::MouseButtons acceptedButtons READ acceptedButtons WRITE setAcceptedButtons NOTIFY acceptedButtonsChanged)
+
+    /**
+     * This property holds the cursor shape for this mouse area.
+     * Note that on platforms that do not display a mouse cursor this may have no effect.
+     */
+    Q_PROPERTY(Qt::CursorShape cursorShape READ cursorShape WRITE setCursorShape RESET unsetCursor NOTIFY cursorShapeChanged)
+
+    /**
+     * True if the mouse is pressed in the item or any of its children
+     */
+    Q_PROPERTY(bool pressed READ isPressed NOTIFY pressedChanged)
+
+    Q_PROPERTY(bool enableMouse READ enableMouse WRITE setEnableMouse)
+public:
+    MouseEventListener(QQuickItem *parent = nullptr);
+    ~MouseEventListener() override;
+
+    bool containsMouse() const;
+    void setHoverEnabled(bool enable);
+    bool hoverEnabled() const;
+    bool isPressed() const;
+
+    Qt::MouseButtons acceptedButtons() const;
+    void setAcceptedButtons(Qt::MouseButtons buttons);
+
+    Qt::CursorShape cursorShape() const;
+    void setCursorShape(Qt::CursorShape shape);
+
+    bool enableMouse();
+    void setEnableMouse(bool enable);
+
+protected:
+    void hoverEnterEvent(QHoverEvent *event) override;
+    void hoverLeaveEvent(QHoverEvent *event) override;
+    void hoverMoveEvent(QHoverEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+    bool childMouseEventFilter(QQuickItem *item, QEvent *event) override;
+    void mouseUngrabEvent() override;
+    void touchUngrabEvent() override;
+
+Q_SIGNALS:
+    void pressed(KDeclarativeMouseEvent *mouse);
+    void positionChanged(KDeclarativeMouseEvent *mouse);
+    void released(KDeclarativeMouseEvent *mouse);
+    void clicked(KDeclarativeMouseEvent *mouse);
+    void pressAndHold(KDeclarativeMouseEvent *mouse);
+    void wheelMoved(KDeclarativeWheelEvent *wheel);
+    void containsMouseChanged(bool containsMouseChanged);
+    void hoverEnabledChanged(bool hoverEnabled);
+    void acceptedButtonsChanged();
+    void cursorShapeChanged();
+    void pressedChanged();
+    void canceled();
+
+private Q_SLOTS:
+    void handlePressAndHold();
+    void handleUngrab();
+
+private:
+    static QScreen *screenForGlobalPos(const QPoint &globalPos);
+
+    bool m_pressed;
+    KDeclarativeMouseEvent *m_pressAndHoldEvent;
+    QPointF m_buttonDownPos;
+    // Important: used only for comparison. If you will ever need to access this pointer, make it a QWeakPointer
+    QEvent *m_lastEvent;
+    QTimer *m_pressAndHoldTimer;
+    bool m_containsMouse;
+    bool m_enableMouse;
+    Qt::MouseButtons m_acceptedButtons;
+};
+
+#endif

--- a/src/src/thumbnailview/positioner.cpp
+++ b/src/src/thumbnailview/positioner.cpp
@@ -1,0 +1,945 @@
+/*
+    SPDX-FileCopyrightText: 2014 Eike Hein <hein@kde.org>
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+
+    SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+
+    SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "positioner.h"
+#include "thumbnailmodel.h"
+
+#include <QTimer>
+#include <QPoint>
+#include <QUrl>
+
+#include <cstdlib>
+
+Positioner::Positioner(QObject *parent)
+    : QAbstractItemModel(parent)
+    , m_enabled(false)
+    , m_thumbnialModel(nullptr)
+    , m_perStripe(0)
+    , m_ignoreNextTransaction(false)
+    , m_deferApplyPositions(false)
+    , m_updatePositionsTimer(new QTimer(this))
+{
+    m_updatePositionsTimer->setSingleShot(true);
+    m_updatePositionsTimer->setInterval(0);
+    connect(m_updatePositionsTimer, &QTimer::timeout, this, &Positioner::updatePositions);
+}
+
+Positioner::~Positioner()
+{
+}
+
+bool Positioner::enabled() const
+{
+    return m_enabled;
+}
+
+void Positioner::setEnabled(bool enabled)
+{
+    if (m_enabled != enabled) {
+        m_enabled = enabled;
+
+        beginResetModel();
+
+        if (enabled && m_thumbnialModel) {
+            initMaps();
+        }
+
+        endResetModel();
+
+        Q_EMIT enabledChanged();
+
+        if (!enabled) {
+            m_updatePositionsTimer->start();
+        }
+    }
+}
+
+ThumbnailModel *Positioner::thumbnailModel() const
+{
+    return m_thumbnialModel;
+}
+
+void Positioner::setThumbnailModel(ThumbnailModel *thumbnailModel)
+{
+    if (m_thumbnialModel != thumbnailModel) {
+        beginResetModel();
+
+        if (m_thumbnialModel) {
+            disconnectSignals(m_thumbnialModel);
+        }
+
+        m_thumbnialModel = thumbnailModel;
+
+        if (m_thumbnialModel) {
+            connectSignals(m_thumbnialModel);
+
+            if (m_enabled) {
+                initMaps();
+            }
+        }
+
+        endResetModel();
+
+        Q_EMIT sortModelChanged();
+    }
+}
+
+int Positioner::perStripe() const
+{
+    return m_perStripe;
+}
+
+void Positioner::setPerStripe(int perStripe)
+{
+    if (m_perStripe != perStripe) {
+        m_perStripe = perStripe;
+
+        Q_EMIT perStripeChanged();
+
+        if (m_enabled && perStripe > 0 && !m_proxyToSource.isEmpty()) {
+            applyPositions();
+        }
+    }
+}
+
+QStringList Positioner::positions() const
+{
+    return m_positions;
+}
+
+void Positioner::setPositions(const QStringList &positions)
+{
+    if (m_positions != positions) {
+        m_positions = positions;
+
+        Q_EMIT positionsChanged();
+
+        // Defer applying positions until listing completes.
+        if (m_thumbnialModel->status() == ThumbnailModel::Listing) {
+            m_deferApplyPositions = true;
+        } else {
+            applyPositions();
+        }
+    }
+}
+
+int Positioner::map(int row) const
+{
+    if (m_enabled && m_thumbnialModel) {
+        return m_proxyToSource.value(row, -1);
+    }
+
+    return row;
+}
+
+int Positioner::nearestItem(int currentIndex, Qt::ArrowType direction)
+{
+    if (!m_enabled || currentIndex >= rowCount()) {
+        return -1;
+    }
+
+    if (currentIndex < 0) {
+        return firstRow();
+    }
+
+    int hDirection = 0;
+    int vDirection = 0;
+
+    switch (direction) {
+    case Qt::LeftArrow:
+        hDirection = -1;
+        break;
+    case Qt::RightArrow:
+        hDirection = 1;
+        break;
+    case Qt::UpArrow:
+        vDirection = -1;
+        break;
+    case Qt::DownArrow:
+        vDirection = 1;
+        break;
+    default:
+        return -1;
+    }
+
+    QList<int> rows(m_proxyToSource.keys());
+    std::sort(rows.begin(), rows.end());
+
+    int nearestItem = -1;
+    const QPoint currentPos(currentIndex % m_perStripe, currentIndex / m_perStripe);
+    int lastDistance = -1;
+    int distance = 0;
+
+    for (const int row : rows) {
+        const QPoint pos(row % m_perStripe, row / m_perStripe);
+
+        if (row == currentIndex) {
+            continue;
+        }
+
+        if (hDirection == 0) {
+            if (vDirection * pos.y() > vDirection * currentPos.y()) {
+                distance = (pos - currentPos).manhattanLength();
+
+                if (nearestItem == -1 || distance < lastDistance || (distance == lastDistance && pos.x() == currentPos.x())) {
+                    nearestItem = row;
+                    lastDistance = distance;
+                }
+            }
+        } else if (vDirection == 0) {
+            if (hDirection * pos.x() > hDirection * currentPos.x()) {
+                distance = (pos - currentPos).manhattanLength();
+
+                if (nearestItem == -1 || distance < lastDistance || (distance == lastDistance && pos.y() == currentPos.y())) {
+                    nearestItem = row;
+                    lastDistance = distance;
+                }
+            }
+        }
+    }
+
+    return nearestItem;
+}
+
+bool Positioner::isBlank(int row) const
+{
+//    if (!m_enabled && m_thumbnailModel) {
+//        return m_thumbnailModel->isBlank(row);
+//    }
+
+//    if (m_proxyToSource.contains(row) && m_thumbnailModel && !m_thumbnailModel->isBlank(m_proxyToSource.value(row))) {
+//        return false;
+//    }
+
+    return false;
+}
+
+int Positioner::indexForUrl(const QUrl &url) const
+{
+    if (!m_thumbnialModel) {
+        return -1;
+    }
+
+    const QString &name = url.fileName();
+
+    int sourceIndex = -1;
+
+    // TODO Optimize.
+    for (int i = 0; i < m_thumbnialModel->rowCount(); ++i) {
+        if (m_thumbnialModel->data(m_thumbnialModel->index(i, 0), Roles::FileNameRole).toString() == name) {
+            sourceIndex = i;
+
+            break;
+        }
+    }
+
+    return m_sourceToProxy.value(sourceIndex, -1);
+}
+
+void Positioner::setRangeSelected(int anchor, int to)
+{
+    if (!m_thumbnialModel) {
+        return;
+    }
+
+    if (m_enabled) {
+        QVariantList indices;
+
+        for (int i = qMin(anchor, to); i <= qMax(anchor, to); ++i) {
+            if (m_proxyToSource.contains(i)) {
+                indices.append(m_proxyToSource.value(i));
+            }
+        }
+
+        if (!indices.isEmpty()) {
+            m_thumbnialModel->updateSelection(indices, false);
+        }
+    } else {
+        m_thumbnialModel->setRangeSelected(anchor, to);
+    }
+}
+
+QHash<int, QByteArray> Positioner::roleNames() const
+{
+    return m_thumbnialModel->roleNames();
+}
+
+QModelIndex Positioner::index(int row, int column, const QModelIndex &parent) const
+{
+    if (parent.isValid()) {
+        return QModelIndex();
+    }
+
+    return createIndex(row, column);
+}
+
+QModelIndex Positioner::parent(const QModelIndex &index) const
+{
+    if (m_thumbnialModel) {
+        m_thumbnialModel->parent(index);
+    }
+
+    return QModelIndex();
+}
+
+QVariant Positioner::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid()) {
+        return QVariant();
+    }
+
+    if (m_thumbnialModel) {
+        if (m_enabled) {
+            if (m_proxyToSource.contains(index.row())) {
+                return m_thumbnialModel->data(m_thumbnialModel->index(m_proxyToSource.value(index.row()), 0), role);
+            } else if (role == Roles::BlankRole) {
+                return true;
+            }
+        } else {
+            return m_thumbnialModel->data(m_thumbnialModel->index(index.row(), 0), role);
+        }
+    }
+
+    return QVariant();
+}
+
+int Positioner::rowCount(const QModelIndex &parent) const
+{
+    if (m_thumbnialModel) {
+        if (m_enabled) {
+            if (parent.isValid()) {
+                return 0;
+            } else {
+                return lastRow() + 1;
+            }
+        } else {
+            return m_thumbnialModel->rowCount(parent);
+        }
+    }
+
+    return 0;
+}
+
+int Positioner::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent)
+
+    if (m_thumbnialModel) {
+        return 1;
+    }
+
+    return 0;
+}
+
+void Positioner::reset()
+{
+    beginResetModel();
+
+    initMaps();
+
+    endResetModel();
+
+    m_positions = QStringList();
+    Q_EMIT positionsChanged();
+}
+
+int Positioner::move(const QVariantList &moves)
+{
+    // Don't allow moves while listing.
+    if (m_thumbnialModel->status() == ThumbnailModel::Listing) {
+        m_deferMovePositions.append(moves);
+        return -1;
+    }
+
+    QVector<int> fromIndices;
+    QVector<int> toIndices;
+    QVariantList sourceRows;
+
+    for (int i = 0; i < moves.count(); ++i) {
+        const int isFrom = (i % 2 == 0);
+        const int v = moves[i].toInt();
+
+        if (isFrom) {
+            if (m_proxyToSource.contains(v)) {
+                sourceRows.append(m_proxyToSource.value(v));
+            } else {
+                sourceRows.append(-1);
+            }
+        }
+
+        (isFrom ? fromIndices : toIndices).append(v);
+    }
+
+    const int oldCount = rowCount();
+
+    for (int i = 0; i < fromIndices.count(); ++i) {
+        const int from = fromIndices[i];
+        int to = toIndices[i];
+        const int sourceRow = sourceRows[i].toInt();
+
+        if (sourceRow == -1 || from == to) {
+            continue;
+        }
+
+        if (to == -1) {
+            to = firstFreeRow();
+
+            if (to == -1) {
+                to = lastRow() + 1;
+            }
+        }
+
+        if (!fromIndices.contains(to) && !isBlank(to)) {
+            /* find the next blank space
+             * we won't be happy if we're moving two icons to the same place
+             */
+            while ((!isBlank(to) && from != to) || toIndices.contains(to)) {
+                to++;
+            }
+        }
+
+        toIndices[i] = to;
+
+        if (!toIndices.contains(from)) {
+            m_proxyToSource.remove(from);
+        }
+
+        updateMaps(to, sourceRow);
+
+        const QModelIndex &fromIdx = index(from, 0);
+        Q_EMIT dataChanged(fromIdx, fromIdx);
+
+        if (to < oldCount) {
+            const QModelIndex &toIdx = index(to, 0);
+            Q_EMIT dataChanged(toIdx, toIdx);
+        }
+    }
+
+    const int newCount = rowCount();
+
+    if (newCount > oldCount) {
+        if (m_beginInsertRowsCalled) {
+            endInsertRows();
+            m_beginInsertRowsCalled = false;
+        }
+        beginInsertRows(QModelIndex(), oldCount, newCount - 1);
+        endInsertRows();
+    }
+
+    if (newCount < oldCount) {
+        beginRemoveRows(QModelIndex(), newCount, oldCount - 1);
+        endRemoveRows();
+    }
+
+    m_thumbnialModel->updateSelection(sourceRows, true);
+
+    m_updatePositionsTimer->start();
+
+    return toIndices.constFirst();
+}
+
+void Positioner::updatePositions()
+{
+    QStringList positions;
+
+    if (m_enabled && !m_proxyToSource.isEmpty() && m_perStripe > 0) {
+        positions.append(QString::number((1 + ((rowCount() - 1) / m_perStripe))));
+        positions.append(QString::number(m_perStripe));
+
+        QHashIterator<int, int> it(m_proxyToSource);
+
+        while (it.hasNext()) {
+            it.next();
+
+            const QString &name = m_thumbnialModel->data(m_thumbnialModel->index(it.value(), 0), Roles::UrlRole).toString();
+
+            if (name.isEmpty()) {
+                return;
+            }
+
+            positions.append(name);
+            positions.append(QString::number(qMax(0, it.key() / m_perStripe)));
+            positions.append(QString::number(qMax(0, it.key() % m_perStripe)));
+        }
+    }
+
+    if (positions != m_positions) {
+        m_positions = positions;
+
+        Q_EMIT positionsChanged();
+    }
+}
+
+void Positioner::sourceStatusChanged()
+{
+    if (m_deferApplyPositions && m_thumbnialModel->status() != ThumbnailModel::Listing) {
+        applyPositions();
+    }
+
+    if (m_deferMovePositions.count() && m_thumbnialModel->status() != ThumbnailModel::Listing) {
+        move(m_deferMovePositions);
+        m_deferMovePositions.clear();
+    }
+}
+
+void Positioner::sourceDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles)
+{
+    if (m_enabled) {
+        int start = topLeft.row();
+        int end = bottomRight.row();
+
+        for (int i = start; i <= end; ++i) {
+            if (m_sourceToProxy.contains(i)) {
+                const QModelIndex &idx = index(m_sourceToProxy.value(i), 0);
+
+                Q_EMIT dataChanged(idx, idx);
+            }
+        }
+    } else {
+        Q_EMIT dataChanged(topLeft, bottomRight, roles);
+    }
+}
+
+void Positioner::sourceModelAboutToBeReset()
+{
+    beginResetModel();
+}
+
+void Positioner::sourceModelReset()
+{
+    if (m_enabled) {
+        initMaps();
+    }
+
+    endResetModel();
+}
+
+void Positioner::sourceRowsAboutToBeInserted(const QModelIndex &parent, int start, int end)
+{
+    if (m_enabled) {
+        // Don't insert yet if we're waiting for listing to complete to apply
+        // initial positions;
+        if (m_deferApplyPositions) {
+            return;
+        } else if (m_proxyToSource.isEmpty()) {
+            beginInsertRows(parent, start, end);
+            m_beginInsertRowsCalled = true;
+
+            initMaps(end + 1);
+
+            return;
+        }
+
+        // When new rows are inserted, they might go in the beginning or in the middle.
+        // In this case we must update first the existing proxy->source and source->proxy
+        // mapping, otherwise the proxy items will point to the wrong source item.
+        int count = end - start + 1;
+        m_sourceToProxy.clear();
+        for (auto it = m_proxyToSource.begin(); it != m_proxyToSource.end(); ++it) {
+            int sourceIdx = *it;
+            if (sourceIdx >= start) {
+                *it += count;
+            }
+            m_sourceToProxy[*it] = it.key();
+        }
+
+        int free = -1;
+        int rest = -1;
+
+        for (int i = start; i <= end; ++i) {
+            free = firstFreeRow();
+
+            if (free != -1) {
+                updateMaps(free, i);
+                m_pendingChanges << createIndex(free, 0);
+            } else {
+                rest = i;
+                break;
+            }
+        }
+
+        if (rest != -1) {
+            int firstNew = lastRow() + 1;
+            int remainder = (end - rest);
+
+            beginInsertRows(parent, firstNew, firstNew + remainder);
+            m_beginInsertRowsCalled = true;
+
+            for (int i = 0; i <= remainder; ++i) {
+                updateMaps(firstNew + i, rest + i);
+            }
+        } else {
+            m_ignoreNextTransaction = true;
+        }
+    } else {
+        beginInsertRows(parent, start, end);
+        beginInsertRows(parent, start, end);
+        m_beginInsertRowsCalled = true;
+    }
+}
+
+void Positioner::sourceRowsAboutToBeMoved(const QModelIndex &sourceParent,
+                                          int sourceStart,
+                                          int sourceEnd,
+                                          const QModelIndex &destinationParent,
+                                          int destinationRow)
+{
+    beginMoveRows(sourceParent, sourceStart, sourceEnd, destinationParent, destinationRow);
+}
+
+void Positioner::sourceRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last)
+{
+    if (m_enabled) {
+        int oldLast = lastRow();
+
+        for (int i = first; i <= last; ++i) {
+            int proxyRow = m_sourceToProxy.take(i);
+            m_proxyToSource.remove(proxyRow);
+            m_pendingChanges << createIndex(proxyRow, 0);
+        }
+
+        QHash<int, int> newProxyToSource;
+        QHash<int, int> newSourceToProxy;
+        QHashIterator<int, int> it(m_sourceToProxy);
+        int delta = std::abs(first - last) + 1;
+
+        while (it.hasNext()) {
+            it.next();
+
+            if (it.key() > last) {
+                newProxyToSource.insert(it.value(), it.key() - delta);
+                newSourceToProxy.insert(it.key() - delta, it.value());
+            } else {
+                newProxyToSource.insert(it.value(), it.key());
+                newSourceToProxy.insert(it.key(), it.value());
+            }
+        }
+
+        m_proxyToSource = newProxyToSource;
+        m_sourceToProxy = newSourceToProxy;
+
+        int newLast = lastRow();
+
+        if (oldLast > newLast) {
+            int diff = oldLast - newLast;
+            beginRemoveRows(QModelIndex(), ((oldLast - diff) + 1), oldLast);
+        } else {
+            m_ignoreNextTransaction = true;
+        }
+    } else {
+        beginRemoveRows(parent, first, last);
+    }
+}
+
+void Positioner::sourceLayoutAboutToBeChanged(const QList<QPersistentModelIndex> &parents, QAbstractItemModel::LayoutChangeHint hint)
+{
+    Q_UNUSED(parents)
+
+    Q_EMIT layoutAboutToBeChanged(QList<QPersistentModelIndex>(), hint);
+}
+
+void Positioner::sourceRowsInserted(const QModelIndex &parent, int first, int last)
+{
+    Q_UNUSED(parent)
+    Q_UNUSED(first)
+    Q_UNUSED(last)
+
+    if (!m_ignoreNextTransaction) {
+        if (m_beginInsertRowsCalled) {
+            endInsertRows();
+            m_beginInsertRowsCalled = false;
+        }
+    } else {
+        m_ignoreNextTransaction = false;
+    }
+
+    flushPendingChanges();
+
+    // Don't generate new positions data if we're waiting for listing to
+    // complete to apply initial positions.
+    if (!m_deferApplyPositions) {
+        m_updatePositionsTimer->start();
+    }
+}
+
+void Positioner::sourceRowsMoved(const QModelIndex &sourceParent, int sourceStart, int sourceEnd, const QModelIndex &destinationParent, int destinationRow)
+{
+    Q_UNUSED(sourceParent)
+    Q_UNUSED(sourceStart)
+    Q_UNUSED(sourceEnd)
+    Q_UNUSED(destinationParent)
+    Q_UNUSED(destinationRow)
+
+    endMoveRows();
+}
+
+void Positioner::sourceRowsRemoved(const QModelIndex &parent, int first, int last)
+{
+    Q_UNUSED(parent)
+    Q_UNUSED(first)
+    Q_UNUSED(last)
+
+    if (!m_ignoreNextTransaction) {
+        Q_EMIT endRemoveRows();
+    } else {
+        m_ignoreNextTransaction = false;
+    }
+
+    flushPendingChanges();
+
+    m_updatePositionsTimer->start();
+}
+
+void Positioner::sourceLayoutChanged(const QList<QPersistentModelIndex> &parents, QAbstractItemModel::LayoutChangeHint hint)
+{
+    Q_UNUSED(parents)
+
+    if (m_enabled) {
+        initMaps();
+    }
+
+    Q_EMIT layoutChanged(QList<QPersistentModelIndex>(), hint);
+}
+
+void Positioner::initMaps(int size)
+{
+    m_proxyToSource.clear();
+    m_sourceToProxy.clear();
+
+    if (size == -1) {
+        size = m_thumbnialModel->rowCount();
+    }
+
+    if (!size) {
+        return;
+    }
+
+    for (int i = 0; i < size; ++i) {
+        updateMaps(i, i);
+    }
+}
+
+void Positioner::updateMaps(int proxyIndex, int sourceIndex)
+{
+    m_proxyToSource.insert(proxyIndex, sourceIndex);
+    m_sourceToProxy.insert(sourceIndex, proxyIndex);
+}
+
+int Positioner::firstRow() const
+{
+    if (!m_proxyToSource.isEmpty()) {
+        QList<int> keys(m_proxyToSource.keys());
+        std::sort(keys.begin(), keys.end());
+
+        return keys.first();
+    }
+
+    return -1;
+}
+
+int Positioner::lastRow() const
+{
+    if (!m_proxyToSource.isEmpty()) {
+        QList<int> keys(m_proxyToSource.keys());
+        std::sort(keys.begin(), keys.end());
+        return keys.last();
+    }
+
+    return 0;
+}
+
+int Positioner::firstFreeRow() const
+{
+    if (!m_proxyToSource.isEmpty()) {
+        int last = lastRow();
+
+        for (int i = 0; i <= last; ++i) {
+            if (!m_proxyToSource.contains(i)) {
+                return i;
+            }
+        }
+    }
+
+    return -1;
+}
+
+void Positioner::applyPositions()
+{
+    // We were called while the source model is listing. Defer applying positions
+    // until listing completes.
+    if (m_thumbnialModel->status() == ThumbnailModel::Listing) {
+        m_deferApplyPositions = true;
+
+        return;
+    }
+
+    if (m_positions.size() < 5) {
+        // We were waiting for listing to complete before proxying source rows,
+        // but we don't have positions to apply. Reset to populate.
+        if (m_deferApplyPositions) {
+            m_deferApplyPositions = false;
+            reset();
+        }
+
+        return;
+    }
+
+    beginResetModel();
+
+    m_proxyToSource.clear();
+    m_sourceToProxy.clear();
+
+    const QStringList &positions = m_positions.mid(2);
+
+    if (positions.count() % 3 != 0) {
+        return;
+    }
+
+    QHash<QString, int> sourceIndices;
+
+    for (int i = 0; i < m_thumbnialModel->rowCount(); ++i) {
+        sourceIndices.insert(m_thumbnialModel->data(m_thumbnialModel->index(i, 0), Roles::UrlRole).toString(), i);
+    }
+
+    QString name;
+    int stripe = -1;
+    int pos = -1;
+    int sourceIndex = -1;
+    int index = -1;
+    bool ok = false;
+    int offset = 0;
+
+    // Restore positions for items that still fit.
+    for (int i = 0; i < positions.count() / 3; ++i) {
+        offset = i * 3;
+        pos = positions.at(offset + 2).toInt(&ok);
+        if (!ok) {
+            return;
+        }
+
+        if (pos <= m_perStripe) {
+            name = positions.at(offset);
+            stripe = positions.at(offset + 1).toInt(&ok);
+            if (!ok) {
+                return;
+            }
+
+            if (!sourceIndices.contains(name)) {
+                continue;
+            } else {
+                sourceIndex = sourceIndices.value(name);
+            }
+
+            index = (stripe * m_perStripe) + pos;
+
+            if (m_proxyToSource.contains(index)) {
+                continue;
+            }
+
+            updateMaps(index, sourceIndex);
+            sourceIndices.remove(name);
+        }
+    }
+
+    // Find new positions for items that didn't fit.
+    for (int i = 0; i < positions.count() / 3; ++i) {
+        offset = i * 3;
+        pos = positions.at(offset + 2).toInt(&ok);
+        if (!ok) {
+            return;
+        }
+
+        if (pos > m_perStripe) {
+            name = positions.at(offset);
+
+            if (!sourceIndices.contains(name)) {
+                continue;
+            } else {
+                sourceIndex = sourceIndices.take(name);
+            }
+
+            index = firstFreeRow();
+
+            if (index == -1) {
+                index = lastRow() + 1;
+            }
+
+            updateMaps(index, sourceIndex);
+        }
+    }
+
+    QHashIterator<QString, int> it(sourceIndices);
+
+    // Find positions for new source items we don't have records for.
+    while (it.hasNext()) {
+        it.next();
+
+        index = firstFreeRow();
+
+        if (index == -1) {
+            index = lastRow() + 1;
+        }
+
+        updateMaps(index, it.value());
+    }
+
+    endResetModel();
+
+    m_deferApplyPositions = false;
+
+    m_updatePositionsTimer->start();
+}
+
+void Positioner::flushPendingChanges()
+{
+    if (m_pendingChanges.isEmpty()) {
+        return;
+    }
+
+    int last = lastRow();
+
+    for (const QModelIndex &index : m_pendingChanges) {
+        if (index.row() <= last) {
+            Q_EMIT dataChanged(index, index);
+        }
+    }
+
+    m_pendingChanges.clear();
+}
+
+void Positioner::connectSignals(ThumbnailModel *model)
+{
+    connect(model, &QAbstractItemModel::dataChanged, this, &Positioner::sourceDataChanged, Qt::UniqueConnection);
+    connect(model, &QAbstractItemModel::rowsAboutToBeInserted, this, &Positioner::sourceRowsAboutToBeInserted, Qt::UniqueConnection);
+    connect(model, &QAbstractItemModel::rowsAboutToBeMoved, this, &Positioner::sourceRowsAboutToBeMoved, Qt::UniqueConnection);
+    connect(model, &QAbstractItemModel::rowsAboutToBeRemoved, this, &Positioner::sourceRowsAboutToBeRemoved, Qt::UniqueConnection);
+    connect(model, &QAbstractItemModel::layoutAboutToBeChanged, this, &Positioner::sourceLayoutAboutToBeChanged, Qt::UniqueConnection);
+    connect(model, &QAbstractItemModel::rowsInserted, this, &Positioner::sourceRowsInserted, Qt::UniqueConnection);
+    connect(model, &QAbstractItemModel::rowsMoved, this, &Positioner::sourceRowsMoved, Qt::UniqueConnection);
+    connect(model, &QAbstractItemModel::rowsRemoved, this, &Positioner::sourceRowsRemoved, Qt::UniqueConnection);
+    connect(model, &QAbstractItemModel::layoutChanged, this, &Positioner::sourceLayoutChanged, Qt::UniqueConnection);
+    connect(m_thumbnialModel, &ThumbnailModel::srcModelReseted, this, &Positioner::reset, Qt::UniqueConnection);
+    connect(m_thumbnialModel, &ThumbnailModel::statusChanged, this, &Positioner::sourceStatusChanged, Qt::UniqueConnection);
+}
+
+void Positioner::disconnectSignals(ThumbnailModel *model)
+{
+    disconnect(model, &QAbstractItemModel::dataChanged, this, &Positioner::sourceDataChanged);
+    disconnect(model, &QAbstractItemModel::rowsAboutToBeInserted, this, &Positioner::sourceRowsAboutToBeInserted);
+    disconnect(model, &QAbstractItemModel::rowsAboutToBeMoved, this, &Positioner::sourceRowsAboutToBeMoved);
+    disconnect(model, &QAbstractItemModel::rowsAboutToBeRemoved, this, &Positioner::sourceRowsAboutToBeRemoved);
+    disconnect(model, &QAbstractItemModel::layoutAboutToBeChanged, this, &Positioner::sourceLayoutAboutToBeChanged);
+    disconnect(model, &QAbstractItemModel::rowsInserted, this, &Positioner::sourceRowsInserted);
+    disconnect(model, &QAbstractItemModel::rowsMoved, this, &Positioner::sourceRowsMoved);
+    disconnect(model, &QAbstractItemModel::rowsRemoved, this, &Positioner::sourceRowsRemoved);
+    disconnect(model, &QAbstractItemModel::layoutChanged, this, &Positioner::sourceLayoutChanged);
+    disconnect(m_thumbnialModel, &ThumbnailModel::srcModelReseted, this, &Positioner::reset);
+    disconnect(m_thumbnialModel, &ThumbnailModel::statusChanged, this, &Positioner::sourceStatusChanged);
+}

--- a/src/src/thumbnailview/positioner.h
+++ b/src/src/thumbnailview/positioner.h
@@ -1,0 +1,140 @@
+/*
+    SPDX-FileCopyrightText: 2014 Eike Hein <hein@kde.org>
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+
+    SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+
+    SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef POSITIONER_H
+#define POSITIONER_H
+
+#include <QAbstractItemModel>
+
+class ThumbnailModel;
+class QTimer;
+
+class Positioner : public QAbstractItemModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
+    Q_PROPERTY(ThumbnailModel *thumbnailModel READ thumbnailModel WRITE setThumbnailModel NOTIFY sortModelChanged)
+    Q_PROPERTY(int perStripe READ perStripe WRITE setPerStripe NOTIFY perStripeChanged)
+    Q_PROPERTY(QStringList positions READ positions WRITE setPositions NOTIFY positionsChanged)
+
+public:
+    explicit Positioner(QObject *parent = nullptr);
+    ~Positioner() override;
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+    ThumbnailModel *thumbnailModel() const;
+    void setThumbnailModel(ThumbnailModel *thumbnailModel);
+
+    int perStripe() const;
+    void setPerStripe(int perStripe);
+
+    QStringList positions() const;
+    void setPositions(const QStringList &positions);
+
+    Q_INVOKABLE int map(int row) const;
+
+    Q_INVOKABLE int nearestItem(int currentIndex, Qt::ArrowType direction);
+
+    Q_INVOKABLE bool isBlank(int row) const;
+    Q_INVOKABLE int indexForUrl(const QUrl &url) const;
+
+    Q_INVOKABLE void setRangeSelected(int anchor, int to);
+
+    Q_INVOKABLE void reset();
+
+    /**
+     * Performs the move operation in the underlying model.
+     *
+     * @param moves List of indexes that were moved. Two
+     *              consecutive entries correspond to the
+     *              from and to position.
+     *
+     * @return The lowest index that was moved. Used to
+     *         determine the first selected item.
+     */
+    Q_INVOKABLE int move(const QVariantList &moves);
+
+    QHash<int, QByteArray> roleNames() const override;
+
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &index) const override;
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
+#ifdef BUILD_TESTING
+    QHash<int, int> proxyToSourceMapping() const
+    {
+        return m_proxyToSource;
+    }
+    QHash<int, int> sourceToProxyMapping() const
+    {
+        return m_sourceToProxy;
+    }
+#endif
+
+Q_SIGNALS:
+    void enabledChanged() const;
+    void sortModelChanged() const;
+    void perStripeChanged() const;
+    void positionsChanged() const;
+
+private Q_SLOTS:
+    void updatePositions();
+    void sourceStatusChanged();
+    void sourceDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);
+    void sourceModelAboutToBeReset();
+    void sourceModelReset();
+    void sourceRowsAboutToBeInserted(const QModelIndex &parent, int start, int end);
+    void sourceRowsAboutToBeMoved(const QModelIndex &sourceParent, int sourceStart, int sourceEnd, const QModelIndex &destinationParent, int destinationRow);
+    void sourceRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
+    void sourceLayoutAboutToBeChanged(const QList<QPersistentModelIndex> &parents, QAbstractItemModel::LayoutChangeHint hint);
+    void sourceRowsInserted(const QModelIndex &parent, int first, int last);
+    void sourceRowsMoved(const QModelIndex &sourceParent, int sourceStart, int sourceEnd, const QModelIndex &destinationParent, int destinationRow);
+    void sourceRowsRemoved(const QModelIndex &parent, int first, int last);
+    void sourceLayoutChanged(const QList<QPersistentModelIndex> &parents, QAbstractItemModel::LayoutChangeHint hint);
+
+private:
+    void initMaps(int size = -1);
+    void updateMaps(int proxyIndex, int sourceIndex);
+    int firstRow() const;
+    int lastRow() const;
+    int firstFreeRow() const;
+    void applyPositions();
+    void flushPendingChanges();
+    void connectSignals(ThumbnailModel *model);
+    void disconnectSignals(ThumbnailModel *model);
+
+    bool m_enabled;
+    ThumbnailModel *m_thumbnialModel;
+
+    int m_perStripe;
+
+    int m_lastRow;
+
+    QModelIndexList m_pendingChanges;
+    bool m_ignoreNextTransaction;
+
+    QStringList m_positions;
+    bool m_deferApplyPositions;
+    QVariantList m_deferMovePositions;
+    QTimer *const m_updatePositionsTimer;
+
+    QHash<int, int> m_proxyToSource;
+    QHash<int, int> m_sourceToProxy;
+    bool m_beginInsertRowsCalled = false; // used to sync the amount of begin/endInsertRows calls
+};
+
+#endif

--- a/src/src/thumbnailview/qimageitem.cpp
+++ b/src/src/thumbnailview/qimageitem.cpp
@@ -1,0 +1,204 @@
+/*
+    SPDX-FileCopyrightText: 2011 Marco Martin <mart@kde.org>
+    SPDX-FileCopyrightText: 2015 Luca Beltrame <lbeltrame@kde.org>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+
+#include "qimageitem.h"
+
+#include <QPainter>
+
+QImageItem::QImageItem(QQuickItem *parent)
+    : QQuickPaintedItem(parent)
+    , m_smooth(false)
+    , m_fillMode(QImageItem::Stretch)
+{
+    setFlag(ItemHasContents, true);
+}
+
+QImageItem::~QImageItem()
+{
+}
+
+void QImageItem::setImage(const QImage &image)
+{
+    bool oldImageNull = m_image.isNull();
+    m_image = image;
+    updatePaintedRect();
+    update();
+    Q_EMIT nativeWidthChanged();
+    Q_EMIT nativeHeightChanged();
+    Q_EMIT imageChanged();
+    if (oldImageNull != m_image.isNull()) {
+        Q_EMIT nullChanged();
+    }
+}
+
+QImage QImageItem::image() const
+{
+    return m_image;
+}
+
+void QImageItem::resetImage()
+{
+    setImage(QImage());
+}
+
+void QImageItem::setSmooth(const bool smooth)
+{
+    if (smooth == m_smooth) {
+        return;
+    }
+    m_smooth = smooth;
+    update();
+}
+
+bool QImageItem::smooth() const
+{
+    return m_smooth;
+}
+
+int QImageItem::nativeWidth() const
+{
+    return m_image.size().width() / m_image.devicePixelRatio();
+}
+
+int QImageItem::nativeHeight() const
+{
+    return m_image.size().height() / m_image.devicePixelRatio();
+}
+
+QImageItem::FillMode QImageItem::fillMode() const
+{
+    return m_fillMode;
+}
+
+void QImageItem::setFillMode(QImageItem::FillMode mode)
+{
+    if (mode == m_fillMode) {
+        return;
+    }
+
+    m_fillMode = mode;
+    updatePaintedRect();
+    update();
+    Q_EMIT fillModeChanged();
+}
+
+void QImageItem::paint(QPainter *painter)
+{
+    if (m_image.isNull()) {
+        return;
+    }
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing, m_smooth);
+    painter->setRenderHint(QPainter::SmoothPixmapTransform, m_smooth);
+
+    if (m_fillMode == TileVertically) {
+        painter->scale(width() / (qreal)m_image.width(), 1);
+    }
+
+    if (m_fillMode == TileHorizontally) {
+        painter->scale(1, height() / (qreal)m_image.height());
+    }
+
+    if (m_fillMode == Pad) {
+        QRect centeredRect = m_paintedRect;
+        centeredRect.moveCenter(m_image.rect().center());
+        painter->drawImage(m_paintedRect, m_image, centeredRect);
+    } else if (m_fillMode >= Tile) {
+        painter->drawTiledPixmap(m_paintedRect, QPixmap::fromImage(m_image));
+    } else {
+        painter->drawImage(m_paintedRect, m_image, m_image.rect());
+    }
+
+    painter->restore();
+}
+
+bool QImageItem::isNull() const
+{
+    return m_image.isNull();
+}
+
+int QImageItem::paintedWidth() const
+{
+    if (m_image.isNull()) {
+        return 0;
+    }
+
+    return m_paintedRect.width();
+}
+
+int QImageItem::paintedHeight() const
+{
+    if (m_image.isNull()) {
+        return 0;
+    }
+
+    return m_paintedRect.height();
+}
+
+void QImageItem::updatePaintedRect()
+{
+    if (m_image.isNull()) {
+        return;
+    }
+
+    QRectF sourceRect = m_paintedRect;
+
+    QRectF destRect;
+
+    switch (m_fillMode) {
+    case PreserveAspectFit: {
+        QSizeF scaled = m_image.size();
+
+        scaled.scale(boundingRect().size(), Qt::KeepAspectRatio);
+        destRect = QRectF(QPoint(0, 0), scaled);
+        destRect.moveCenter(boundingRect().center().toPoint());
+        break;
+    }
+    case PreserveAspectCrop: {
+        QSizeF scaled = m_image.size();
+
+        scaled.scale(boundingRect().size(), Qt::KeepAspectRatioByExpanding);
+        destRect = QRectF(QPoint(0, 0), scaled);
+        destRect.moveCenter(boundingRect().center().toPoint());
+        break;
+    }
+    case TileVertically: {
+        destRect = boundingRect().toRect();
+        destRect.setWidth(destRect.width() / (width() / (qreal)m_image.width()));
+        break;
+    }
+    case TileHorizontally: {
+        destRect = boundingRect().toRect();
+        destRect.setHeight(destRect.height() / (height() / (qreal)m_image.height()));
+        break;
+    }
+    case Stretch:
+    case Tile:
+    case Pad:
+    default:
+        destRect = boundingRect().toRect();
+    }
+
+    if (destRect != sourceRect) {
+        m_paintedRect = destRect.toRect();
+        Q_EMIT paintedHeightChanged();
+        Q_EMIT paintedWidthChanged();
+    }
+}
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+void QImageItem::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
+#else
+void QImageItem::geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry)
+#endif
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QQuickPaintedItem::geometryChanged(newGeometry, oldGeometry);
+#else
+    QQuickPaintedItem::geometryChange(newGeometry, oldGeometry);
+#endif
+    updatePaintedRect();
+}

--- a/src/src/thumbnailview/qimageitem.h
+++ b/src/src/thumbnailview/qimageitem.h
@@ -1,0 +1,88 @@
+/*
+    SPDX-FileCopyrightText: 2011 Marco Martin <mart@kde.org>
+    SPDX-FileCopyrightText: 2015 Luca Beltrame <lbeltrame@kde.org>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+
+#ifndef QIMAGEITEM_H
+#define QIMAGEITEM_H
+
+#include <QImage>
+#include <QQuickPaintedItem>
+
+class QImageItem : public QQuickPaintedItem
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QImage image READ image WRITE setImage NOTIFY imageChanged RESET resetImage)
+    Q_PROPERTY(bool smooth READ smooth WRITE setSmooth)
+    Q_PROPERTY(int nativeWidth READ nativeWidth NOTIFY nativeWidthChanged)
+    Q_PROPERTY(int nativeHeight READ nativeHeight NOTIFY nativeHeightChanged)
+    Q_PROPERTY(int paintedWidth READ paintedWidth NOTIFY paintedWidthChanged)
+    Q_PROPERTY(int paintedHeight READ paintedHeight NOTIFY paintedHeightChanged)
+    Q_PROPERTY(FillMode fillMode READ fillMode WRITE setFillMode NOTIFY fillModeChanged)
+    Q_PROPERTY(bool null READ isNull NOTIFY nullChanged)
+
+public:
+    enum FillMode {
+        Stretch, // the image is scaled to fit
+        PreserveAspectFit, // the image is scaled uniformly to fit without cropping
+        PreserveAspectCrop, // the image is scaled uniformly to fill, cropping if necessary
+        Tile, // the image is duplicated horizontally and vertically
+        TileVertically, // the image is stretched horizontally and tiled vertically
+        TileHorizontally, // the image is stretched vertically and tiled horizontally
+        Pad, /**< the image is not transformed @since 5.96 **/
+    };
+    Q_ENUM(FillMode)
+
+    explicit QImageItem(QQuickItem *parent = nullptr);
+    ~QImageItem() override;
+
+    void setImage(const QImage &image);
+    QImage image() const;
+    void resetImage();
+
+    void setSmooth(const bool smooth);
+    bool smooth() const;
+
+    int nativeWidth() const;
+    int nativeHeight() const;
+
+    int paintedWidth() const;
+    int paintedHeight() const;
+
+    FillMode fillMode() const;
+    void setFillMode(FillMode mode);
+
+    void paint(QPainter *painter) override;
+
+    bool isNull() const;
+
+Q_SIGNALS:
+    void nativeWidthChanged();
+    void nativeHeightChanged();
+    void fillModeChanged();
+    void imageChanged();
+    void nullChanged();
+    void paintedWidthChanged();
+    void paintedHeightChanged();
+
+protected:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;
+#else
+    void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
+#endif
+
+private:
+    QImage m_image;
+    bool m_smooth;
+    FillMode m_fillMode;
+    QRect m_paintedRect;
+
+private Q_SLOTS:
+    void updatePaintedRect();
+};
+
+#endif

--- a/src/src/thumbnailview/roles.cpp
+++ b/src/src/thumbnailview/roles.cpp
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "roles.h"

--- a/src/src/thumbnailview/roles.h
+++ b/src/src/thumbnailview/roles.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ROLES_H
+#define ROLES_H
+
+#include <QObject>
+
+class Roles : public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(RoleNames)
+public:
+    using QObject::QObject;
+    ~Roles() = default;
+    enum RoleNames { BlankRole = Qt::UserRole + 1, DBImgInfoRole, Thumbnail, ReloadThumbnail, ItemTypeRole, SelectedRole, SourceIndex
+    , ModelTypeRole, FileNameRole, UrlRole, FilePathRole, PathHashRole, RemainDaysRole
+                   };
+};
+
+#endif

--- a/src/src/thumbnailview/rubberband.cpp
+++ b/src/src/thumbnailview/rubberband.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "rubberband.h"
+
+#include <QApplication>
+#include <QStyleOptionRubberBand>
+
+RubberBand::RubberBand(QQuickItem *parent)
+    : QQuickPaintedItem(parent)
+{
+}
+
+RubberBand::~RubberBand()
+{
+}
+
+void RubberBand::paint(QPainter *painter)
+{
+    if (!qApp || !qApp->style()) {
+        return;
+    }
+
+    QStyleOptionRubberBand opt;
+    opt.state = QStyle::State_None;
+    opt.direction = qApp->layoutDirection();
+    opt.styleObject = this;
+    opt.palette = qApp->palette();
+    opt.shape = QRubberBand::Rectangle;
+    opt.opaque = false;
+    opt.rect = contentsBoundingRect().toRect();
+    qApp->style()->drawControl(QStyle::CE_RubberBand, &opt, painter);
+}
+
+bool RubberBand::intersects(const QRectF &rect) const
+{
+    return m_geometry.intersects(rect);
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+void RubberBand::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
+#else
+void RubberBand::geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry)
+#endif
+{
+    Q_UNUSED(oldGeometry);
+
+    m_geometry = newGeometry;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QQuickItem::geometryChanged(newGeometry, oldGeometry);
+#else
+    QQuickItem::geometryChange(newGeometry, oldGeometry);
+#endif
+}

--- a/src/src/thumbnailview/rubberband.h
+++ b/src/src/thumbnailview/rubberband.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RUBBERBAND_H
+#define RUBBERBAND_H
+
+#include <QQuickPaintedItem>
+
+class RubberBand : public QQuickPaintedItem
+{
+    Q_OBJECT
+
+public:
+    explicit RubberBand(QQuickItem *parent = nullptr);
+    ~RubberBand() override;
+
+    void paint(QPainter *painter) override;
+
+    Q_INVOKABLE bool intersects(const QRectF &rect) const;
+
+protected:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;
+#else
+    void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
+#endif
+
+private:
+    QRectF m_geometry;
+};
+
+#endif

--- a/src/src/thumbnailview/thumbnailmodel.cpp
+++ b/src/src/thumbnailview/thumbnailmodel.cpp
@@ -1,0 +1,455 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "thumbnailmodel.h"
+#include "unionimage/unionimage.h"
+#include "imageengine/imagedataservice.h"
+#include "imagedatamodel.h"
+
+#include <QDebug>
+#include <QIcon>
+#include <QUrl>
+
+ThumbnailModel::ThumbnailModel(QObject *parent)
+    : QSortFilterProxyModel(parent)
+    , m_viewAdapter(nullptr)
+    , m_screenshotSize(256, 256)
+    , m_containImages(false)
+{
+    setSortLocaleAware(true);
+    sort(0);
+    m_selectionModel = new QItemSelectionModel(this);
+    connect(m_selectionModel, &QItemSelectionModel::selectionChanged, this, &ThumbnailModel::changeSelection);
+    connect(m_selectionModel, &QItemSelectionModel::selectionChanged, this, &ThumbnailModel::selectionChanged);
+
+    // 图片数据服务有图片加载成功，通知model刷新界面
+    connect(ImageDataService::instance(), &ImageDataService::gotImage, this, &ThumbnailModel::showPreview, Qt::ConnectionType::QueuedConnection);
+}
+
+ThumbnailModel::~ThumbnailModel()
+{
+
+}
+
+Types::ModelType ThumbnailModel::modelType() const
+{
+    Types::ModelType modelType = Types::Normal;
+    ImageDataModel *dataModel = qobject_cast<ImageDataModel *>(sourceModel());
+    if (dataModel)
+        modelType = dataModel->modelType();
+
+    return modelType;
+}
+
+void ThumbnailModel::setContainImages(bool value)
+{
+    m_containImages = value;
+    emit containImagesChanged();
+}
+
+void ThumbnailModel::showPreview(const QString &path)
+{
+    int idx = indexForFilePath(path);
+    if (idx != -1) {
+        dataChanged(index(idx, 0, QModelIndex()), index(idx, 0, QModelIndex()));
+    }
+}
+
+void ThumbnailModel::changeSelection(const QItemSelection &selected, const QItemSelection &deselected)
+{
+    QModelIndexList indices = selected.indexes();
+    indices.append(deselected.indexes());
+
+    const QVector<int> roles{Roles::SelectedRole};
+
+    for (const QModelIndex &index : indices) {
+        Q_EMIT dataChanged(index, index, roles);
+    }
+}
+
+QByteArray ThumbnailModel::sortRoleName() const
+{
+    int role = sortRole();
+    return roleNames().value(role);
+}
+
+void ThumbnailModel::setSortRoleName(const QByteArray &name)
+{
+    if (!sourceModel()) {
+        m_sortRoleName = name;
+        return;
+    }
+
+    const QHash<int, QByteArray> roles = sourceModel()->roleNames();
+    for (auto it = roles.begin(); it != roles.end(); it++) {
+        if (it.value() == name) {
+            setSortRole(it.key());
+            return;
+        }
+    }
+    qDebug() << "Sort role" << name << "not found";
+}
+
+QHash<int, QByteArray> ThumbnailModel::roleNames() const
+{
+    QHash<int, QByteArray> hash = sourceModel()->roleNames();
+    hash.insert(Roles::BlankRole, "blank");
+    hash.insert(Roles::SelectedRole, "selected");
+    hash.insert(Roles::Thumbnail, "thumbnail");
+    hash.insert(Roles::ReloadThumbnail, "reloadThumbnail");
+    hash.insert(Roles::SourceIndex, "sourceIndex");
+    hash.insert(Roles::ModelTypeRole, "modelType");
+    return hash;
+}
+
+QVariant ThumbnailModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid()) {
+        return {};
+    }
+
+    switch (role) {
+
+    case Roles::BlankRole: {
+        return false;
+    }
+
+    case Roles::SelectedRole: {
+        return m_selectionModel->isSelected(index);
+    }
+
+    case Roles::Thumbnail: {
+        QString srcPath = data(index, Roles::FilePathRole).toString();
+        QImage image = ImageDataService::instance()->getThumnailImageByPathRealTime(srcPath, modelType() == Types::RecentlyDeleted);
+        if (!image.isNull()) {
+            return image;
+        } else
+            return {};
+    }
+
+    case Roles::ReloadThumbnail: {
+        QString srcPath = data(index, Roles::FilePathRole).toString();
+        QImage image = ImageDataService::instance()->getThumnailImageByPathRealTime(srcPath, modelType() == Types::RecentlyDeleted, true);
+        if (!image.isNull()) {
+            return image;
+        } else
+            return {};
+    }
+
+    case Roles::SourceIndex: {
+        return mapToSource(index).row();
+    }
+
+    case Roles::ModelTypeRole: {
+        return modelType();
+    }
+    }
+
+    return QSortFilterProxyModel::data(index, role);
+}
+
+bool ThumbnailModel::lessThan(const QModelIndex &source_left, const QModelIndex &source_right) const
+{
+    return QSortFilterProxyModel::lessThan(source_left, source_right);
+}
+
+ThumbnailModel::Status ThumbnailModel::status() const
+{
+    return m_status;
+}
+
+QObject *ThumbnailModel::viewAdapter() const
+{
+    return m_viewAdapter;
+}
+
+void ThumbnailModel::setViewAdapter(QObject *adapter)
+{
+    if (m_viewAdapter != adapter) {
+        ItemViewAdapter *abstractViewAdapter = dynamic_cast<ItemViewAdapter *>(adapter);
+
+        m_viewAdapter = abstractViewAdapter;
+
+        Q_EMIT viewAdapterChanged();
+    }
+}
+
+void ThumbnailModel::setStatus(Status status)
+{
+    if (m_status != status) {
+        m_status = status;
+        Q_EMIT statusChanged();
+    }
+}
+
+void ThumbnailModel::setSourceModel(QAbstractItemModel *sourceModel)
+{
+    QAbstractItemModel *oldSrcModel = QSortFilterProxyModel::sourceModel();
+    if (oldSrcModel)
+        disconnect(oldSrcModel, SIGNAL(modelReset()), this, SIGNAL(srcModelReseted()));
+
+    QSortFilterProxyModel::setSourceModel(sourceModel);
+
+    connect(sourceModel, SIGNAL(modelReset()), this, SIGNAL(srcModelReseted()));
+
+    if (!m_sortRoleName.isEmpty()) {
+        setSortRoleName(m_sortRoleName);
+        m_sortRoleName.clear();
+    }
+}
+
+bool ThumbnailModel::containImages()
+{
+    return m_containImages;
+}
+
+bool ThumbnailModel::isSelected(int row)
+{
+    if (row < 0) {
+        return false;
+    }
+
+    return m_selectionModel->isSelected(index(row, 0));
+}
+
+void ThumbnailModel::setSelected(int indexValue)
+{
+    if (indexValue < 0)
+        return;
+
+    QModelIndex index = QSortFilterProxyModel::index(indexValue, 0);
+    m_selectionModel->select(index, QItemSelectionModel::Select);
+    emit dataChanged(index, index);
+    emit selectedIndexesChanged();
+}
+
+void ThumbnailModel::toggleSelected(int indexValue)
+{
+    if (indexValue < 0)
+        return;
+
+    QModelIndex index = QSortFilterProxyModel::index(indexValue, 0);
+    m_selectionModel->select(index, QItemSelectionModel::Toggle);
+    emit dataChanged(index, index);
+    emit selectedIndexesChanged();
+}
+
+void ThumbnailModel::setRangeSelected(int anchor, int to)
+{
+    if (anchor < 0 || to < 0) {
+        return;
+    }
+
+    QItemSelection selection(index(anchor, 0), index(to, 0));
+    m_selectionModel->select(selection, QItemSelectionModel::ClearAndSelect);
+
+    emit selectedIndexesChanged();
+}
+
+void ThumbnailModel::updateSelection(const QVariantList &rows, bool toggle)
+{
+    QItemSelection newSelection;
+
+    QList<int> oldSelecteds = selectedIndexes();
+
+    int iRow = -1;
+
+    for (const QVariant &row : rows) {
+        iRow = row.toInt();
+
+        if (iRow < 0) {
+            return;
+        }
+
+        const QModelIndex &idx = index(iRow, 0);
+        newSelection.select(idx, idx);
+    }
+
+    if (toggle) {
+        QItemSelection pinnedSelection = m_pinnedSelection;
+        pinnedSelection.merge(newSelection, QItemSelectionModel::Toggle);
+        m_selectionModel->select(pinnedSelection, QItemSelectionModel::ClearAndSelect);
+    } else {
+        m_selectionModel->select(newSelection, QItemSelectionModel::ClearAndSelect);
+    }
+
+    // 仅选择项有改变，才向外部通知选中内容改变
+    if (oldSelecteds != selectedIndexes())
+        emit selectedIndexesChanged();
+}
+
+void ThumbnailModel::clearSelection()
+{
+    if (m_selectionModel->hasSelection()) {
+        QModelIndexList selectedIndex = m_selectionModel->selectedIndexes();
+        m_selectionModel->clear();
+//        for (auto indexValue : selectedIndex) {
+//            emit dataChanged(indexValue, indexValue);
+//        }
+    }
+    emit selectedIndexesChanged();
+}
+
+void ThumbnailModel::pinSelection()
+{
+    m_pinnedSelection = m_selectionModel->selection();
+}
+
+void ThumbnailModel::unpinSelection()
+{
+    m_pinnedSelection = QItemSelection();
+}
+
+void ThumbnailModel::selectAll()
+{
+    setRangeSelected(0, rowCount() - 1);
+}
+
+int ThumbnailModel::proxyIndex(const int &indexValue)
+{
+    if (sourceModel()) {
+        return mapFromSource(sourceModel()->index(indexValue, 0, QModelIndex())).row();
+    }
+    return -1;
+}
+
+int ThumbnailModel::sourceIndex(const int &indexValue)
+{
+    return mapToSource(index(indexValue, 0, QModelIndex())).row();
+}
+
+QJsonArray ThumbnailModel::allUrls()
+{
+    QJsonArray arr;
+    for (int row = 0; row < rowCount(); row++)
+        arr.append(QJsonValue(data(index(row, 0), Roles::UrlRole).toString()));
+
+    return arr;
+}
+
+QJsonArray ThumbnailModel::allPaths()
+{
+    QJsonArray arr;
+    for (int row = 0; row < rowCount(); row++)
+        arr.append(QJsonValue(data(index(row, 0), Roles::FilePathRole).toString()));
+
+    return arr;
+}
+
+QJsonArray ThumbnailModel::selectedUrls()
+{
+    QJsonArray arr;
+
+    for (auto index : m_selectionModel->selectedIndexes())
+        arr.push_back(QJsonValue(data(index, Roles::UrlRole).toString()));
+
+    return arr;
+}
+
+QJsonArray ThumbnailModel::selectedPaths()
+{
+    QJsonArray arr;
+
+    for (auto index : m_selectionModel->selectedIndexes())
+        arr.push_back(QJsonValue(data(index, Roles::FilePathRole).toString()));
+
+    return arr;
+}
+
+QList<int> ThumbnailModel::selectedIndexes()
+{
+    QList<int> selects;
+    for (auto index : m_selectionModel->selectedIndexes()) {
+        selects.push_back(index.row());
+    }
+
+    return selects;
+}
+
+int ThumbnailModel::indexForUrl(const QString &url)
+{
+    QModelIndexList indexList;
+    for (int row = 0; row < rowCount(); row++) {
+        indexList.append(index(row, 0, QModelIndex()));
+    }
+    for (auto index : indexList) {
+        if (url == data(index, Roles::UrlRole).toString()) {
+            return index.row();
+        }
+    }
+    return -1;
+}
+
+QList<int> ThumbnailModel::indexesForUrls(const QStringList &urls)
+{
+    QList<int> indexes;
+    for (int row = 0; row < rowCount(); row++) {
+        if (urls.indexOf(data(index(row, 0, QModelIndex()), Roles::UrlRole).toString()) != -1)
+            indexes.push_back(row);
+    }
+
+    return indexes;
+}
+
+int ThumbnailModel::indexForFilePath(const QString &filePath)
+{
+    QModelIndexList indexList;
+    for (int row = 0; row < rowCount(); row++) {
+        indexList.append(index(row, 0, QModelIndex()));
+    }
+    for (auto index : indexList) {
+        if (filePath == data(index, Roles::FilePathRole).toString()) {
+            return index.row();
+        }
+    }
+    return -1;
+}
+
+QVariant ThumbnailModel::data(int idx, const QString &role)
+{
+    QHash<int, QByteArray> hash = roleNames();
+    int roleType = -1;
+    QHash<int, QByteArray>::const_iterator i = hash.constBegin();
+    while (i != hash.constEnd()) {
+        int nType = i.key();
+        if (i.value() == role) {
+            roleType = nType;
+            break;
+        }
+        i++;
+    }
+
+    if (roleType != -1)
+        return data(index(idx, 0, QModelIndex()), roleType);
+
+    return QVariant();
+}
+
+void ThumbnailModel::refresh(int type)
+{
+    ImageDataModel *dataModel = qobject_cast<ImageDataModel *>(sourceModel());
+    if (dataModel)
+        dataModel->loadData(static_cast<Types::ItemType>(type));
+}
+
+void ThumbnailModel::selectUrls(const QStringList &urls)
+{
+    QItemSelection newSelection;
+
+    QList<int> indexes = indexesForUrls(urls);
+    for (auto i : indexes) {
+        const QModelIndex &idx = index(i, 0);
+        newSelection.select(idx, idx);
+    }
+
+    m_selectionModel->select(newSelection, QItemSelectionModel::ClearAndSelect);
+}
+
+DBImgInfo ThumbnailModel::indexForData(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return DBImgInfo();
+
+    return index.data().value<DBImgInfo>();
+}

--- a/src/src/thumbnailview/thumbnailmodel.h
+++ b/src/src/thumbnailview/thumbnailmodel.h
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef JUNGLE_SORTMODEL_H
+#define JUNGLE_SORTMODEL_H
+
+#include "types.h"
+#include "roles.h"
+#include "itemviewadapter.h"
+#include "unionimage/unionimage_global.h"
+
+#include <QItemSelectionModel>
+#include <QJsonArray>
+#include <QSize>
+#include <QSortFilterProxyModel>
+#include <QVariant>
+#include <QTimer>
+#include <QPointer>
+
+class ThumbnailModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QByteArray sortRoleName READ sortRoleName WRITE setSortRoleName)
+    Q_PROPERTY(bool containImages READ containImages WRITE setContainImages NOTIFY containImagesChanged)
+    Q_PROPERTY(QList<int> selectedIndexes READ selectedIndexes NOTIFY selectedIndexesChanged)
+    Q_PROPERTY(QJsonArray selectedUrls READ selectedUrls NOTIFY selectedIndexesChanged)
+    Q_PROPERTY(QJsonArray selectedPaths READ selectedPaths NOTIFY selectedIndexesChanged)
+    Q_PROPERTY(int count READ rowCount NOTIFY srcModelReseted)
+    Q_PROPERTY(Types::ModelType modelType READ modelType)
+    Q_PROPERTY(Status status READ status NOTIFY statusChanged)
+    Q_PROPERTY(QObject *viewAdapter READ viewAdapter WRITE setViewAdapter NOTIFY viewAdapterChanged)
+public:
+    enum Status {
+        None,
+        Ready,
+        Listing,
+        Canceled,
+    };
+    Q_ENUM(Status)
+
+    explicit ThumbnailModel(QObject *parent = nullptr);
+    ~ThumbnailModel() override;
+
+    QByteArray sortRoleName() const;
+    void setSortRoleName(const QByteArray &name);
+
+    QHash<int, QByteArray> roleNames() const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    bool lessThan(const QModelIndex &source_left, const QModelIndex &source_right) const override;
+
+    Status status() const;
+
+    QObject *viewAdapter() const;
+    void setViewAdapter(QObject *adapter);
+
+    void setSourceModel(QAbstractItemModel *sourceModel) override;
+    bool containImages();
+
+    Q_INVOKABLE Types::ModelType modelType() const;
+    Q_INVOKABLE bool isSelected(int row);
+    Q_INVOKABLE void setSelected(int indexValue);
+    Q_INVOKABLE void toggleSelected(int indexValue);
+    Q_INVOKABLE void setRangeSelected(int anchor, int to);
+    Q_INVOKABLE void updateSelection(const QVariantList &rows, bool toggle);
+    Q_INVOKABLE void clearSelection();
+    Q_INVOKABLE void pinSelection();
+    Q_INVOKABLE void unpinSelection();
+    Q_INVOKABLE void selectAll();
+    Q_INVOKABLE int proxyIndex(const int &indexValue);
+    Q_INVOKABLE int sourceIndex(const int &indexValue);
+    Q_INVOKABLE QJsonArray allUrls();
+    Q_INVOKABLE QJsonArray allPaths();
+    Q_INVOKABLE QJsonArray selectedUrls();
+    Q_INVOKABLE QJsonArray selectedPaths();
+    Q_INVOKABLE QList<int> selectedIndexes();
+    Q_INVOKABLE int indexForUrl(const QString &url);
+    Q_INVOKABLE QList<int> indexesForUrls(const QStringList &urls);
+    Q_INVOKABLE int indexForFilePath(const QString &filePath);
+
+    Q_INVOKABLE QVariant data(int index, const QString &role);
+
+    Q_INVOKABLE void refresh(int type = 0);
+
+    Q_INVOKABLE void selectUrls(const QStringList &urls);
+
+    DBImgInfo indexForData(const QModelIndex &index) const;
+
+protected Q_SLOTS:
+    void setContainImages(bool);
+    void showPreview(const QString &path);
+    void changeSelection(const QItemSelection &selected, const QItemSelection &deselected);
+
+signals:
+    void containImagesChanged();
+    void selectedIndexesChanged();
+    void srcModelReseted() const;
+    void statusChanged() const;
+    void viewAdapterChanged();
+    void selectionChanged() const;
+
+private:
+    void setStatus(Status status);
+
+private:
+    QByteArray m_sortRoleName;
+    Status m_status = Status::None;
+
+    QItemSelectionModel *m_selectionModel;
+    QItemSelection m_pinnedSelection;
+
+    QPointer<ItemViewAdapter> m_viewAdapter;
+
+    QTimer *m_previewTimer;
+    QSize m_screenshotSize;
+    bool m_containImages;
+};
+
+#endif // JUNGLE_SORTMODEL_H

--- a/src/src/thumbnailview/types.cpp
+++ b/src/src/thumbnailview/types.cpp
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "types.h"

--- a/src/src/thumbnailview/types.h
+++ b/src/src/thumbnailview/types.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ITEMTYPES_H
+#define ITEMTYPES_H
+#include <QObject>
+
+#include "unionimage/unionimage_global.h"
+class Types : public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(ItemType)
+    Q_ENUMS(ModelType)
+public:
+    using QObject::QObject;
+    ~Types() = default;
+
+    enum ItemType { All = 0, Picture, Video };
+    enum ModelType {
+        Normal = 0,       // 常规视图model （大多缩略图使用该model）
+        DayCollecttion,  // 合集日视图model
+        AllCollection,   // 合集所有项目视图model
+        HaveImported,    // 已导入视图数据model
+        RecentlyDeleted, // 最近删除视图model
+        CustomAlbum,     // 自定义相册视图model
+        SearchResult,    // 搜索结果视图model
+        Device           // 设备视图mode
+    };
+};
+
+#endif

--- a/src/src/unionimage/baseutils.h
+++ b/src/src/unionimage/baseutils.h
@@ -128,12 +128,16 @@ namespace base {
 void        copyOneImageToClipboard(const QString &path);
 void        copyImageToClipboard(const QStringList &paths);
 void        showInFileManager(const QString &path);
+QString     hash(const QString &str);
 QString     hashByString(const QString &str);
+QString     hashByData(const QString &str);
 int         stringWidth(const QFont &f, const QString &str);
 int         stringHeight(const QFont &f, const QString &str);
 
 QPixmap     renderSVG(const QString &filePath, const QSize &size);
-QString     hash(const QString &str);
+QString     mkMutiDir(const QString &path);
+//根据源文件路径生产缩略图路径
+QString     filePathToThumbnailPath(const QString &filePath, QString dataHash = "");
 //QString     wrapStr(const QString &str, const QFont &font, int maxWidth);
 QString     SpliteText(const QString &text, const QFont &font, int nLabelSize, bool bReturn = false);
 //QString     sizeToHuman(const qlonglong bytes);

--- a/src/src/unionimage/unionimage_global.h
+++ b/src/src/unionimage/unionimage_global.h
@@ -167,6 +167,8 @@ struct DBImgInfo {
         return getFileNameFromFilePath(filePath);
     }
 };
+Q_DECLARE_METATYPE(DBImgInfo)
+
 typedef QList<DBImgInfo> DBImgInfoList;
 
 enum OpenImgViewType {

--- a/src/translations/deepin-album.ts
+++ b/src/translations/deepin-album.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="en">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>All photos and videos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>Disk is busy, cannot eject now</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Exit fullscreen/slideshow</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>View</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Export photos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Import photos/videos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Select all</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Photo/Video info</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Set as wallpaper</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Rotate clockwise</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Rotate counterclockwise</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Zoom in</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Zoom out</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Unfavorite</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>New album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Rename album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Page up</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Page down</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Photos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Albums</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Screen Capture</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Draw</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Unnamed</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Channel</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Pictures</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>New album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Import folders</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Version:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Album is a stylish management tool for viewing and organizing photos and videos.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 is released under %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Show side pane</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Hide side pane</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Original ratio</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Square thumbnails</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>All</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Unfavorite</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Rotate</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 photos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 videos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>No results</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 photos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 videos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>No results</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>No photos or videos found</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Screen Capture</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Draw</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(copy)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 photos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 videos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 photo </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 photos </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1 Drive</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Blank %1 Disc</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1 Encrypted</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>%1 Volume</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Are you sure you want to delete this file locally?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>You can restore it in the trash</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>Are you sure you want to delete %1 files locally?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>You can restore them in the trash</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Are you sure you want to permanently delete this file?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>You cannot restore it any longer</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Are you sure you want to permanently delete %1 files?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>You cannot restore them any longer</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 photos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 videos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Import to:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>New Album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Import All</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>Import 1 Item</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>Import %1 Items</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Import successful</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>No results</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Loading...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Ignore</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>File name cannot be empty!</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Save to:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Pictures</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Documents</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Downloads</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Videos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Music</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Select other directories</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Quality:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Export successful</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Export failed</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Exit fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Extract text</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Rotate clockwise</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Rotate counterclockwise</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Set as wallpaper</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Image info</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Zoom in</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Zoom out</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Image Viewing</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Select all</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>Live Text</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>All</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Photos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Videos</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>The photo/video already exists</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>1 item selected (1 photo)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>1 item selected (1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>%1 items selected (%1 photos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>%1 items selected (%1 videos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>%1 items selected (1 photo, %2 videos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>%1 items selected (%2 photos, 1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>%1 items selected (%2 photos, %3 videos)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 photos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 videos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>You have no permission to view the image</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>Image file not found</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Import Photos and Videos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>Or drag them here</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Imported on</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 item</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 items</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Basic info</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>File name</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Dimensions</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Date captured</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Date modified</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Aperture</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Exposure program</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Focal length</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Exposure mode</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Exposure time</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Flash compensation</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Max aperture</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Colorspace</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Metering mode</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>White balance</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Device model</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Lens model</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>Importing...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation>Imported:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation>0</translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Import successful</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>Import failed</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Unnamed</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>New Album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Confirm</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>No photos or videos found</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Select pictures</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Import successful</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Import failed</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>System Disk</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>The file already exists, please use another name</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Trash</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>The file already exists, please use another name</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Confirm</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 photos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 videos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Trash</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>The files will be permanently deleted after the days shown on them</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Delete All</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Delete Selected (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Restore Selected (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Are you sure you want to delete this album?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>1 photo found</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>%1 photos found</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>1 video found</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>%1 videos found</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>%1 items found</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Search results</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Slide Show</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>No search results</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>Album “%1” removed</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Gallery</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Collection</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Trash</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Device</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Albums</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Add an album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Screen Capture</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Draw</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>New album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Play</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Exit</translation>
     </message>
@@ -1455,178 +1455,305 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>days</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>day</source>
         <translation>day</translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation type="unfinished">days</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>day</source>
+        <translation type="unfinished">day</translation>
+    </message>
+</context>
+<context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Export successful</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Export failed</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>View</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Add to album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>New album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Successfully added to “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Remove from album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Unfavorite</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Rotate clockwise</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Rotate counterclockwise</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Set as wallpaper</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Restore</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Photo info</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Video info</translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation type="unfinished">View</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation type="unfinished">Fullscreen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation type="unfinished">Print</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation type="unfinished">Slide show</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation type="unfinished">Add to album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation type="unfinished">New album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation type="unfinished">Successfully added to “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation type="unfinished">Export</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation type="unfinished">Copy</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation type="unfinished">Delete</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation type="unfinished">Remove from album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation type="unfinished">Favorite</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation type="unfinished">Unfavorite</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation type="unfinished">Rotate clockwise</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation type="unfinished">Rotate counterclockwise</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation type="unfinished">Set as wallpaper</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation type="unfinished">Display in file manager</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation type="unfinished">Restore</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation type="unfinished">Photo info</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished">Video info</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="obsolete">Export successful</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="obsolete">Export failed</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation>Back to Album</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
         <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation>Original size</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
         <translation>Fit to window</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation>Rotate</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
         <translation>Unfavorite</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Extract text</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Basic info</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>File name</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Date captured</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Duration</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Path</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Codec info</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>Video CodecID</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Video CodeRate</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Proportion</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Resolution</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>Audio CodecID</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Audio CodeRate</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Audio digit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Channels</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Sampling</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Exit fullscreen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Extract text</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Unfavorite</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Rotate clockwise</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Rotate counterclockwise</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Show navigation window</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Hide navigation window</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Set as wallpaper</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Image info</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Export successful</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>Export failed</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Album is a stylish management tool for viewing and organizing photos and videos.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 items</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 item</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>All photos and videos</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Import successful</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Import failed</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_ar.ts
+++ b/src/translations/deepin-album_ar.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ar_EG">
+<TS version="2.1" language="ar">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>القرص يعمل حالياً، لا يمكن إخراجه الآن</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>موافق</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ملء الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>الخروج من وضع ملء الشاشة/عرض الشرائح</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>مساعدة</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض الإختصارات</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض في مدير الملفات</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض الشرائح</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>اختيار الكل</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>نسخ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>اجعل الصورة كخلفية</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>تدوير بإتجاه عقارب الساعة</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>ادر الصور بعكس إتجاه عقارب الساعة</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>كبّر الصورة</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>صغّر الصورة</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>السابق</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>التالي</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>تفضيل</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>عدم التفضيل</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>ألبوم جديد</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>إعادة تسمية الإلبوم</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>الذهاب لأعلى الصفحة</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>الذهاب لأسفل الصفحة</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>الصور</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>الإلبومات</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>المفضلات</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>بلا اسم</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>الصور</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>ألبوم جديد</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>الإلبوم</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>تفضيل</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>عدم التفضيل</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 فيديو</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 فيديو</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 فيديو</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 مساحة القرص</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>الفارغ 1% من القرص</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 مشفّر</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>مساحة القرص 1%</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 فيديو</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>استيراد إلى:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>استيراد</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ألبوم جديد</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>استيراد الكل</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>تم الاستيراد بنجاح</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>تجاهل</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>موافق</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>الاسم:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>حفظ إلى:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>الصور</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>المستندات</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>التنزيلات</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>سطح المكتب</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>الفيديوهات</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>الموسيقى</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>اختر مجلدات أخرى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>الصيغة</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>الجودة:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>تم التصدير بنجاح</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>فشل التصدير</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ملء الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>الخروج من وضع ملء الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض الشرائح</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>إعادة تسمية</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>نسخ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>تدوير بإتجاه عقارب الساعة</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>ادر الصور بعكس إتجاه عقارب الساعة</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>اجعل الصورة كخلفية</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض في مدير الملفات</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>السابق</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>التالي</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>كبّر الصورة</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>صغّر الصورة</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>طباعة</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>مساعدة</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض الإختصارات</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>اختيار الكل</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>الصور</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>الفيديوهات</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 فيديو</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>استيراد</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>لا تملك الصلاحية لعرض الصورة</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>المعلومات الأساسية</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>الابعاد</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>النوع</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>تاريخ الإلتقاط</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>تاريخ التعديل</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>التفاصيل</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>فجوة</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>برنامج العرض</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>الطول المركزي</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>وضع العرض</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>وقت العرض</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>فلاش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>التعويضات السريعة</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>الفجوة القصوى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>مساحة اللون</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>وضع القياس المتري</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>التوازن الأبيض</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>طراز العدسة</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>يتم الآن الاستيراد...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>تم الاستيراد بنجاح</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>فشل الاستيراد</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>بلا اسم</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ألبوم جديد</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>الاسم:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>قرص النظام</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>سلة المحذوفات</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>الإلبوم</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 فيديو</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>سلة المحذوفات</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف الكل</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>هل أنت متأكد من حذف هذا الألبوم؟</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>تم العثور علي 1 صورة</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>نتائج البحث</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض الشرائح</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>لا توجد نتائج لبحثك</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>تم حذف الإلبوم “1%”</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>المعرض</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>استيراد</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>المفضلات</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>سلة المحذوفات</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>الجهاز</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>الإلبومات</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض الشرائح</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>تصدير</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>ألبوم جديد</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>إعادة تسمية</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>السابق</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>إيقاف مؤقت</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>تشغيل</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>التالي</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>خروج</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>الأيام</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>الأيام</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>تم التصدير بنجاح</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>فشل التصدير</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ملء الشاشة</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>طباعة</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض الشرائح</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>إضافة إلى الإلبوم</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>ألبوم جديد</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>تم الإضافة إلى “1%”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف من الإلبوم</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>تفضيل</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>عدم التفضيل</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>أدر الصورة بإتجاه عقارب الساعة</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>ادر الصور بعكس إتجاه عقارب الساعة</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>اجعلها كخلفية</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض في مدير الملفات</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>إستعادة</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>معلومات الصورة</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>ملء الشاشة</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>طباعة</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>عرض الشرائح</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>إضافة إلى الإلبوم</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>ألبوم جديد</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>تم الإضافة إلى “1%”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>حذف</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>حذف من الإلبوم</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>تفضيل</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>عدم التفضيل</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>تدوير بإتجاه عقارب الساعة</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>ادر الصورة بعكس إتجاه عقارب الساعة</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>اجعل الصورة كخلفية</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>عرض في مدير الملفات</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>إستعادة</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>معلومات الصورة</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">تم التصدير بنجاح</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">فشل التصدير</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>السابق</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>التالي</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>ضبط إلى حجم النافذة</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>تفضيل</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>عدم التفضيل</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>المعلومات الأساسية</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>تاريخ الإلتقاط</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>النوع</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ملء الشاشة</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>الخروج من وضع ملء الشاشة</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>طباعة</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض الشرائح</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>تصدير</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>نسخ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>إعادة تسمية</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>حذف</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>تفضيل</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>عدم التفضيل</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>تدوير بإتجاه عقارب الساعة</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>ادر الصور بعكس إتجاه عقارب الساعة</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>أظهار نافذة التنقل</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>أخفاء نافذة التنقل</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>اجعل الصورة كخلفية</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>عرض في مدير الملفات</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>تم التصدير بنجاح</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>فشل التصدير</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>الإلبوم</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_ast.ts
+++ b/src/translations/deepin-album_ast.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ast_ES">
+<TS version="2.1" language="ast">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>El discu ta ocupáu y nun pue estrayese</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>D&apos;acuerdu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Poner a pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Colar d&apos;una presentación/pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar los atayos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar nel xestor de ficheros</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Aniciar una presentación</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Esbillar too</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Afitar como fondu de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Voltiar a la derecha</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Voltiar a la esquierda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Averar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Alloñar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Amestar a Favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitar de Favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum nuevu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomar un álbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Avanzar una páxina</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Retroceder una páxina</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Semeyes</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbumes</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Axustes</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Ensin nome</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Semeyes</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum nuevu</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Amestar a Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitar de Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>Unidá de %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Discu virxe de %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume cifráu de %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume de %1</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar a:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum nuevu</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar too</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>La importación tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Inorar</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>D&apos;acuerdu</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar en:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Semeyes</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Documentos</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Descargues</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Escritoriu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Vídeos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Música</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Esbillar otru direutoriu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatu:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Calidá:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>La esportación tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>La esportación falló</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Poner a pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Colar de la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Aniciar una presentación</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Voltiar a la derecha</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Voltiar a la esquierda</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Afitar como fondu de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar nel xestor de ficheros</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Averar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Alloñar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprentar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar los atayos</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Axustes</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Esbillar too</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Semeyes</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Vídeos</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Nun tienes permisu pa ver la imaxe</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Importóse&apos;l</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Información básica</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensiones</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Data de captura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Data de modificación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Detalles</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Apertura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Programa d&apos;esposición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Llonxitú focal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mou d&apos;esposición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiempu d&apos;esposición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Flax</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Compensación del flax</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Apertura máxima</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Espaciu de colores</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mou de midida</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance de blancos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Modelu de la lente</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importando…</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>La importación tuvo ésitu</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>La importación falló</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Ensin nome</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum nuevu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Discu del sistema</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papelera</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papelera</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar too</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>¿De xuru que quies desaniciar esti álbum?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Encaboxar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Resultaos de la busca</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Aniciar una presentación</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Nun hai resultaos</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitóse l&apos;álbum «%1»</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galería</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papelera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Preseos</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbumes</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Aniciar una presentación</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Esportar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum nuevu</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomar</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Posar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Reproducir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Colar</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation> díes</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation> díes</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>La esportación tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>La esportación falló</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Ver</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Poner a pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprentar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Aniciar una presentación</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Amestar al álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum nuevu</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Amestóse con ésitu a «%1»</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Esportar</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitar del álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Amestar a Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitar de Favoritos</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Voltiar a la derecha</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Voltiar a la esquierda</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Afitar como fondu de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar nel xestor de ficheros</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Información de la semeya</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Ver</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Poner a pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Imprentar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Aniciar una presentación</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Amestar al álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Álbum nuevu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Amestóse con ésitu a «%1»</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Esportar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Desaniciar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Quitar del álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Amestar a Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Quitar de Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Voltiar a la derecha</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Voltiar a la esquierda</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Afitar como fondu de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Amosar nel xestor de ficheros</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Restaurar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Información de la semeya</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">La esportación tuvo ésitu</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">La esportación falló</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Axustar a la ventana</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Amestar a Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitar de Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Información básica</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Data de captura</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Poner a pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Colar de la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprentar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Aniciar una presentación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Esportar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Desaniciar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Amestar a Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitar de Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Voltiar a la derecha</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Voltiar a la esquierda</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar la ventana de navegación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Anubrir la ventana de navegación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Afitar como fondu de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar nel xestor de ficheros</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>La esportación tuvo ésitu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>La esportación falló</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_az.ts
+++ b/src/translations/deepin-album_az.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Bütün şəkillər və videolar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>Disk məşğuldur, indi çıxarıla bilməz</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Tam ekran və ya slayd rejimindən çıxmaq</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Kömək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Qısayolları göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Fayl menecerində göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Slayd-şou</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Baxış</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Fotoşəkilləri ixrac edin</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Fotoşəkilləri/videoları idxal edin</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Hamısını seçmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Foto/video məlumatı</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Divar kağızı kimi təyin etmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Saat əqrəbi istiqamətinə döndərmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Saat əqrəbinin əksinə döndərmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Yaxınlaşdırmaq</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Uzaqlaşdırmaq</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Əvvəlki</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Növbəti</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Sevimlilər</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Sevimlilərdən çıxartmaq</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Yeni albom</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Albomun adını dəyişmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Yuxarı səhifələmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Aşağı səhifələmək</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Fotoşəkillər</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Albomlar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Sevimlilər</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Ekran şəkli</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Rəsm çəkin</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Adsız</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Kanal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Şəkillər</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Yeni albom</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Qovluqları idxal edin</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Albom</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Versiya:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Albom, videolara və şəkillərə baxmaq və onları idarə etmək üçün bir alətidir.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1, %2 altında buraxılı</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Yan paneli göstərmək</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Yan paneli gizlətmək</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Orijinal nisbət</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Dördbucaqlı eskizlər</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>İl</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>Ay</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Hamısı</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Axtarış</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Sevimlilər</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Sevimlilərdən çıxartmaq</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Döndər</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Nəticələr yoxdur</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 şəkil%1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Nəticələr yoxdur</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>Heç bir şəkil və ya video tapılmadı</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Ekran şəkli</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Rəsm çəkin</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(kopya)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1 sürücü</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Boş %1 disk</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1 şifrələnib</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>%1 həcm</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Siz bu faylı yerli diskdən silmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Siz bunu səbətdən bərpa edə bilərsiniz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>%1 faylı yerli diskdən silmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Siz onları səbətdən bərpa edə bilərsiniz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Bu faylı həmişəlik silmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Artıq onu bərpa edə bilməyəcəksiniz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>%1 faylı həmişəlik silmək istədiyinizə əminisiniz?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Artıq onları bərpa edə bilməyəcəksiniz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Buraya idxal etmək:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>İdxal</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Yeni albom</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Hamısını idxal etmək</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>1 elementi idxal et</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>%1 elementi idxal et</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Uğurla idxal olundu</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Nəticələr yoxdur</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Yüklənir...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Ötürmək</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>Fayl adı boş ola bilməz!</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Adı:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Burada saxlamaq:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Şəkillər</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Sənədlər</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Endirmələr</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>İş Masas</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Videolar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Musiqi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Başqa qovluqlar seçmək</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Formatı:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Keyfiyyəti:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Təsdiq et</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Uğurla ixrac olundu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>İxrac alınmadı</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Tam ekrandan çıxış</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Mətni çıxart</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Slayd-şou</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Adını dəyişmək</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Saat əqrəbi istiqamətinə döndərmək</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Saat əqrəbinin əksinə döndərmək</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Divar kağızı kimi təyin etmək</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Fayl menecerində göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Şəkil məlumatı</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Əvvəlki</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Növbəti</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Yaxınlaşdırmaq</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Uzaqlaşdırmaq</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Çap</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Şəkilə baxış</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Kömək</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Qısayolları göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Hamısını seçmək</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>Canlı mətn</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Hamısı</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Fotoşəkillər</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Videolar</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>Şəkil və ya video artıq mövcuddur</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>1 element seçildi (1 şəkil)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>1 element seçildi (1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>%1 element seçildi (%1 fotoşəkil)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>%1 element seçildi (%1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>%1 element seçildi (1 fotoşəkil, %2 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>%1 element seçildi (%2 fotoşəkil, 1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>%1 element seçildi (%2 şəkil, %3 video)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>İdxal</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>Bu şəkilə baxmağa icazəniz yoxdur</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>Şəkil faylı tapılmadı</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Şəkilləri və Videoları idxal edin</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>Və ya onları buraya atın</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Buraya idxal olundu:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 element</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 element</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Baza məlumatları</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>Fayl adı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Ölçüsü</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Ölçülər</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Növ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Çəkilmə tarixi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Dəyişdirilmə tarixi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Təfərrüatlar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Diafraqma</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Ekspozisiya proqramı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Fokus məsafəsi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Ekspozisiya rejimi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Ekspozisiya vaxtı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Flaş işığın tarazlaşdırılması</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Maks. diafraqma</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Rəng sahəsi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Ölçmə rejimi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Bəyazlıq balansı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Cihazın modeli</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Linza modeli</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>İdxal edilir...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation>İdxal edildi:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Uğurla idxal olundu</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>İdxal alınmadı</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Adsız</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Yeni albom</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Adı:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Təsdiq et</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>Heç bir şəkil və ya video tapılmadı</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Şəkilləri seç</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Uğurla idxal olundu</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">İdxal alınmadı</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Sistem diski</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>Fayl artıq mövcuddur, başqa ad seçin</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Səbət</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Albom</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>Fayl artıq mövcuddur, başqa ad seç</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Təsdiq et</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 şəkil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Səbət</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>Fayllar, onlarda göstərilən vaxt bitdikdən sonra birdəfəlik silinəcəkdir</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Hamısını silmək</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Seçilmişləri sil (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Seçilmişləri bərpa et (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Bu albomu silmək istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>1 şəkil tapıldı</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>%1 fotoşəkil tapıldı</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>1 video tapıldı</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>%1 video tapıldı</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>%1 element tapıldı</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Axtarış nəticələri</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Slayd-şou</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>Axtarış nəticəsi yoxdur</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>%1 albomu silindi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Qalareya</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Kolleksiya</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>İdxal</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Sevimlilər</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Səbət</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Qurğular</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Albomlar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Bir albom əlavə et</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Ekran şəkli</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Rəsm çəkin</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Slayd-şou</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>İxrac</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Yeni albom</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Adını dəyişmək</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Əvvəlki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Fasilə</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Oynatmaq</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Növbəti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Çıxış</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>günlər</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>gün</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>günlər</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>gün</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Uğurla ixrac olundu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>İxrac alınmadı</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Baxış</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Çap</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Slayd-şou</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Alboma əlavə etmək</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Yeni albom</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Buraya uğurla əlavə edildi: %1</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>İxrac</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Albomdan silmək</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Sevimlilər</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Sevimlilərdən çıxartmaq</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Saat əqrəbi istiqamətinə döndərmək</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Saat əqrəbinin əksinə döndərmək</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Divar kağızı kimi təyin etmək</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Fayl menecerində göstərmək</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Bərpa etmək</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Fotoşəkil məlumatları</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Video haqqında</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>Alboma qayıt</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Baxış</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Əvvəlki</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Növbəti</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Çap</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Orijinal ölçüsü</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Slayd-şou</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Pəncərə sığışdırmaq</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Alboma əlavə etmək</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Döndər</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Yeni albom</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Buraya uğurla əlavə edildi: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>İxrac</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopyalamaq</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Silmək</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Albomdan silmək</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Sevimlilər</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Sevimlilərdən çıxartmaq</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Saat əqrəbi istiqamətinə döndərmək</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Saat əqrəbinin əksinə döndərmək</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Divar kağızı kimi təyin etmək</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Fayl menecerində göstərmək</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Bərpa etmək</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Fotoşəkil məlumatları</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Video haqqında</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Uğurla ixrac olundu</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">İxrac alınmadı</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Alboma qayıt</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Əvvəlki</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Növbəti</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Orijinal ölçüsü</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Pəncərə sığışdırmaq</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Döndər</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Sevimlilər</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Sevimlilərdən çıxartmaq</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Mətni çıxart</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Baza məlumatları</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>Fayl adı</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Çəkilmə tarixi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Ölçüsü</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Müddəti</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Növ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Yol</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Kodek haqqında</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>Video CodecID</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Video CodeRate</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Nisbət</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Görüntü imkanı</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>Audio CodecID</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Audio CodeRate</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Səs rəqəmi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Kanallar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Sampling</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Tam ekrandan çıxış</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Çap</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Mətni çıxart</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Slayd-şou</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>İxrac</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Adını dəyişmək</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Sevimlilər</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Sevimlilərdən çıxartmaq</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Saat əqrəbi istiqamətinə döndərmək</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Saat əqrəbinin əksinə döndərmək</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Naviqasiya pəncərəsini göstərmək</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Naviqasiya pəncərəsini gizlətmək</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Divar kağızı kimi təyin etmək</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Fayl menecerində göstərmək</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Şəkil məlumatı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Uğurla ixrac olundu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>İxrac alınmadı</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Albom, videolara və şəkillərə baxmaq və onları idarə etmək üçün bir alətidir.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Albom</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 element</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 element</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Bütün şəkillər və videolar</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Uğurla idxal olundu</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">İdxal alınmadı</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_bo.ts
+++ b/src/translations/deepin-album_bo.ts
@@ -1,812 +1,812 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="bo_CN">
+<TS version="2.1" language="bo">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་དང་བརྙན་ཆ་ཚང་།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>སྡུད་སྡེར་གྱི་ཡིག་ཆ་གཞན་གྱིས་བཟུང་ཡོད་པས། ཕྱིར་འདོན་ཐབས་བྲལ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡོལ་གང་ནས་ཕྱིར་འཐོན།/སྒྲོན་བརྙན་སྟོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>རོགས་རམ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>མྱུར་མཐེབ་མངོན་སྟོན།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡིག་ཆ་དོ་དམ་བྱེད་ཆས་ཁྲོད་མངོན་སྟོན་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲོན་བརྙན་སྟོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>ལྟ་བཤེར།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཕྱིར་འདོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་དང་བརྙན་ནང་དུ་འདྲེན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཆ་ཚང་འདེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་དང་བརྙན་གྱི་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>རྒྱབ་ཤོག་ཏུ་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>གཡས་སྐོར་བརྒྱབ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>གཡོན་སྐོར་བརྒྱབ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཆེ་རུ་གཏོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཆུང་དུ་གཏོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་འོག་མ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར་བྱེད་པ་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་གསར་འཛུགས།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་མིང་བསྐྱར་དུ་འདོགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>བརྙན་ཡོལ་གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>བརྙན་ཡོལ་རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>པར།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>ངའི་བསྡུ་ཉར།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>བཪྙན་ཡོལ་པར་ལེན།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>རིས་གདན།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>མིང་བཏགས་མེད་པའི་པར་ཁུག</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་རིས།</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་གསར་འཛུགས།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡིག་ཁུག་ནང་འདྲེན་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་དེབ་ནི་འདྲ་པར་དང་བཪྙན་པར་ལྟ་བ་དང་ལེགས་སྒྲིག་བྱེད་པའི་དོ་དམ་ཡོ་བྱད་ཞིག་རེད།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1གཞིར་བཟུང་%2གྲོས་ཡིག་འགྲེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>འགྲམ་ཟུར་བྱང་བུ་འགྲེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>འགྲམ་ཟུར་བྱང་བུ་ཟུམ་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>རྣམ་གྲངས་ཆ་ཚང་།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར་བྱེད་པ་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>སུབ་པ།</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་པར་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་བརྙན་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>འབྲས་བུ་མེད།</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་པར་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་བརྙན་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>འབྲས་བུ་མེད།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་དང་བརྙན་གྱི་ཡིག་ཆ་མ་རྙེད།</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>བཪྙན་ཡོལ་པར་ལེན།</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>རིས་གདན།</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(བུ་དེབ་)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་པར་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་བརྙན་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/ལོའི་ཟླ་%2/ཚེས་%3ཉིན།</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>སྐུལ་ཆས་%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>འོད་སྡེར་སྟོང་པ་%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>གསང་སྡོམ་%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>བམ་པོ་%1</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>ཡིག་ཆ་འདི་བསུབ་རྒྱུ་ཡིན་པ་ཁྱོད་ཀྱིས་གཏན་ཁེལ་ལམ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>ཁྱེད་ཀྱིས་“ཉེ་འཆར་སུབ་པ་”ནང་ནས་བསྐྱར་གསོ་བྱེད་ཆོག</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>རང་ས་ནས་ཡིག་ཆ་%1འདི་བསུབ་རྒྱུ་ཡིན་པ་ཁྱོད་ཀྱིས་གཏན་ཁེལ་ལམ།</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>ཁྱེད་ཀྱིས་“ཉེ་འཆར་སུབ་པ་”ནང་ནས་བསྐྱར་གསོ་བྱེད་ཆོག</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>ཡིག་ཆ་འདི་བསུབ་རྒྱུ་ཡིན་པ་ཁྱོད་ཀྱིས་གཏན་ཁེལ་ལམ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>སུབ་རྗེས་བསྐྱར་གསོ་བྱེད་ཐབས་མེད།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>ཡིག་ཆ་%1འདི་བསུབ་རྒྱུ་ཡིན་པ་ཁྱོད་ཀྱིས་གཏན་ཁེལ་ལམ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>སུབ་རྗེས་བསྐྱར་གསོ་བྱེད་ཐབས་མེད།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>སུབ་པ།</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་པར་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་བརྙན་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>ནང་འདྲེན་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>ནང་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་གསར་འཛུགས།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>ཚང་མ་ནང་འདྲེན་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>ནང་འདྲེན་ལེགས་གྲུབ་བྱུང་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>འབྲས་བུ་མེད།</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>སྣོན་འཇུག་བྱེད་བཞིན་ཡོད་པས། ཏོག་ཙམ་སྒུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>སྣང་མེད་གཏོང་།</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ཆོག</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡིག་ཆའི་མིང་།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>ཉར་ཚགས་བྱེད།</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>པར་རིས།</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>ཡིག་ཆ།</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>ཕབ་ལེན།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>ཅོག་ངོས།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>བརྙན་འཕྲིན།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>རོལ་མོ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>དཀར་ཆག་གཞན་ཞིག་འདེམས།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡིག་ཆའི་རྣམ་གཞག</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གྱི་སྤུས་ཚད།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱིར་འདྲེན་ལེགས་གྲུབ་བྱུང་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱིར་འདྲེན་མ་ཐུབ།</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡོལ་གང་ལས་ཕྱིར་འཐེན།</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>སྒྲོན་བརྙན་སྟོན་པ།</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>མིང་ཡང་བསྐྱར་འདོགས་པ།</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>པར་སློག</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>སུབ་པ།</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>གཡས་སྐོར་བརྒྱབ།</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>གཡོན་སྐོར་བརྒྱབ།</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>རྒྱབ་ཤོག་ཏུ་བྱེད་པ།</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>ཡིག་ཆ་དོ་དམ་བྱེད་ཆས་ཁྲོད་མངོན་སྟོན་བྱེད།</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>པར་གྱི་ཆ་འཕྲིན།</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>པར་གོང་མ།</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>པར་འོག་མ།</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>པར་ཆེ་རུ་གཏོང་བ།</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>པར་ཆུང་དུ་གཏོང་བ།</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་འདེབས།</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>རོགས་རམ།</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>མྱུར་མཐེབ་མངོན་སྟོན།</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲིག་འགོད།</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཆ་ཚང་འདེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>རྣམ་གྲངས་ཆ་ཚང་།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>པར།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>བརྙན་འཕྲིན།</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>པར་དང་བརྙན་ཡོད་པ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་པར་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་བརྙན་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>ནང་འདྲེན།</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོད་ལ་པར་རིས་འདི་ལྟ་བཤེར་བྱེད་དབང་མེད།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་དང་བརྙན་ནང་དུ་འདྲེན་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱེད་ཀྱིས་པར་དང་བརྙན་འདིར་འདྲུད་ཀྱང་ཆོག</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>་་་་་དུ་ནང་འདྲེན་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>གཞི་རྩའི་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གྱི་རིང་ཐུང་།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གྱི་རིགས།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་རྒྱག་པའི་ཚེས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>ཚེས་གྲངས་བཟོ་བཅོས།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>ཞིབ་ཕྲའི་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>འོད་ཁུང་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>འོད་ཕོག་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>མདོ་ཐག</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISOའོད་ལེན་ཚད།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>འོད་ཕོག་པའི་དཔེ་རྣམ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>འོད་ཕོག་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>འཁྱུག་སྒྲོན།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>འཁྱུག་སྒྲོན་ཁ་གསབ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>འོད་ཁུང་གི་གྲངས་ཐང་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>ཚོས་གཞིའི་བར་སྟོང་།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>འོད་འཇལ་དཔེ་རྣམ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>དཀར་སྙོམས།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཆས་ཀྱི་ཤེལ་སྒོའི་བཟོ་དབྱིབས།</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ནང་དུ་འདྲེན་བཞིན་ཡོད་པས། ཏོག་ཙམ་སྒུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/ལོའི་ཟླ་%2/ཚེས་%3ཉིན། {1/%2?}</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>ནང་འདྲེན་ལེགས་གྲུབ་བྱུང་བ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>ནང་དུ་འདྲེན་མ་ཐུབ།</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/ལོའི་ཟླ་%2/ཚེས་%3ཉིན། {1/%2?}</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>མིང་བཏགས་མེད་པའི་པར་ཁུག</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་གསར་འཛུགས།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡིག་ཆའི་མིང་།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་དང་བརྙན་གྱི་ཡིག་ཆ་མ་རྙེད།</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>རྒྱུད་ཁོངས་སྡེར།</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/ལོའི་ཟླ་%2/ཚེས་%3ཉིན། {1/%2/%3 %4:%5?}</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/ལོའི་ཟླ་%2/ཚེས་%3ཉིན། {1?}</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/ལོའི་ཟླ་%2/ཚེས་%3ཉིན། {1/%2?}</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/ལོའི་ཟླ་%2/ཚེས་%3ཉིན།</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>ཉེ་ཆར་བསུབས་པ།</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་པར་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་བརྙན་1།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>ཉེ་ཆར་བསུབས་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡིག་ཆ་མ་བསུབ་གོང་ཉིན་གྲངས་ལྷག་མ་མཐོང་ཐུབ། དེ་རྗེས་རྦད་དེ་བསུབ་པ་ཡིན།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>ཆ་ཚང་སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་འདི་བསུབ་རྒྱུ་ཡིན་པ་ཁྱོད་ཀྱིས་གཏན་ཁེལ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>སུབ་པ།</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་པར་1རྙེད་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>ཁྱོན་བརྙན་1རྙེད་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>བཙལ་འབྲས།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲོན་བརྙན་སྟོན་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>བཙལ་འབྲས་མེད།</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་%1བསུབས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་མཛོད།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>ནང་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>ངའི་བསྡུ་ཉར།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>ཉེ་ཆར་བསུབས་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>བཪྙན་ཡོལ་པར་ལེན།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཆས།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>རིས་གདན།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲོན་བརྙན་སྟོན་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་གསར་འཛུགས།</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>མིང་ཡང་བསྐྱར་འདོགས་པ།</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>མཚམས་འཇོག་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>གཏོང་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་འོག་མ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱིར་འཐོན།</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>ཉིན།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>ཉིན།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,393 +1481,507 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱིར་འདྲེན་ལེགས་གྲུབ་བྱུང་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱིར་འདྲེན་མ་ཐུབ།</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>ལྟ་བཤེར།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་འདེབས།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲོན་བརྙན་སྟོན་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་ནང་དུ་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་གསར་འཛུགས།</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation> “%1”ནང་སྣོན་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>པར་སློག</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག་ལས་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར་བྱེད་པ་འདོར་བ།</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>གཡས་སྐོར་བརྒྱབ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>གཡོན་སྐོར་བརྒྱབ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>རྒྱབ་ཤོག་ཏུ་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡིག་ཆ་དོ་དམ་བྱེད་ཆས་ཁྲོད་མངོན་སྟོན་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>སོར་ཆུད།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གྱི་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>བརྙན་གྱི་ཆ་འཕྲིན།</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>ལྟ་བཤེར།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>ཡོལ་གང་།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>པར་འདེབས།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>སྒྲོན་བརྙན་སྟོན་པ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>པར་ཁུག་ནང་དུ་སྣོན་པ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>པར་ཁུག་གསར་འཛུགས།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation> “%1”ནང་སྣོན་ཐུབ་པ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>ཕྱིར་འདྲེན།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>པར་སློག</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>སུབ་པ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>པར་ཁུག་ལས་སྤོ་བ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>བསྡུ་ཉར།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>བསྡུ་ཉར་བྱེད་པ་འདོར་བ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>གཡས་སྐོར་བརྒྱབ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>གཡོན་སྐོར་བརྒྱབ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>རྒྱབ་ཤོག་ཏུ་བྱེད་པ།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>ཡིག་ཆ་དོ་དམ་བྱེད་ཆས་ཁྲོད་མངོན་སྟོན་བྱེད།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>སོར་ཆུད།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>པར་གྱི་ཆ་འཕྲིན།</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>བརྙན་གྱི་ཆ་འཕྲིན།</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">ཕྱིར་འདྲེན་ལེགས་གྲུབ་བྱུང་བ།</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">ཕྱིར་འདྲེན་མ་ཐུབ།</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་འོག་མ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒེའུ་ཁུང་དང་འཚམ་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར་བྱེད་པ་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>སུབ་པ།</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>གཞི་རྩའི་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་རྒྱག་པའི་ཚེས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>དུས་ཚོད་རིང་ཐུང་།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གྱི་རིགས།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡིག་ཆའི་འགྲོ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>རིམ་སྒྲིག་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>བརྙན་འཕྲིན་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>བརྙན་ཨང་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>བརྙན་གྱི་འཁོར་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>མངོན་ཚད།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>འབྱེད་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>རིམ་པ་སྒྲིག་པའི་དཔེ།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>རིམ་པ་སྒྲིག་ཚད།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲ་ཟློས་གྲངས་གནས།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲ་ལམ་གྱི་ཁ་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>དཔེ་དབྱིབས་བསྡུ་གྲངས།</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡོལ་གང་ལས་ཕྱིར་འཐེན།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་འདེབས།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>སྒྲོན་བརྙན་སྟོན་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>མིང་ཡང་བསྐྱར་འདོགས་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>བསྡུ་ཉར་བྱེད་པ་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>གཡས་སྐོར་བརྒྱབ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>གཡོན་སྐོར་བརྒྱབ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱོགས་སྟོན་སྒེའུ་ཁུང་མངོན་སྟོན་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱོགས་སྟོན་སྒེའུ་ཁུང་ཡིབ་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>རྒྱབ་ཤོག་ཏུ་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ཡིག་ཆ་དོ་དམ་བྱེད་ཆས་ཁྲོད་མངོན་སྟོན་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་གྱི་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱིར་འདྲེན་ལེགས་གྲུབ་བྱུང་བ།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>ཕྱིར་འདྲེན་མ་ཐུབ།</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་དེབ་ནི་འདྲ་པར་དང་བཪྙན་པར་ལྟ་བ་དང་ལེགས་སྒྲིག་བྱེད་པའི་དོ་དམ་ཡོ་བྱད་ཞིག་རེད།</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་ཁུག</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/ལོའི་ཟླ་%2/ཚེས་%3ཉིན། {1?}</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>པར་དང་བརྙན་ཆ་ཚང་།</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_br.ts
+++ b/src/translations/deepin-album_br.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="br_FR">
+<TS version="2.1" language="br">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Ac&apos;hubet eo an disk, n&apos;heller ket strinkañ anezhañ er-maez</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Mat eo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuitaat ar skramm-leun/diaporama</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Skoazell</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Diskouez ar berradurioù</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Diskouez er merer restroù</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Gweled</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Diuzañ pep-tra</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Eilañ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Termeniñ evel paper-moger</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Treiñ er memes tu hag an horolaj</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Treiñ en tu enep eus an horolaj</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoumañ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Dizoumañ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Kent</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Da-heul</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Sined</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Disinedet</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom nevez</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Adenvel an albom</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Pajenn gent</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Pajenn war-draoñ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoioù</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albomoù</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Arventennoù</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Sinedoù</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Chomet dizanv</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Skeudennoù</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom nevez</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Sined</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Disinedet</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Lenner</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk %1 goullo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Enkriptet</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Live-son</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Emporzhiañ davet:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Emporzhiañ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom nevez</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Emporzhiañ pep-tra</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Emporzhiet gant berzh</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Na ober van</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Mat eo</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Anv:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Enrollañ e-barzh:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Skeudennoù</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Teuliadoù</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Pellgargadennoù</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Burev</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Videoioù</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Sonerezh</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Diuzañ ar c&apos;havlec&apos;hioù</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Furmad:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kalite:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Ezporzhiet gant berzh</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Ezporzhiañ c&apos;hwitet</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuitaat ar skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Adenvel</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Eilañ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Treiñ er memes tu hag an horolaj</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Treiñ en tu enep eus an horolaj</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Termeniñ evel paper-moger</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Diskouez er merer restroù</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Kent</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Da-heul</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoumañ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Dizoumañ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Moullañ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Skoazell</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Diskouez ar berradurioù</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Arventennoù</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Diuzañ pep-tra</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoioù</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Videoioù</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Emporzhiañ</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>N&apos;hoc&apos;h ket aotreet da welet ar skeudenn</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Emporzhiet e-barzh</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Titouroù diazez</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Mentoù</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Doare</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Deiziad an dapadenn</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Deiziad ar c&apos;hemm</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Munudoù</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Digeriñ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program an dapadenn</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Hirded ar fokal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mod tapadenn</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Padelezh an dapadenn</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Kempouezañ flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Digoret d&apos;ar maksimom</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Spas al livioù</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mod muzuliañ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Balañs al livioù gwenn</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Model lentilh</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Oc&apos;h emporzhiañ...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Emporzhiet gant berzh</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Emporzhiañ c&apos;hwitet</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Chomet dizanv</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom nevez</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Anv:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk sistem</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Pod-lastez</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Pod-lastez</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel pep-tra</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Ha fellout a ra deoc&apos;h dilemel an albom-mañ?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Disoc&apos;hoù an enklask</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Disoc&apos;h ebet d&apos;an enklask</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom “%1” dilamet</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Katalog</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Emporzhiañ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Sinedoù</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Pod-lastez</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Aparailh</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albomoù</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Ezporzhiañ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom nevez</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Adenvel</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Kent</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Ehan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Lenn</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Da-heul</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuitat</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>devezhioù</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>devezhioù</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Ezporzhiet gant berzh</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ezporzhiañ c&apos;hwitet</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Gweled</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Skramm-leun</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Moullañ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouzhpennañ d&apos;an albom</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom nevez</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Ouzhpennet gant berzh da &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Ezporzhiañ</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Eilañ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel diwar an albom</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Sined</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Disinedet</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Treiñ er memes tu hag an horolaj</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Treiñ en tu enep eus an horolaj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Termeniñ evel paper-moger</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Diskouez er merer restroù</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Adsevel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Titouroù ar skeudenn</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Gweled</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Skramm-leun</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Moullañ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Diaporama</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Ouzhpennañ d&apos;an albom</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Albom nevez</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Ouzhpennet gant berzh da &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Ezporzhiañ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Eilañ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Dilemel</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Dilemel diwar an albom</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Sined</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Disinedet</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Treiñ er memes tu hag an horolaj</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Treiñ en tu enep eus an horolaj</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Termeniñ evel paper-moger</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Diskouez er merer restroù</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Adsevel</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Titouroù ar skeudenn</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Ezporzhiet gant berzh</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Ezporzhiañ c&apos;hwitet</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Kent</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Da-heul</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Keidañ d&apos;ar prenestr</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Sined</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Disinedet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Titouroù diazez</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Deiziad an dapadenn</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Doare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Skramm-leun</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuitaat ar skramm-leun</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Moullañ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Ezporzhiañ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Eilañ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Adenvel</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dilemel</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Sined</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Disinedet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Treiñ er memes tu hag an horolaj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Treiñ en tu enep eus an horolaj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Diskouez ar prenestr merdeiñ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuzhat prenestr ar merdeiñ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Termeniñ evel paper-moger</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Diskouez er merer restroù</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Ezporzhiet gant berzh</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Ezporzhiañ c&apos;hwitet</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albom</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_ca.ts
+++ b/src/translations/deepin-album_ca.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Totes les fotografies i vídeos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>El disc està ocupat. No es pot expulsar ara.</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Surt de la pantalla completa / presentació</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Mostra les dreceres</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Mostra-ho al gestor de fitxers.</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Presentació</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Visualització</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Exporta fotografies</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Importa fotografies / vídeos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Selecciona-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Informació de la fotografia o vídeo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Estableix com a fons de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Gira-la a la dreta</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Gira-la a l&apos;esquerra</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Amplia</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Redueix</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Següent</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Preferits</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Elimina dels preferits</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Àlbum nou</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Canvia el nom de l&apos;àlbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Pàgina amunt</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Pàgina avall</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Fotografies</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Àlbums</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Paràmetres</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Preferits</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Captura de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Càmera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Dibuix</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Sense nom</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Canal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Imatges</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Àlbum nou</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Importa carpetes</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Àlbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Versió:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>L&apos;Àlbum és una eina de gestió elegant per veure i organitzar fotografies i vídeos.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 publicat amb la llicència %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Mostra el plafó lateral</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Amaga el plafó lateral</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Ràtio original</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Miniatures quadrades</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Tot</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Preferits</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Elimina dels preferits</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Gira</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 fotografia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 fotografies</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Sense resultats</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 fotografia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 fotografies</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Sense resultats</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>No s&apos;ha trobat cap fotografia ni vídeo.</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Captura de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Càmera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Dibuix</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(copia)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 fotografia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 fotografies</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 fotografia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 fotografies</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%3/%2/%1</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>Unitat: %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Disc en blanc: %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>Encriptat: %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>Volum: %1</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Segur que voleu eliminar aquest fitxer localment?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>El podreu restaurar des de la paperera.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>Segur que voleu eliminar %1 fitxers localment?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Els podreu restaurar des de la paperera.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Segur que voleu eliminar permanentment aquest fitxer?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Ja no el podreu restaurar.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Segur que voleu eliminar permanentment %1 fitxers?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Ja no els podreu restaurar.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 fotografia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 fotografies</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Importa-ho a:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Importa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Àlbum nou</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Importa-ho tot</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>Importa 1 element</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>Importa %1 elements</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>S&apos;ha importat correctament.</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Sense resultats</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Es carrega...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Ignora-ho</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>El nom del fitxer no pot estar en blanc.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>D&apos;acord</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Nom:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Desa-ho a:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Imatges</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Documents</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Baixades</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Escriptori</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Seleccioneu altres directoris</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Qualitat:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Confirmeu-ho</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>S&apos;ha exportat correctament.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Ha fallat exportar-ho.</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Surt de la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Extreu-ne el text</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Presentació</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Canvia&apos;n el nom</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Gira-la a la dreta</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Gira-la a l&apos;esquerra</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Estableix com a fons de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Mostra-ho al gestor de fitxers.</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Informació de la imatge</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Següent</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Amplia</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Redueix</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Obre</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Imprimeix</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Visualització de la imatge</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Mostra les dreceres</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Paràmetres</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Selecciona-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>Text viu</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Tot</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Fotografies</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Vídeos</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>La fotografia o vídeo ja existeix.</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation>El format del fitxer no s&apos;admet.</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>1 element seleccionat (1 foto)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>1 element seleccionat (1 vídeo)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>1% elements seleccionats (1% fotos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>1% elements seleccionats (1% vídeos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation>%1 element seleccionat (1 foto, 1 vídeo)</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>%1 elements seleccionats (1 foto, %2 vídeos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>%1 elements seleccionats (%2 fotos, 1 vídeo)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>%1 elements seleccionats (%2 fotos, %3 vídeos)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 fotografia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 fotografies</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Importa</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>No teniu permís per veure la imatge.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>No s&apos;ha trobat el fitxer d&apos;imatge.</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Importa fotografies i vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>o arrossegueu-ne aquí.</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Importat el</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 element</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 elements</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Informació bàsica</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>Nom del fitxer</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Dimensions</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Data de captura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Data de modificació</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Detalls</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Obertura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Programa d&apos;exposició</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Distància focal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Mode d&apos;exposició</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Hora d&apos;exposició</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Flaix</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Compensació del flaix</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Obertura màxima</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Espai de color</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Sistema de mesura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Equilibri de blancs</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Model del dispositiu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Model de la lent</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>S&apos;importa...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation>Importat:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1 / %2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>S&apos;ha importat correctament.</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>Ha fallat importar-ho.</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1 / %2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Sense nom</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Àlbum nou</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Nom:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Confirmeu-ho</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>No s&apos;ha trobat cap fotografia ni vídeo.</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Seleccioneu imatges</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">S&apos;ha importat correctament.</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Ha fallat importar-ho.</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Disc de sistema</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>El fitxer ja existeix, useu un altre nom.</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%3/%2/%1 %4.%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1 / %2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%3/%2/%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Paperera</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Àlbum</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>El fitxer ja existeix, useu un altre nom.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Confirmeu-ho</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 fotografia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 fotografies</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Paperera</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>Els fitxers s&apos;eliminaran permanentment després dels dies que s&apos;hi mostren.</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Elimina-ho tot</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Elimina la selecció (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Restaura la selecció (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Segur que voleu eliminar aquest àlbum?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>S&apos;ha trobat 1 fotografia.</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>%1 fotografies trobades</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>S&apos;ha trobat 1 vídeo.</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>%1 vídeos trobats</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>%1 elements trobats</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Resultats de la cerca</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Presentació</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>No hi ha cap resultat de la cerca.</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>S&apos;ha eliminat l&apos;àlbum %1.</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Galeria</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Col·lecció</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Importa</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Preferits</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Paperera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Dispositiu</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Àlbums</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Afegeix un àlbum</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Captura de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Càmera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Dibuix</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Presentació</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Exporta-ho</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Àlbum nou</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Canvia&apos;n el nom</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Pausa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Reprodueix</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Següent</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Surt</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>dies</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>dia</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dies</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>dia</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>S&apos;ha exportat correctament.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Ha fallat exportar-ho.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Visualització</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Imprimeix</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Presentació</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Afegeix a l&apos;àlbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Àlbum nou</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>S&apos;ha afegit correctament a %1.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Exporta-ho</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Elimina de l&apos;àlbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Afegeix als preferits</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Elimina dels preferits</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Gira-la a la dreta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Gira-la a l&apos;esquerra</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Estableix com a fons de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Mostra-ho al gestor de fitxers.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Restaura</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Informació de la fotografia</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Informació del vídeo</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>Torna a l&apos;Àlbum</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Visualització</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Anterior</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Següent</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Imprimeix</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Mida original</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Presentació</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Ajusta-ho a la finestra</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Afegeix a l&apos;àlbum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Gira</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Àlbum nou</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>S&apos;ha afegit correctament a %1.</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exporta-ho</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copia</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Elimina</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Elimina de l&apos;àlbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Preferits</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Elimina dels preferits</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Gira-la a la dreta</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Gira-la a l&apos;esquerra</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Estableix com a fons de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Mostra-ho al gestor de fitxers.</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Restaura</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Informació de la fotografia</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Informació del vídeo</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">S&apos;ha exportat correctament.</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Ha fallat exportar-ho.</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Torna a l&apos;Àlbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Anterior</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Següent</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Mida original</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Ajusta-ho a la finestra</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Gira</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Preferits</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Elimina dels preferits</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Extreu-ne el text</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Informació bàsica</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>Nom del fitxer</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Data de captura</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Durada</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Camí</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Informació del còdec</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>ID del còdec de vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Velocitat del codi de vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Proporció</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Resolució</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>ID del còdec d&apos;àudio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Velocitat del codi d&apos;àudio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Dígit d&apos;àudio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Canals</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Exemple</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Surt de la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Imprimeix</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Extreu-ne el text</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Presentació</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Exporta-ho</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Canvia&apos;n el nom</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Afegeix als preferits</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Elimina dels preferits</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Gira-la a la dreta</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Gira-la a l&apos;esquerra</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Mostra la finestra de navegació</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Amaga la finestra de navegació</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Estableix com a fons de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Mostra-ho al gestor de fitxers.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Informació de la imatge</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>S&apos;ha exportat correctament.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>Ha fallat exportar-ho.</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>L&apos;Àlbum és una eina de gestió elegant per veure i organitzar fotografies i vídeos.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Àlbum</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 elements</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 element</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Totes les fotografies i vídeos</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">S&apos;ha importat correctament.</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Ha fallat importar-ho.</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_cs.ts
+++ b/src/translations/deepin-album_cs.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="cs">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Všechny fotky a videa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>Jednotka je zaneprázdněná. Nyní ji nelze vysunout</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Opustit celou obrazovku/promítání</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Zobrazit klávesové zkratky</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Zobrazit ve správci souborů</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Promítání</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Pohled</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Exportovat fotky</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Importovat fotky/videa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Kopírovat</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Informace o fotce/videu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Nastavit jako pozadí plochy</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Otočit doprava</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Otočit doleva</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Přiblížit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Oddálit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Předchozí</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Přidat do oblíbených</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Odebrat z oblíbených</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Nové album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Přejmenovat album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>O stránku výše</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>O stránku níže</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Fotky</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Alba</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Oblíbené</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Zachycení obsahu obrazovky</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Kreslit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Nepojmenované</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Kanál</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Obrázky</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Nové album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Importovat složky</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Verze:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"/>
+        <translation>Album je šikovný správce pro zobrazování a uspořádávání fotek a videí</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 je vydáno pod %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Ukázat postranní panel</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Skrýt postranní panel</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
-        <translation type="unfinished"/>
+        <translation>Původní velikost</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
-        <translation type="unfinished"/>
+        <translation>Čtvercové náhledy</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Vše</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Hledat</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Přidat do oblíbených</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Odebrat z oblíbených</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Otočit</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 fotka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 fotek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 videí</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Nic nenalezeno</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 fotka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 fotek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 videí</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Nic nenalezeno</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>Nenalezeny žádné fotky či videa</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Zachycení obsahu obrazovky</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Kreslit</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(kopie)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 fotka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 fotek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 videí</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 fotka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 fotek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1 jednotka</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Prázdný %1 disk</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1 zašifrováno</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>%1 svazek</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Opravdu chcete tento soubor lokálně smazat?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Je možné ho obnovit z koše</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
-        <translation>Opravdu chcete lokálně smazat %1 souborů?</translation>
+        <translation>Opravdu chcete místně smazat %1 souborů?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Je možné je obnovit z koše</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Opravdu chcete tento soubor natrvalo smazat?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Už ho není možné obnovit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Opravdu chcete natrvalo smazat %1 souborů?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Už je není možné obnovit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 fotka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 fotek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 videí</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Importovat do:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Nové album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Naimportovat vše</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
-        <translation type="unfinished"/>
+        <translation>Zavést 1 položku</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
-        <translation type="unfinished"/>
+        <translation>Zavést %1 položek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Úspěšně naimportováno</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Nic nenalezeno</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Načítání…</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Ignorovat</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>Název souboru nemůže být prázdný!</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Název:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Uložit do:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Obrázky</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Dokumenty</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Stažené</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Plocha</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Videa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Hudba</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Vybrat jiné složky</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Formát:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Kvalita:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Potvrdit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Úspěšně exportováno</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Export se nezdařil</translation>
     </message>
@@ -688,141 +690,141 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Opustit celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Vytáhnout text</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Promítání</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Přejmenovat</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Kopírovat</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Otočit doprava</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Otočit doleva</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Nastavit jako pozadí plochy</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Zobrazit ve správci souborů</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Informace o obrázku</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Předchozí</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Přiblížit</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Oddálit</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
-        <translation type="unfinished"/>
+        <translation>Otevřít</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Tisk</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
-        <translation type="unfinished"/>
+        <translation>Zobrazení obrázků</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Zobrazit klávesové zkratky</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
-        <translation type="unfinished"/>
+        <translation>Živý text</translation>
     </message>
 </context>
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Vše</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Fotky</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Videa</translation>
     </message>
@@ -830,70 +832,81 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>Fotka/video už existuje</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
-        <translation type="unfinished"/>
+        <translation>Vybrána 1 položka (1 obrázek)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
-        <translation type="unfinished"/>
+        <translation>Vybrána 1 položka (1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
-        <translation type="unfinished"/>
+        <translation>Vybráno %1 položek (%1 obrázků)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
-        <translation type="unfinished"/>
+        <translation>Vybráno %1 položek (%1 videí)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
-        <translation type="unfinished"/>
+        <translation>Vybráno %1 položek (1 obrázek, %2 videí)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
-        <translation type="unfinished"/>
+        <translation>Vybráno %1 položek (%2 obrázků, 1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
-        <translation type="unfinished"/>
+        <translation>Vybráno %1 položek (%2 obrázků, %3 videí)</translation>
     </message>
 </context>
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 fotka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 fotek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 videí</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
@@ -901,25 +914,25 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>Nemáte oprávnění zobrazit obrázek</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
-        <translation type="unfinished"/>
+        <translation>Nebyly nalezeny žádné obrazové soubory</translation>
     </message>
 </context>
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Importovat fotky a videa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>Nebo je přetáhněte sem</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation>Importováno </translation>
+        <translation>Zavedeno </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 položka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 položek</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Základní údaje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
-        <translation type="unfinished"/>
+        <translation>Název souboru</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Rozměry</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Datum pořízení</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Změněno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Podrobnosti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Clona</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Expoziční program</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Ohnisková vzdálenost</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>Citlivost ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Režim expozice</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Expoziční čas</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Blesk</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Vyrovnání blesku</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Nejvyšší clona</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Barevný prostor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Režim měření</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Vyvážení bílé</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
-        <translation type="unfinished"/>
+        <translation>Model zařízení</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Model objektivu</translation>
     </message>
@@ -1058,41 +1071,36 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation>Importování…</translation>
+        <translation>Zavádí se…</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation>Zavedeno:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Úspěšně naimportováno</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation>Import se nezdařil</translation>
+        <translation>Nepodařilo se zavést</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Nepojmenované</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Nové album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Název:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Potvrdit</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>Nenalezeny žádné fotky či videa</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Vybrat obrázky</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Úspěšně naimportováno</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Import se nezdařil</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Systémový disk</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>Soubor již existuje, použijte jiný název</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"/>
+        <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"/>
+        <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Koš</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>Soubor již existuje, použijte jiný název</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Potvrdit</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 fotka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 fotka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Koš</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>Po uplynutí na nich zobrazeného počtu dnů budou soubory nadobro smazány</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Smazat vše</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Smazat vybrané (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Obnovit vybrané (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Opravdu chcete toto album smazat?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>Nalezena 1 fotka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>Nalezeno %1 fotek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>Nalezeno 1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>Nalezeno %1 videí</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>Nalezeno %1 položek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Výsledky hledání</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Promítání</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>Nic nenalezeno</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>Album „%1“ odstraněno</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Galerie</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Sbírka</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Oblíbené</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Koš</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Zařízení</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Alba</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
-        <translation type="unfinished"/>
+        <translation>Přidat album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Zachycení obsahu obrazovky</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Kreslit</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Promítání</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Nové album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Přejmenovat</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Předchozí</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Pozastavit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Přehrát</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Ukončit</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>dní</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>den</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dní</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>den</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Úspěšně exportováno</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Export se nezdařil</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Pohled</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Tisk</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Promítání</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Přidat do alba</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Nové album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Úspěšně přidáno do „%1“</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Kopírovat</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Odstranit z alba</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Přidat do oblíbených</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Odebrat z oblíbených</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Otočit doprava</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Otočit doleva</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Nastavit jako pozadí plochy</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Zobrazit ve správci souborů</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Obnovit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Informace o fotce</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Informace o videu</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation type="unfinished"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Pohled</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Předchozí</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Další</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Tisk</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Původní velikost</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Promítání</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Přizpůsobit oknu</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Přidat do alba</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Otočit</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Nové album</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Úspěšně přidáno do „%1“</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Export</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Zkopírovat</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Smazat</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Odstranit z alba</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Přidat do oblíbených</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Odebrat z oblíbených</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Otočit doprava</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Otočit doleva</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Nastavit jako pozadí plochy</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Zobrazit ve správci souborů</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Obnovit</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Informace o fotce</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Informace o videu</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Úspěšně exportováno</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Nepodařilo se vyvést</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Zpět do alba</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Předchozí</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Další</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Původní velikost</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Přizpůsobit oknu</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Otočit</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Přidat do oblíbených</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Odebrat z oblíbených</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Vytáhnout text</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Základní údaje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
-        <translation type="unfinished"/>
+        <translation>Název souboru</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Datum pořízení</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Trvání</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Popis umístění</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Informace o kodeku</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>Identifikátor kodeku videa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Bitová rychlost kodeku videa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>SN/S</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Proporce</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Rozlišení</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>Identifikátor kodeku zvuku</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Bitová rychlost kodeku zvuku</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Zvuk digit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Kanály</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Frekvence vzorkování</translation>
     </message>
@@ -1728,115 +1855,115 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Opustit celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Tisk</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Vytáhnout text</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Promítání</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Kopírovat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Přejmenovat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Přidat do oblíbených</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Odebrat z oblíbených</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Otočit doprava</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Otočit doleva</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Zobrazit okno navigace</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Skrýt navigační okno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Nastavit jako pozadí plochy</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Zobrazit ve správci souborů</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Informace o obrázku</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Úspěšně exportováno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation>Export se nezdařil</translation>
+        <translation>Nepodařilo se vyvést</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"/>
+        <translation>Album je šikovný správce pro zobrazování a uspořádávání fotek a videí</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"/>
+        <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 položek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 položka</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Všechny fotky a videa</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Úspěšně naimportováno</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Import se nezdařil</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_da.ts
+++ b/src/translations/deepin-album_da.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="da_DK">
+<TS version="2.1" language="da">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Disken er optaget — kan ikke skubbe ud nu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuldskærm</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Afslut fuldskærm/slideshow</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Hjælp</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Vis genveje</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Vis i filhåndtering</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slideshow</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Vis</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Vælg alle</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopiér</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstil som tapet</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Drej med urets retning</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Drej modsat urets retning</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom ind</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom ud</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Forrige</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Næste</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstil som favorit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Fjern fra favorit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyt album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Omdøb album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Side op</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Side ned</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Billeder</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albummer</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstillinger</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritter</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Unavngivet</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Billeder</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyt album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstil som favorit</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Fjern fra favorit</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%3/%2/%1</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1-drev</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Ryd %1-disk</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1-krypteret</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1-bind</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Importér til:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importér</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyt album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Importér alle</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Import lykkedes</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignorer</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Navn:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Gem til:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Billeder</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Dokumenter</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Downloads</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Skrivebord</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Videoer</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Musik</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Vælg andre mapper</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kvalitet:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport lykkedes</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport mislykkedes</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuldskærm</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Afslut fuldskærm</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slideshow</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Omdøb</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopiér</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Drej med urets retning</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Drej modsat urets retning</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstil som tapet</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Vis i filhåndtering</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Forrige</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Næste</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom ind</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom ud</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Udskriv</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Hjælp</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Vis genveje</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstillinger</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Vælg alle</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Billeder</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Videoer</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importér</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Du har ikke tilladelse til at vise billedet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Grundlæggende information</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensioner</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Optagelsesdato</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Ændringsdato</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Detaljer</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Blænde</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksponeringsprogram</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Brændvidde</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksponeringstilstand</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksponeringstid</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Blitz</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Blitzkompensering</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Maksimal blænde</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Farverum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Målingstilstand</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Hvidbalance</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Lensemodel</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importerer ...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%3/%2/%1 {1/%2?}</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Import lykkedes</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Import mislykkedes</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%3/%2/%1 {1/%2?}</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Unavngivet</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyt album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Navn:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Systemdisk</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%3/%2/%1 {1/%2/%3 %4:%5?}</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%3/%2/%1 {1?}</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%3/%2/%1 {1/%2?}</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%3/%2/%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papirkurv</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papirkurv</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet alle</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Er du sikker på, at du vil slette albummet?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Søgeresultater</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slideshow</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Ingen søgeresultater</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Albummet “%1” blev fjernet</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galleri</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importér</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritter</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papirkurv</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Enhed</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albummer</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slideshow</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksportér</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyt album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Omdøb</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Forrige</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Afspil</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Næste</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Afslut</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>dage</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dage</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport lykkedes</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport mislykkedes</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Vis</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuldskærm</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Udskriv</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slideshow</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Tilføj til album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyt album</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Tilføjet til “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Eksportér</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Kopiér</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Fjern fra album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstil som favorit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Fjern fra favorit</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Drej med urets retning</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Drej modsat urets retning</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstil som tapet</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Vis i filhåndtering</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Gendan</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Billedinformation</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Vis</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Fuldskærm</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Udskriv</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Slideshow</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Tilføj til album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Nyt album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Tilføjet til “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Eksportér</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopiér</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Slet</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Fjern fra album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Indstil som favorit</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Fjern fra favorit</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Drej med urets retning</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Drej modsat urets retning</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Indstil som tapet</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Vis i filhåndtering</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Gendan</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Billedinformation</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Eksport lykkedes</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Eksport mislykkedes</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Forrige</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Næste</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Tilpas til vindue</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstil som favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Fjern fra favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Grundlæggende information</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Optagelsesdato</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuldskærm</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Afslut fuldskærm</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Udskriv</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slideshow</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksportér</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopiér</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Omdøb</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstil som favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Fjern fra favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Drej med urets retning</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Drej modsat urets retning</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Vis navigationsvindue</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Skjul navigationsvindue</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Indstil som tapet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Vis i filhåndtering</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport lykkedes</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport mislykkedes</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%3/%2/%1 {1?}</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_de.ts
+++ b/src/translations/deepin-album_de.ts
@@ -1,812 +1,812 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="de_DE">
+<TS version="2.1" language="de">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle Fotos und Videos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Laufwerk arbeitet, kann jetzt nicht ausgeworfen werden</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Vollbildmodus/Diashow verlassen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Tastenkombinationen anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Im Dateimanager anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diashow</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ansicht</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos exportieren</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos/Videos importieren</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle auswählen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Foto-/Videoinfo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Als Hintergrundbild festlegen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Im Uhrzeigersinn drehen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Gegen den Uhrzeigersinn drehen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Hineinzoomen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Herauszoomen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Vorheriges</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Nächstes</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Neues Album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album umbenennen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Bild auf</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Bild ab</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Alben</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildschirmaufnahme</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Ohne Namen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilder</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Neues Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Ordner importieren</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine Ergebnisse</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine Ergebnisse</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine Fotos oder Videos gefunden</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildschirmaufnahme</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(Kopie)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Laufwerk</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Leeres %1 Laufwerk</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 verschlüsselt</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Laufwerk</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>Sind Sie sicher, dass Sie diese Datei lokal löschen möchten?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>Sie können Sie im Papierkorb wiederherstellen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>Sind Sie sicher, dass Sie %1 Dateien lokal löschen möchten?</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>Sie können sie im Papierkorb wiederherstellen</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>Sind Sie sicher, dass Sie diese Datei endgültig löschen möchen?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>Sie können sie nicht mehr wiederherstellen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>Sind Sie sicher, dass sie endgültig %1 Dateien löschen möchten?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>Sie können sie nicht mehr wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Importieren nach:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importieren</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Neues Album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle importieren</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Importieren erfolgreich</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine Ergebnisse</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Wird geladen ...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignorieren</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Speichern in:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Bilder</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Dokumente</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Downloads</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Schreibtisch</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Videos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Musik</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Andere Verzeichnisse auswählen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Qualität:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportieren erfolgreich</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportieren fehlgeschlagen</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Vollbildmodus beenden</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Diashow</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Umbenennen</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Kopieren</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Löschen</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>Im Uhrzeigersinn drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Gegen den Uhrzeigersinn drehen</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Als Hintergrundbild festlegen</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Im Dateimanager anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Bildinfo</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Vorheriges</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Nächstes</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>Hineinzoomen</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>Herauszoomen</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Drucken</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Tastenkombinationen anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle auswählen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Videos</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>Das Foto/Video existiert bereits</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importieren</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Sie haben keine Berechtigung das Bild anzeigen zu lassen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos und Videos importieren</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Oder hierher ziehen</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Importiert am</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Allgemeine Informationen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Abmessungen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Aufnahmedatum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Änderungsdatum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Details</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Blende</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Belichtunsprogramm</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Brennweite</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Belichtungsmodus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Belichtungszeit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Blitz</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Blitzbelichtungskorrektur</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Maximale Blende</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Farbraum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Messmodus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Weißabgleich</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Objektivmodell</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Wird importiert ...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Importieren erfolgreich</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Importieren fehlgeschlagen</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Ohne Namen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Neues Album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine Fotos oder Videos gefunden</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Systemlaufwerk</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papierkorb</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papierkorb</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Dateien werden nach Ablauf der auf ihnen angegebenen Tage endgültig gelöscht</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle löschen</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Sind Sie sicher, dass Sie dieses Album löschen möchten?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Foto gefunden</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 Video gefunden</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Suchergebnisse</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diashow</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine Suchergebnisse</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Album &quot;%1&quot; gelöscht</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galerie</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importieren</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papierkorb</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Gerät</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Alben</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildschirmaufnahme</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diashow</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportieren</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Neues Album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Umbenennen</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Vorheriges</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Abspielen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Nächstes</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Beenden</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>Tage</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>Tage</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,393 +1481,507 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportieren erfolgreich</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportieren fehlgeschlagen</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Ansicht</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Drucken</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diashow</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Zum Album hinzufügen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Neues Album</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Erfolgreich zu &quot;%1&quot; hinzugefügt</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Exportieren</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Kopieren</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Aus Album entfernen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Im Uhrzeigersinn drehen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Gegen den Uhrzeigersinn drehen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Als Hintergrundbild festlegen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Im Dateimanager anzeigen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Foto-Info</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Video-Info</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Ansicht</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Vollbild</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Drucken</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Diashow</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Zum Album hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Neues Album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Erfolgreich zu &quot;%1&quot; hinzugefügt</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exportieren</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopieren</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Löschen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Aus Album entfernen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Zu Favoriten hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Aus Favoriten entfernen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Im Uhrzeigersinn drehen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Gegen den Uhrzeigersinn drehen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Als Hintergrundbild festlegen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Im Dateimanager anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Wiederherstellen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Foto-Info</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Video-Info</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Exportieren erfolgreich</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Exportieren fehlgeschlagen</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Vorheriges</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Nächstes</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>An Fenster anpassen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Allgemeine Informationen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Aufnahmedatum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Dauer</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Pfad</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>Codec-Info</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Videocodec-ID</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Video-Codierungsrate</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>BpS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>Verhältnis</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Auflösung</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Audiocodec-ID</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio-Codierungsrate</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanäle</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>Abtastung</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Vollbildmodus beenden</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Drucken</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diashow</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportieren</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Umbenennen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Im Uhrzeigersinn drehen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Gegen den Uhrzeigersinn drehen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Navigationsfenster anzeigen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Navigationsfenster ausblenden</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Als Hintergrundbild festlegen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Im Dateimanager anzeigen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Bildinfo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportieren erfolgreich</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportieren fehlgeschlagen</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle Fotos und Videos</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_el.ts
+++ b/src/translations/deepin-album_el.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="el_GR">
+<TS version="2.1" language="el">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Ο δίσκος είναι απασχολημένος, αδυναμία εξαγωγής</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ΟΚ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Πλήρης Οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Έξοδος πλήρης οθόνης/παρουσίασης</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Βοήθεια</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή συντομεύσεων</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή στον διαχειριστή αρχείων</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή εικονών</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Επιλογή όλων</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Αντιγραφή</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Ορισμός ως ταπετσαρία</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Περιστροφή δεξιόστροφα</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Περιστροφή αριστερόστροφα</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Μεγεύθυνση</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Σμίκρυνση</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Προηγούμενο</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Επόμενο</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Αφαίρεση από τα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Νέο άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Μετονομασία άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Σελίδα πάνω</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Σελίδα κάτω</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Φωτογραφίες</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Χώρις όνομα</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Εικόνες</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Νέο άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Αφαίρεση από τα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Δίσκος</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Κενός %1 Δίσκος</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Κρυπτογραφημένος</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Τόμος</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Απόρριψη</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Εισαγωγή σε:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Εισαγωγή</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Νέο Άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Εισαγωγή όλων</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Επιτυχία εισαγωγής</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Απόρριψη</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Αγνόηση</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ΟΚ</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Όνομα:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Αποθήκευση σε:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Εικόνες</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Έγγραφα</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Λήψεις</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Επιφάνει Εργασίας</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Βίντεο</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Μουσική</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Επιλογή άλλων διευθύνσεων</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Τύπος αρχείου:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ποιότητα</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Απόρριψη</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Επιτυχία εισαγωγής</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Αποτυχία εξαγωγής</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Πλήρης Οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Έξοδος από πλήρη οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή εικονών</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Μετονομασία</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Αντιγραφή</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Περιστροφή δεξιόστροφα</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Περιστροφή αριστερόστροφα</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Ορισμός ως ταπετσαρία</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή στον διαχειριστή αρχείων</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Προηγούμενο</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Επόμενο</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Μεγεύθυνση</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Σμίκρυνση</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Εκτύπωση</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Βοήθεια</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή συντομεύσεων</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Επιλογή όλων</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Φωτογραφίες</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Βίντεο</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Εισαγωγή</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Δεν έχετε άδεια προβολής της φωτογραφίας</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Εισάχθηκαν σε</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Βασικές πληροφορίες</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαστάσεις</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Τύπος</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Ημερομηνία λήψης</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Ημερομηνία τροποποίησης</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Λεπτομέριες</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Διάφραγμα</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Πρόγραμμα έκθεσης</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Εστιακή απόσταση</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Ρυθμίσεις έκθεσης</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Χρόνος έκθεσης</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Φλας</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Αντιστάθμιση Φλας</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Μέγιστο διάφραγμα</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Χρωματικός χώρος</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Λειτουργία μέτρησης</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Ισορροπία λευκού</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Μοντέλο φακών</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Εισαγωγή...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Επιτυχία εισαγωγής</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Αποτυχία εισαγωγής </translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Χώρις όνομα</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Νέο Άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Όνομα:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Απόρριψη</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Δίσκος Συστήματος</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Κάδος Απορριμμάτων</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Άλμπουμ</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Απόρριψη</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Κάδος Απορριμμάτων</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή όλων</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε αυτό το άλμπουμ;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Απόρριψη</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Αποτελέσματα αναζήτησης</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Παρουσίαση εικονών</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Δεν βρέθηκαν αποτελέσματα</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Το Άλμπουμ “%1” αφαιρέθηκε</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Γκαλερί</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Εισαγωγή</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Κάδος Απορριμμάτων</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Συσκευή</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή εικονών</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Εξαγωγή</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Νέο άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Μετονομασία</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Προηγούμενο</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Παύση</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Αναπαραγωγή</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Επόμενο</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Έξοδος</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>Ημέρες</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>Ημέρες</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Επιτυχία εισαγωγής</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Αποτυχία εξαγωγής</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Προβολή</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Πλήρης Οθόνη</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Εκτύπωση</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή εικονών</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Προσθήκη σε άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Νέο άλμπουμ</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Επιτυχώς προστέθηκε στο “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Εξαγωγή</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Αντιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Αφαίρεση από άλμπουμ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Αγαπημένο</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Αφαίρεση από τα αγαπημένα</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Περιστροφή δεξιόστροφα</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Περιστροφή αριστερόστροφα</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Ορισμός ως ταπετσαρία</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή στον διαχειριστή αρχείων</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Επαναφορά</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Πληροφορίες φωτογραφίας</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Προβολή</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Πλήρης Οθόνη</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Εκτύπωση</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Προβολή εικονών</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Προσθήκη σε άλμπουμ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Νέο άλμπουμ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Επιτυχώς προστέθηκε στο “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Εξαγωγή</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Αντιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Διαγραφή</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Αφαίρεση από άλμπουμ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Προσθήκη στα αγαπημένα</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Αφαίρεση από τα αγαπημένα</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Περιστροφή δεξιόστροφα</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Περιστροφή αριστερόστροφα</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Ορισμός ως ταπετσαρία</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Προβολή στον διαχειριστή αρχείων</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Επαναφορά</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Πληροφορίες φωτογραφίας</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Επιτυχία εισαγωγής</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Αποτυχία εξαγωγής</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Προηγούμενο</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Επόμενο</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Εφαρμογή στο παράθυρο</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Αφαίρεση από τα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Βασικές πληροφορίες</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Ημερομηνία λήψης</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Τύπος</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Πλήρης Οθόνη</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Έξοδος από πλήρη οθόνη</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Εκτύπωση</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή εικονών</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Εξαγωγή</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Αντιγραφή</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Μετονομασία</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Αγαπημένο</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Αφαίρεση από τα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Περιστροφή δεξιόστροφα</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Περιστροφή αριστερόστροφα</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή παραθύρου πλοήγησης</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Απόκρυψη παραθύρου πλοήγησης</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Ορισμός ως ταπετσαρία</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή στον διαχειριστή αρχείων</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Επιτυχία εισαγωγής</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Αποτυχία εξαγωγής</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Άλμπουμ</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_en_AU.ts
+++ b/src/translations/deepin-album_en_AU.ts
@@ -4,329 +4,329 @@
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk is busy, cannot eject now</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Exit fullscreen/slideshow</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>View</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Select all</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Set as wallpaper</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotate clockwise</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotate counterclockwise</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom in</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom out</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favourite</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Unfavourite</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>New album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Rename album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Page up</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Page down</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Photos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albums</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favourites</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Unnamed</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Pictures</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>New album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favourite</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Unfavourite</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Drive</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Blank %1 Disc</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Encrypted</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Volume</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Import to:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>New Album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Import All</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Import successful</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignore</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Save to:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Pictures</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Documents</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Downloads</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Desktop</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Videos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Music</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Select other directories</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Quality:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Export successful</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Export failed</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Exit fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotate clockwise</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotate counterclockwise</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Set as wallpaper</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom in</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom out</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Select all</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Photos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Videos</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>You have no permission to view the image</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Imported on</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Basic info</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensions</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Date captured</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Date modified</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Details</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Aperture</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Exposure program</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Focal length</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Exposure mode</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Exposure time</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Flash compensation</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Max aperture</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Colorspace</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Metering mode</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>White balance</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Lens model</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importing...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Import successful</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Import failed</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Unnamed</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>New Album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>System Disk</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Trash</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Trash</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete All</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Are you sure you want to delete this album?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Search results</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slide Show</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>No search results</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Album “%1” removed</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Gallery</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favourites</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Trash</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Device</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albums</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Export</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>New album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Rename</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Play</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Next</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Exit</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>days</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>days</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Export successful</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Export failed</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>View</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Add to album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>New album</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Successfully added to “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Export</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Copy</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove from album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favourite</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Unfavourite</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Rotate clockwise</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotate counterclockwise</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Set as wallpaper</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Restore</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Photo info</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>View</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Fullscreen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Print</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Slide show</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Add to album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>New album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Successfully added to “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Export</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copy</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Delete</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Remove from album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Favourite</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Unfavourite</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Rotate clockwise</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Rotate counterclockwise</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Set as wallpaper</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Display in file manager</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Restore</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Photo info</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Export successful</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Export failed</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Next</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Fit to window</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favourite</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Unfavourite</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Basic info</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Date captured</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Exit fullscreen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Print</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slide show</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Export</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favourite</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Unfavourite</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotate clockwise</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotate counterclockwise</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Show navigation window</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Hide navigation window</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Set as wallpaper</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Export successful</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Export failed</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_es.ts
+++ b/src/translations/deepin-album_es.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Todas las fotos y videos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>El disco está ocupado, no se puede expulsar ahora</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Salir de pantalla completa/presentación</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atajos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Mostrar en el administrador de archivos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Presentación</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Exportar fotos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Importar fotos/videos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Información de foto/video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Establecer como fondo de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Girar hacia la derecha</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Girar hacia la izquierda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Acercarse</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Alejarse</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Quitar de favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Nuevo álbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Renombrar álbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Página arriba</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Página abajo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Álbumes</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Captura de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Cámara</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Dibujo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Sin nombre</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Canal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Imágenes</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Nuevo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Importar carpetas</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Álbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Version:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Álbum es una elegante herramienta de gestión para ver y organizar fotos y vídeos.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 se libera bajo %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Mostrar panel lateral</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Ocultar el panel lateral</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Proporción original</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Miniaturas cuadradas</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Todo</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Quitar de favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Girar</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>No hay resultados</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>No hay resultados</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>No fotos o videos encontrados</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Captura de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Cámara</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Dibujo</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(copia)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1 unidad</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>%1 disco en blanco</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1 cifrado</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>%1 Volumen</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>¿Está seguro de que quiere eliminar este archivo localmente?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Puedes restaurarlo en la papelera</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>¿Estás seguro de que quieres borrar los archivos %1 localmente?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Puedes restaurarlos en la papelera</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>¿Está seguro de que quiere eliminar permanentemente este archivo?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Ya no se puede restaurar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>¿Está seguro de que quiere eliminar permanentemente los archivos %1?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Ya no se pueden restaurar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Importar a:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Nuevo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Importar todo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>Importar 1 elemento</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>Importar %1 elementos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Importación exitosa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>No hay resultados</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Cargando...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Ignorar</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>El nombre del archivo no puede estar vacío.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Guardar en:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Imágenes</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Documentos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Descargas</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Escritorio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Videos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Seleccionar otras carpetas</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Formato:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Calidad:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Exportación exitosa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Error al exportar</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Salir de pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Extraer el texto</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Presentación</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Girar hacia la derecha</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Girar hacia la izquierda</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Establecer como fondo de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Mostrar en el administrador de archivos</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Inf. de la imagen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Acercarse</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Alejarse</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Visor de imagen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atajos</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>Texto en vivo</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Todo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Videos</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>La foto o el video ya existe</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>1 elemento seleccionado (1 foto)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>1 elemento seleccionado (1 vídeo)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>%1 elementos seleccionados (%1 fotos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>%1 elementos seleccionados (%1 vídeos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>%1 elementos seleccionados (1 foto, %2 vídeos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>%1 elementos seleccionados (%2 fotos, 1 vídeo)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>%1 elementos seleccionados (%2 fotos, %3 vídeos)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>No tienes permisos para ver la imagen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>Archivo de imagen no encontrado</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Importar fotos y videos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>O arrastrarlos hasta aquí</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Importar en</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 elemento</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 elementos</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Información básica</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>Nombre del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Dimensiones</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Fecha de captura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Fecha de modificación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Apertura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Programa de exposición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Longitud focal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Modo de exposición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Tiempo de exposición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Compensación de flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Abertura máxima</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Espacio de color</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Modo de medición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Balance de blancos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Modelo de dispositivo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Modelo de lente</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>Importando…</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation>Importada:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Importación exitosa</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>Error al importar</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Sin nombre</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Nuevo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>No fotos o videos encontrados</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Seleccionar imágenes</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Importación exitosa</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Error al importar</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Disco del sistema</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>El archivo ya existe, por favor utilice otro nombre</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Papelera</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Álbum</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>El archivo ya existe, por favor utilice otro nombre</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Papelera</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>Los archivos se borrarán permanentemente después de los días indicados en ellos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Borrar todo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Borrar lo seleccionado (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Restaurar seleccionado (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>¿Está seguro que desea borrar este álbum?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>1 foto encontrada</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>%1 fotos encontradas</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>1 video encontrado</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>%1 videos encontrados</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>%1 artículos encontrados</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Resultados de la búsqueda</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Presentación</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>No hay resultados de búsqueda</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>Álbum &quot;%1&quot; borrado</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Galería</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Colección</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Papelera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Álbumes</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Añadir un álbum</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Captura de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Cámara</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Dibujo</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Presentación</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Nuevo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Pausa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Reproducir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Salir</translation>
     </message>
@@ -1455,178 +1455,305 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>días</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>day</source>
-        <translation type="unfinished"/>
+        <translation>día</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>días</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>day</source>
+        <translation>día</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Exportación exitosa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Error al exportar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Presentación</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Añadir al álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Nuevo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Correctamente añadido a &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Quitar del álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Añadir a favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Quitar de favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Girar hacia la derecha</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Girar hacia la izquierda</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Establecer como fondo de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Mostrar en el administrador de archivos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Información de la foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Inf de video</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>Volver al álbum</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Anterior</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Siguiente</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Tamaño original</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Presentación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Ajustar a la ventana</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Añadir al álbum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Girar</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Nuevo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Correctamente añadido a &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Borrar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Quitar del álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Quitar de favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Girar hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Girar hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Establecer como fondo de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Mostrar en el administrador de archivos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Restaurar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Inf. de la foto</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Inf de video</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Exportación exitosa</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Error al exportar</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Volver al álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Anterior</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Siguiente</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Tamaño original</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Ajustar a la ventana</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Girar</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Favorito</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Quitar de favoritos</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Extraer el texto</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Información básica</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>Nombre del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Fecha de captura</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Duración</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Ruta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Inf del códec</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>CodecID de video</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>CodeRate de video</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Proporción</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Resolución</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>CodecID de Audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>CodeRate de audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Dígito de audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Canales</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Muestreo</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Salir de pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Extraer el texto</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Presentación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Añadir a favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Quitar de favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Girar hacia la derecha</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Girar hacia la izquierda</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Mostrar panel de navegación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Ocultar panel de navegación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Establecer como fondo de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Mostrar en el administrador de archivos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Inf. de la imagen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Exportación exitosa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>Error al exportar</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Álbum es una elegante herramienta de gestión para ver y organizar fotos y vídeos.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Álbum</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 elementos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 elemento</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Todas las fotos y videos</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Importación exitosa</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Error al importar</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_et.ts
+++ b/src/translations/deepin-album_et.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="et_EE">
+<TS version="2.1" language="et">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Täisekraan</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Välju täisekraanist/slaidiseansist</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Abiinfo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Näita otseteesid</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Näita failihalduris</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidiseanss</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Vaata</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Vali kõik</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopeeri</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Määra taustapildiks</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pööra päripäeva</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pööra vastupäeva</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Eelmine</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Järgmine</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Lemmik</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Eemalda lemmikutest</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uus album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimeta album ümber</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotod</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumid</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Seaded</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Lemmikud</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimetu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Pildid</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uus album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Lemmik</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Eemalda lemmikutest</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,62 +399,62 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ketas</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 krüpteeritud</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation type="unfinished"></translation>
     </message>
@@ -462,117 +462,117 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Tühista</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Impordi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uus album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Impordi kõik</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Importimine oli edukas</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Tühista</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignoreeri</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimi:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Salvesta kohta:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Pildid</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Dokumendid</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Allalaadimsied</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Töölaud</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Videod</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Muusika</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Vali teine kaust</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Vorming:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kvaliteet:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Tühista</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksporditud</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksportimine ebaõnnestus</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Täisekraan</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Välju täisekraanist</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidiseanss</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimeta ümber</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopeeri</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pööra päripäeva</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pööra vastupäeva</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Määra taustapildiks</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Näita failihalduris</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Eelmine</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Järgmine</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Prindi</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Abiinfo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Näita otseteesid</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Seaded</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Vali kõik</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotod</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Videod</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Impordi</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Sul pole pildi vaatamiseks õigusi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Põhiinfo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Mõõdud</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Liik</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Pildistamise kuupäev</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Muutmise kuupäev</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Üksikasjad</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Fookuskaugus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Välk</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Vägu kompensatsioon</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Värviruum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mõõtmise režiim</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Valge tasakaal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Läätse mudel</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importimine...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Importimine oli edukas</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Importimine ebaõnnestus</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimetu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uus album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimi:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Tühista</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Süsteemiketas</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Prügikasti</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Tühista</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Prügikasti</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta kõik</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Oled sa kindel, et soovid seda albumit kustutada?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Tühista</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Otsingu tulemused</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidiseanss</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Otsing ei andnud tulemusi</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Album “%1” on eemaldatud</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galerii</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Impordi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Lemmikud</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Prügikasti</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Seade</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumid</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidiseanss</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspordi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uus album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimeta ümber</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Eelmine</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Paus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Esita</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Järgmine</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Välju</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>päeva</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>päeva</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksporditud</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksportimine ebaõnnestus</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Vaata</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Täisekraan</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Prindi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidiseanss</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Lisa albumisse</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uus album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspordi</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Kopeeri</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Eemalda albumist</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Lemmik</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Eemalda lemmikutest</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Pööra päripäeva</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pööra vastupäeva</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Määra taustapildiks</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Näita failihalduris</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Taasta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Foto info</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Vaata</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Täisekraan</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Prindi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Slaidiseanss</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Lisa albumisse</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Uus album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Ekspordi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopeeri</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Kustuta</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Eemalda albumist</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Lemmik</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Eemalda lemmikutest</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Pööra päripäeva</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Pööra vastupäeva</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Määra taustapildiks</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Näita failihalduris</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Taasta</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Foto info</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Eksporditud</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Eksportimine ebaõnnestus</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Eelmine</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Järgmine</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Mahuta aknasse</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Lemmik</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Eemalda lemmikutest</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Põhiinfo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Pildistamise kuupäev</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Liik</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Täisekraan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Välju täisekraanist</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Prindi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidiseanss</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspordi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopeeri</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimeta ümber</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Kustuta</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Lemmik</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Eemalda lemmikutest</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pööra päripäeva</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pööra vastupäeva</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Näita navigeerimise akent</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Peida navigeerimise aken</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Määra taustapildiks</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Näita failihalduris</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksporditud</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksportimine ebaõnnestus</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_fi.ts
+++ b/src/translations/deepin-album_fi.ts
@@ -1,1859 +1,1997 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fi_FI">
+<TS version="2.1" language="fi">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaikki kuvat ja videot</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Levy varattu, sitä ei voi poistaa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Koko näyttö</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Poistu koko näytöstä/diaesityksestä</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Apua</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä pikakuvakkeet</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä tiedostohallinnassa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaesitys</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Vie kuvat</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuo valokuvia/videoita</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Valokuva-/videotiedot</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Aseta taustakuvaksi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Käännä myötäpäivään</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Käännä vastapäivään</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Lähennä</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Loitonna</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Edellinen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Seuraava</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Suosikki</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Inhokki</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uusi albumi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimeä albumi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Sivu ylös</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Sivu alas</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvat</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Suosikit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruudunkaappaus</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Piirrä</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimeämätön</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanava</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvat</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uusi albumi</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuo kansiot</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Versio:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi on tyylikäs työkalu valokuvien ja videoiden katseluun, sekä järjestämiseen.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 on julkaistu %2 alla</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä sivupaneeli</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Piilota sivupaneeli</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
-        <translation type="unfinished"></translation>
+        <translation>Alkuperäinen suhde</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
-        <translation type="unfinished"></translation>
+        <translation>Pikkukuvat neliönä</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation>V</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
-        <translation type="unfinished"></translation>
+        <translation>KK</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
-        <translation type="unfinished"></translation>
+        <translation>P</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaikki</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Haku</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Suosikki</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Inhokki</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
-        <translation type="unfinished"></translation>
+        <translation>Käännä</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 kuva</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kuvaa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 videota</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Ei tuloksia</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
-        <source>1 photo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
-        <source>%1 photos</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
-        <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <source>1 photo</source>
+        <translation>1 kuva</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <source>%1 photos</source>
+        <translation>%1 kuvaa</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
+        <source>1 video</source>
+        <translation>1 video</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 videota</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Ei tuloksia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvia tai videoita ei löytynyt</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruudunkaappaus</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Piirrä</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(kopio)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 kuva</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kuvaa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 videota</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
-        <translation type="unfinished"></translation>
+        <translation>1 kuva</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kuvaa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%3/%2/%1</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 asema</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Tyhjä %1 levy</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 salattu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Asema</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>Haluatko varmasti poistaa tämän tiedoston paikallisesti?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>Voit palauttaa sen roskakoriin</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>Haluatko varmasti poistaa %1 tiedostoa paikallisesti?</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>Voit palauttaa ne roskakoriin</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>Haluatko varmasti poistaa tämän tiedoston pysyvästi?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>Et voi enää palauttaa sitä</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>Haluatko varmasti poistaa %1 tiedostoa pysyvästi?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>Et voi enää palauttaa niitä</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
-        <source>1 photo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
-        <source>%1 photos</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
-        <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <source>1 photo</source>
+        <translation>1 kuva</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <source>%1 photos</source>
+        <translation>%1 kuvaa</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
+        <source>1 video</source>
+        <translation>1 video</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 videota</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuo kohteeseen:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuonti</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uusi albumi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuo kaikki</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuotu 1 kohde</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuotu %1 kohdetta</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuonti onnistui</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Ei tuloksia</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Ladataan...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ohita</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiedostonimi ei voi olla tyhjä!</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimi:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Tallenna nimellä:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Kuvat</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Asiakirjat</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Lataukset</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Työpöytä</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Videot</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Musiikki</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Valitse toinen hakemisto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Muoto:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Laatu:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Vahvista</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti onnistui</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti epäonnistui</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
-        <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
-        <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
-        <source>Extract text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <source>Fullscreen</source>
+        <translation>Koko näyttö</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <source>Exit fullscreen</source>
+        <translation>Poistu koko näytöstä</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <source>Extract text</source>
+        <translation>Poimi teksti</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Diaesitys</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Nimeä</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Kopioi</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Poista</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
-        <source>Open</source>
-        <translation type="unfinished"></translation>
+        <source>Rotate clockwise</source>
+        <translation>Käännä myötäpäivään</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1244"/>
-        <source>Print</source>
-        <translation type="unfinished"></translation>
+        <source>Rotate counterclockwise</source>
+        <translation>Käännä vastapäivään</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Aseta taustakuvaksi</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Näytä tiedostohallinnassa</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Kuvan tiedot</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Edellinen</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Seuraava</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1268"/>
-        <source>Image Viewing</source>
-        <translation type="unfinished"></translation>
+        <source>Zoom in</source>
+        <translation>Lähennä</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1272"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
+        <source>Zoom out</source>
+        <translation>Loitonna</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1276"/>
+        <source>Open</source>
+        <translation>Avaa</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
+        <source>Print</source>
+        <translation>Tulosta</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
+        <source>Image Viewing</source>
+        <translation>Kuvien katselu</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
+        <source>Help</source>
+        <translation>Apua</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä pikakuvakkeet</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Elävä teksti</translation>
     </message>
 </context>
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaikki</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvat</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Videot</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>Kuva/video on jo olemassa</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
-        <translation type="unfinished"></translation>
+        <translation>1 kohde valittu (1 kuva)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
-        <translation type="unfinished"></translation>
+        <translation>1 kohde valittu (1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kohdetta valittu (%1 valokuvaa)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
+        <translation>%1 kohdetta valittu (%1 videota)</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kohdetta valittu (1 valokuva, %2 videota)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kohdetta valittu (%2 valokuvaa, 1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kohdetta valittu (%2 valokuvaa, %3 videota)</translation>
     </message>
 </context>
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 kuva</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kuvaa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 videota</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuonti</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Sinulla ei ole lupaa katsoa kuvaa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvatiedostoa ei löydy</translation>
     </message>
 </context>
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuo valokuvia ja videoita</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>tai vedä ne tänne</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuotu </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
-        <translation type="unfinished"></translation>
+        <translation>1 kohde</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kohdetta</translation>
     </message>
 </context>
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Perustiedot</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiedostonimi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Mitat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tyyppi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvauspäivä</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Muokattu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Yksityiskohdat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Aukko</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Valotusohjelma</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Polttoväli</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Valotustila</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Valotusaika</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Salama</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Salamakorjaus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Suurin aukko</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Väriavaruus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mittaustila</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Valkotasapaino</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
-        <translation type="unfinished"></translation>
+        <translation>Laitteen malli</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Linssimalli</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuodaan...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuotu:</translation>
     </message>
     <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation>%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Tuonti onnistui</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuonti epäonnistui</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimeämätön</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uusi albumi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimi:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Vahvista</translation>
     </message>
 </context>
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvia tai videoita ei löytynyt</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Valitse kuvat</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Järjestelmälevy</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiedosto on jo olemassa, käytä toista nimeä</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation>%3/%2/%1 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%3/%2/%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Roskakori</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiedosto on jo olemassa, käytä toista nimeä</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Vahvista</translation>
     </message>
 </context>
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
-        <source>1 photo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
-        <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <source>1 photo</source>
+        <translation>1 kuva</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
-        <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
+        <source>%1 photos</source>
+        <translation>%1 kuvaa</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <source>1 video</source>
+        <translation>1 video</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 videota</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Roskakori</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiedostot poistetaan pysyvästi niille annetun päivän jälkeen</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista kaikki</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista valitut (% 1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Palauta valitut (% 1)</translation>
     </message>
 </context>
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Haluatko varmasti poistaa tämän albumin?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 kuva löytyi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kuvaa löydetty</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video löytyi</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
+        <source>%1 videos found</source>
+        <translation>%1 videota löydetty</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
-        <source>%1 videos found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
         <source>%1 items found</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kohdetta löydetty</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Hakutuloksia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaesitys</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Ei hakutuloksia</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi “%1” poistettu</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galleria</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
-        <translation type="unfinished"></translation>
+        <translation>Kokoelma</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuonti</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Suosikit</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Roskakori</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Laite</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumit</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
-        <translation type="unfinished"></translation>
+        <translation>Lisää albumi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruudunkaappaus</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Piirrä</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaesitys</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Vie</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Uusi albumi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimeä</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Edellinen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Tauko</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Toista</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Seuraava</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Poistu</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>päivää</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>day</source>
-        <translation type="unfinished"></translation>
+        <translation>päivä</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>päivää</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>day</source>
+        <translation>päivä</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti onnistui</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti epäonnistui</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Näytä</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Koko näyttö</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Tulosta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaesitys</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Lisää albumiin</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Uusi albumi</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>&quot;%1&quot; lisättiin onnistuneesti</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Vie</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Kopioi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista albumista</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Suosikki</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Inhokki</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Käännä myötäpäivään</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Käännä vastapäivään</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Aseta taustakuvaksi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä tiedostohallinnassa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Palauta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvan tiedot</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Videon tiedot</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Näytä</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Koko näyttö</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Tulosta</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Diaesitys</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Lisää albumiin</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Uusi albumi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>&quot;%1&quot; lisättiin onnistuneesti</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Vie</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopioi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Poista</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Poista albumista</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Suosikki</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Inhokki</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Käännä myötäpäivään</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Käännä vastapäivään</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Aseta taustakuvaksi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Näytä tiedostohallinnassa</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Palauta</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Kuvan tiedot</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Videon tiedot</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Vienti onnistui</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Vienti epäonnistui</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Takaisin albumiin</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Edellinen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Seuraava</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
-        <translation type="unfinished"></translation>
+        <translation>Alkuperäinen koko</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Sovita ikkunaan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
-        <translation type="unfinished"></translation>
+        <translation>Käännä</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Suosikki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Inhokki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
-        <translation type="unfinished"></translation>
+        <translation>Poimi teksti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Perustiedot</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiedostonimi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvauspäivä</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Kesto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tyyppi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Polku</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>Koodekin tiedot</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Videokoodekin tunnus</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Videokoodekin nopeus</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>Mittasuhde</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Resoluutio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Äänikoodekin tunnus</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Äänikoodekin nopeus</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>Ääni nro</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanavat</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytteenotto</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Koko näyttö</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Poistu koko näytöstä</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Tulosta</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
-        <translation type="unfinished"></translation>
+        <translation>Poimi teksti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaesitys</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Vie</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimeä</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Suosikki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Inhokki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Käännä myötäpäivään</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Käännä vastapäivään</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä navigointi-ikkuna</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Piilota navigointi-ikkuna</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Aseta taustakuvaksi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä tiedostohallinnassa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuvan tiedot</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti onnistui</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Vienti epäonnistui</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi on tyylikäs työkalu valokuvien ja videoiden katseluun, sekä järjestämiseen.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kohdetta</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
-        <translation type="unfinished"></translation>
+        <translation>1 kohde</translation>
     </message>
 </context>
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaikki kuvat ja videot</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_fr.ts
+++ b/src/translations/deepin-album_fr.ts
@@ -1,812 +1,812 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fr_FR">
+<TS version="2.1" language="fr">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Toutes les photos et vidéos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Le disque est occupé, impossible d&apos;éjecter maintenant</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitter le plein écran/diaporama</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher les raccourcis</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher dans le gestionnaire de fichiers</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Exporter des photos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer des photos/vidéos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informations sur les photos/vidéos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Définir comme fond d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotation dans le sens horaire</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotation dans le sens inverse</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom avant</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Zoom arrière</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Précédent</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Suivant</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Défavoris</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouvel album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Renommer l&apos;album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Page précédente</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Page suivante</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Photos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albums</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Capture d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Caméra</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Dessiner</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Sans nom</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Canaliser</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Images</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouvel album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer des dossiers</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tout</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Défavoris</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vidéo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucun résultat</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vidéo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucun résultat</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucune photo ou vidéo trouvée</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Capture d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Caméra</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Dessiner</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(copie)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vidéo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Lecteur</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Disque %1 vierge</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Chiffré</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Volume</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>Voulez-vous vraiment supprimer ce fichier localement&#xa0; ?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>Vous pouvez le restaurer dans la corbeille</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>Voulez-vous vraiment supprimer %1&#xa0;fichiers localement&#xa0; ?</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>Vous pouvez les restaurer dans la corbeille</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>Êtes-vous sûr de vouloir supprimer définitivement ce fichier&#xa0;?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>Vous ne pouvez plus le restaurer</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>Voulez-vous vraiment supprimer définitivement %1&#xa0;fichiers&#xa0;?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>Vous ne pouvez plus les restaurer</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vidéo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer vers :</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouvel album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer tout</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Importation réussie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucun résultat</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Chargement...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignorer</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Enregistrer dans :</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Images</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Documents</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Téléchargements</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Bureau</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Vidéos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Musique</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner d&apos;autres dossiers</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Format :</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Qualité :</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportation réussie</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;exportation</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitter le plein écran</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Diaporama</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Renommer</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Copier</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Supprimer</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>Rotation dans le sens horaire</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Rotation dans le sens inverse</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Définir comme fond d&apos;écran</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Afficher dans le gestionnaire de fichiers</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Informations sur l&apos;image</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Précédent</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Suivant</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>Zoom avant</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>Zoom arrière</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimer</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
-        <translation type="unfinished"></translation>
+        <translation>Visualisation d&apos;images</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher les raccourcis</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tout</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Photos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Vidéos</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>La photo/vidéo existe déjà</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vidéo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Vous n&apos;êtes pas autorisé à afficher l&apos;image</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer des photos et des vidéos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Ou les faire glisser ici</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Importé le</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Info de base</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensions</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Date de capture</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Date de modification</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Détails</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouverture</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Programme d&apos;exposition</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Longueur focale</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode d&apos;exposition</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Durée d&apos;exposition</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Compensation flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouverture maximale</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Espace colorimétrique</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode de mesure</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance des blancs</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Modèle d&apos;objectif</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importation...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Importation réussie</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;importation</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Sans nom</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouvel album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucune photo ou vidéo trouvée</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Disque système</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Corbeille</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 photo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vidéo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Corbeille</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>Les fichiers seront définitivement supprimés après les jours indiqués dessus</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer tout</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Voulez-vous vraiment supprimer cet album ?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 photo trouvée</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vidéo trouvée</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Résultats de la recherche</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucun résultat trouvé</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Album &quot;%1&quot; supprimé</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galerie</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Corbeille</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Appareil</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albums</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Capture d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Caméra</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Dessiner</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouvel album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renommer</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Précédent</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pause</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Lire</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Suivant</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitter</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>jours</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>jours</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,393 +1481,507 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportation réussie</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;exportation</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Afficher</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimer</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajouter à l&apos;album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouvel album</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Ajout réussi à &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Exporter</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Copier</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer de l&apos;album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Défavoris</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Rotation dans le sens horaire</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotation dans le sens inverse</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Définir comme fond d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher dans le gestionnaire de fichiers</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Restaurer</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informations sur la photo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informations sur la vidéo</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Afficher</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Plein écran</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Imprimer</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Diaporama</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Ajouter à l&apos;album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Nouvel album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Ajout réussi à &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exporter</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copier</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Supprimer</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Supprimer de l&apos;album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Favoris</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Défavoris</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Rotation dans le sens horaire</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Rotation dans le sens inverse</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Définir comme fond d&apos;écran</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Afficher dans le gestionnaire de fichiers</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Restaurer</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Informations sur la photo</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Informations sur la vidéo</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Exportation réussie</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Échec de l&apos;exportation</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Précédent</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Suivant</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajuster à la fenêtre</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Défavoris</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Info de base</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Date de capture</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Durée</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Chemin</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informations sur les codecs</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>ID de codec vidéo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Taux de code vidéo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>Proportion</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Résolution</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>ID de codec audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Taux de code audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio numérique</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>Canaux</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>Échantillonnage</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitter le plein écran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimer</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaporama</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renommer</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Défavoris</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotation dans le sens horaire</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotation dans le sens inverse</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher la fenêtre de navigation</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Masquer la fenêtre de navigation</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Définir comme fond d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher dans le gestionnaire de fichiers</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informations sur l&apos;image</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportation réussie</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;exportation</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Toutes les photos et vidéos</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_gl_ES.ts
+++ b/src/translations/deepin-album_gl_ES.ts
@@ -4,329 +4,329 @@
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Disco está ocupado, non se pode executar agora</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Saír da pantalla completa/presentación das diapositivas</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Axuda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar atallos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar no xestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Presentación das diapositivas</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer como fondo de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Xira en sentido horario</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Xire en sentido antihorario</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Ampliar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Afastar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Posterior</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Non favorito</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Volver a nomear o álbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Mover cara arriba polas páxinas</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Mover cara abaixo polas páxinas</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbums</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuracións</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Sen nome</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Non favorito</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Drive</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 disco en branco</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 encriptado</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Volume</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar a:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar todo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar con éxito</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignorar</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Aceptar</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Gardar en:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Fotos</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Documentos</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Descargas</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Escritorio</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Vídeos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Música</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccionar outros directorios</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Formato:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Calidade:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar con éxito</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro ao exportar</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Saír da pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Presentación das diapositivas</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Xira en sentido horario</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Xire en sentido antihorario</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer como fondo de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar no xestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Posterior</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Ampliar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Afastar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Axuda</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar atallos</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuracións</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Vídeos</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Non tes permiso para ver a imaxe</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Importado en</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Información básica</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensións</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Datos collidos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Datos modificados</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Detalles</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Apertura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Programa de exposición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Distancia focal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Modo exposición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempo de exposición</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Lanterna</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Compensación co flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Apertura máxima</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Espazo de cor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Modo contador</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance de brancos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Modelo dos lentes</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importando...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Importar con éxito</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro ao importar</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Sen nome</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Disco do sistema</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papeleira</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papeleira</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar todo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Está seguro que quere eliminar este álbum?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Sen resultados de busca</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Presentación das diapositivas</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Sen resultados de busca</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum “%1” eliminado</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galería</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Papeleira</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbums</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Presentación das diapositivas</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomear</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Parar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Reproducir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Posterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Saír</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>días</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>días</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar con éxito</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro ao exportar</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Ver</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Presentación das diapositivas</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Engadir ao álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Engadiuse con éxito a &quot;% 1&quot;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar do álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Non favorito</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Xira en sentido horario</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Xire en sentido antihorario</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer como fondo de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar no xestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Información da foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Ver</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Imprimir</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Presentación das diapositivas</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Engadir ao álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Novo álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Engadiuse con éxito a &quot;% 1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Eliminar do álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Favorito</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Non favorito</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Xira en sentido horario</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Xire en sentido antihorario</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Establecer como fondo de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Amosar no xestor de ficheiros</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Restaurar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Información da foto</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Exportar con éxito</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Erro ao exportar</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Posterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Axustar a xanela</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Non favorito</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Información básica</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Datos collidos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Saír da pantalla completa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Presentación das diapositivas</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Non favorito</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Xira en sentido horario</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Xire en sentido antihorario</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar a xanela de navegación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Agochar a xanela de navegación</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer como fondo de pantalla</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Amosar no xestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar con éxito</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro ao exportar</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_hi_IN.ts
+++ b/src/translations/deepin-album_hi_IN.ts
@@ -4,329 +4,329 @@
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>डिस्क व्यस्त है अतः अभी हटाना संभव नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्ण स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>फुलस्क्रीन / स्लाइड शो से बाहर निकलें</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>मदद</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>शॉर्टकट दिखाएं</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>फ़ाइल प्रबंधक में प्रदर्शित करें</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>देखना</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>सभी का चयन करे</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>नकल करे</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>वॉलपेपर के रूप में सेट करें</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घड़ी की सुई की दिशा में घुमाए</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घड़ी की सुई के विपरीत दिशा में घुमाइए</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>आकार बढ़ाए</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>आकार घटाए</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>पीछे</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>आगे</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>नापसंदीदा</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>नई एल्बम</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम का नाम बदले</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>पृष्ठ ऊपर</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>पृष्ठ नीचे</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>तस्वीरें</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बमस</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>सेटटिंग</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>अज्ञात</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>चित्र</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>नई एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>नापसंदीदा</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाएँ</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ड्राइव</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>रिक्त 1% डिस्क</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>% 1 एन्क्रिप्ट किया गया</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 आवाज</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाएँ</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>यहाँ आयात करें :</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>नई एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>सभी आयात करें</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात सफल रहा</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>लोड होना जारी...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>अनदेखा करें</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ठीक है</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>में सहेजें:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>चित्र</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>दस्तावेज़</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>डाउनलोडस</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>डेस्कटॉप</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>चल चित्र</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>संगीत</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>अन्य डिरेक्टोरिएस का चयन करें</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>स्वरूप:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>गुणवत्ता:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात सफल रहा</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात असफल रहा</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्ण स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्ण स्क्रीन से बाहर निकलें</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम बदलें</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>नकल करे</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घड़ी की सुई की दिशा में घुमाए</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घड़ी की सुई के विपरीत दिशा में घुमाइए</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>वॉलपेपर के रूप में सेट करें</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>फ़ाइल प्रबंधक में प्रदर्शित करें</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>पीछे</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>आगे</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>आकार बढ़ाए</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>आकार घटाए</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रिंट</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>मदद</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>शॉर्टकट दिखाएं</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>सेटटिंग</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>सभी का चयन करे</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>तस्वीरें</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>चल चित्र</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>आपको छवि देखने की कोई अनुमति नहीं है</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>आयत किया गया</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>बुनियादी जानकारी</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>आयाम</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रकार</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>तिथि  ली</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>तिथि संशोधित</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>विवरण</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>छिद्र</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>एक्सपोजर प्रोग्राम</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>केन्द्र लम्बाई</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>आइ एस ओ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>एक्सपोजर मोड</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>एक्सपोजर समय</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>फ़्लैश</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>फ्लैश कोम्पेनसेसन</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>अधिकतम छिद्र का आकार</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>रंगीन स्थान</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>पैमाइश प्रणाली</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>श्वेत संतुलन</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>लेंस मॉडल</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात किया जा रहा है...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>आयात सफल रहा</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात असफल रहा</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>अज्ञात</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>नई एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>सिस्टम डिस्क</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>ट्रैश</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>ट्रैश</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>सभी हटाए</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>क्या आप निश्चित ही यह एल्बम हटाना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ठीक है</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाएँ</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>खोज का परिणाम</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>कोई खोज परिणाम नहीं</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम &quot;% 1&quot; निकाला गया</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>दीर्घा</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>ट्रैश</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>यंत्र</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बमस</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाएँ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>नई एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम बदलें</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>पीछे</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>रोके</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>चलाये</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>आगे</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>बाहर जाएं</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>दिनों</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>दिनों</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात सफल रहा</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात असफल रहा</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>देखना</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्ण स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रिंट</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>नयी एल्बम</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>सफलतापूर्वक &quot;% 1&quot; में जोड़ा गया</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>निर्यात</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>नकल करे</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>मिटाए</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम से निकालें</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>नापसंदीदा</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>घड़ी की सुई की दिशा में घुमाए</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घड़ी की सुई के विपरीत दिशा में घुमाइए</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>वॉलपेपर के रूप में सेट करें</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>फ़ाइल प्रबंधक में प्रदर्शित करें</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>पुनःस्थापन करे</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>फोटो की जानकारी</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>देखना</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>पूर्ण स्क्रीन</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>प्रिंट</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>स्लाइड शो</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>एल्बम में जोड़ें</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>नई एल्बम</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>सफलतापूर्वक &quot;% 1&quot; में जोड़ा गया</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>निर्यात</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>नकल करे</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>हटाएँ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>एल्बम से निकालें</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>पसंदीदा</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>नापसंदीदा</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>घड़ी की सुई की दिशा में घुमाए</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>घड़ी की सुई के विपरीत दिशा में घुमाइए</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>वॉलपेपर के रूप में सेट करें</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>फ़ाइल प्रबंधक में प्रदर्शित करें</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>पुनःस्थापन करे</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>फोटो की जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">निर्यात सफल रहा</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">निर्यात असफल रहा</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>पीछे</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>आगे</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Fit to window</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>नापसंदीदा</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाएँ</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>बुनियादी जानकारी</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>तिथि  ली</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रकार</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्ण स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्ण स्क्रीन से बाहर निकलें</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रिंट</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>नकल करे</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम बदलें</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाएँ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>नापसंदीदा</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घड़ी की सुई की दिशा में घुमाए</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घड़ी की सुई के विपरीत दिशा में घुमाइए</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>नेविगेशन विंडो दिखाएं</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>नेविगेशन विंडो छिपाएँ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>वॉलपेपर के रूप में सेट करें</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>फ़ाइल प्रबंधक में प्रदर्शित करें</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात सफल रहा</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात असफल रहा</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_hr.ts
+++ b/src/translations/deepin-album_hr.ts
@@ -1,397 +1,397 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="hr_HR">
+<TS version="2.1" language="hr">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Sve fotografije i videa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk je zauzet, ne mogu sada izbaciti</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>U redu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Napusti cijeli zaslon/klizni prikaz</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Pomoć</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži prečace</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži u upravitelju datotekama</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Klizni prikaz</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Pogled</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvezi fotografije</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvezi fotografije/videa</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Odaberi sve</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Postavi kao tapetu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotirajte u smjeru kazaljka na satu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotirajte u smjeru suprotnom od kazaljke na satu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Prethodno</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Slijedeće</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novi album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Preimenuj album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Stranica gore</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Stranica dolje</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotografije</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Postavke</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoriti</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Neimenovano</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Slike</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novi album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvezi mape</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Inačica:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Sve</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Traži</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotografija</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Nema rezultata</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotografija</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Nema rezultata</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Nisu nađene fotografije ni videa</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,62 +399,62 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotografija</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Prazni %1 disk</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation type="unfinished"></translation>
     </message>
@@ -462,351 +462,351 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
+        <translation>Jeste li sigurni da želite trajno izbrisati ovu datoteku?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotografija</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvezi u:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvezi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novi album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvezi sve</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Uspješan uvoz</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Nema rezultata</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Učitavam...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignoriraj</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>U redu</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ime:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Spremi u:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Slike</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Dokumenti</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Preuzimanja</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Radna površina</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Videa</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Glazba</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Odaberi drugi direktorije</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kvalitet:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Potvrdi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Uspješan izvoz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Neuspješan izvoz</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Napusti cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Klizni prikaz</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Preimenuj</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotirajte u smjeru kazaljka na satu</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotirajte u smjeru suprotnom od kazaljke na satu</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Postavi kao tapetu</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži u upravitelju datotekama</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Prethodno</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Slijedeće</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Otvori</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Ispis</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Pomoć</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži prečace</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Postavke</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Odaberi sve</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Sve</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotografije</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Videa</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>Fotografija/video već postoji</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotografija</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvezi</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Nemate dozvolu za gledanje slike</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvezi fotografije i videa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Ili ih privucite ovdje</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>uvezeno na</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,310 +958,310 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Osnovne informacije</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ime datoteke</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Veličina</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimenzije</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Vrsta</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Datum izmjene</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Pojedinosti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
-        <translation type="unfinished"></translation>
+        <translation>Model uređaja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Model leća</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozim...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Uspješan uvoz</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Neuspješan uvoz</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Neimenovano</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novi album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ime:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Potvrdi</translation>
     </message>
 </context>
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Nisu nađene fotografije ni videa</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Odaberi fotografije</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk sustava</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ova datoteka već postoji, molim koristite drugo ime</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Smeće</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ova datoteka već postoji, molim koristite drugo ime</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Potvrdi</translation>
     </message>
 </context>
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotografija</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Smeće</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši sve</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Jeste li sigurni da želite izbrisati ovaj album?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video nađen</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Rezultati pretrage</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Klizni prikaz</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Nema rezultata pretrage</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Album “%1” je uklonjen</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galerija</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvezi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoriti</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Smeće</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Uređaj</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
-        <translation type="unfinished"></translation>
+        <translation>Dodaj album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Klizni prikaz</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvezi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novi album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Preimenuj</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Prethodno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pauza</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Slijedeće</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Izađi</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>dana</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dana</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Uspješan izvoz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Neuspješan izvoz</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Pogled</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Ispis</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Klizni prikaz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Dodaj u album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Novi album</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Uspješno dodan u “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Izvezi</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Kopiraj</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Ukloni iz albuma</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Rotirajte u smjeru kazaljka na satu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotirajte u smjeru suprotnom od kazaljke na satu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Postavi kao tapetu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži u upravitelju datotekama</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Obnovi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
+        <translation>Informacije o fotografiji</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
+        <source>Video info</source>
+        <translation>Informacije o videu</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Pogled</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Cijeli zaslon</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Ispis</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Klizni prikaz</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Dodaj u album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Novi album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Uspješno dodan u “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Izvezi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopiraj</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Izbriši</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Ukloni iz albuma</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Favorit</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Rotirajte u smjeru kazaljka na satu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Rotirajte u smjeru suprotnom od kazaljke na satu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Postavi kao tapetu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Prikaži u upravitelju datotekama</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Obnovi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Informacije o fotografiji</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informacije o videu</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Uspješan izvoz</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Neuspješan izvoz</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Prethodno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Slijedeće</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvorna veličina</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Pristajanje u prozor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Osnovne informacije</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Ime datoteke</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Veličina</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Trajanje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Vrsta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Putanja</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Razlučivost</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanali</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Napusti cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Ispis</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Klizni prikaz</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvezi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Preimenuj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotirajte u smjeru kazaljka na satu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotirajte u smjeru suprotnom od kazaljke na satu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokaži navigacijski prozor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Sakrij navigacijski prozor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Postavi kao tapetu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži u upravitelju datotekama</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Uspješan izvoz</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Neuspješan izvoz</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Sve fotografije i videa</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_hu.ts
+++ b/src/translations/deepin-album_hu.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Összes Kép és Videó</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>A lemez használatban, nem lehet most kiadni</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Kilépés a teljes képernyős módból vagy a diavetítésből</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Segítség</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Gyorsbillentyűk megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Megjelenítés a fájlkezelőben</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Diavetítés</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Nézet</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Képek exportálása</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Képek/Videók importálása</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Összes kijelölése</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Kép/Videó tulajdonságai</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Beállítás háttérképként</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Forgatás az óramutató járásával megegyezően</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Forgatás az óramutató járásával ellentétes irányba</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Nagyítás</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Kicsinyítés</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Előző</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Következő</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Kedvenc</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Eltávolítás a kedvencekből</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Új album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Album átnevezése</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Lapozás felfelé</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Lapozás lefelé</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Képek</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Albumok</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Kedvencek</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Képernyő Rögzítő</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Rajzoló</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Névtelen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Csatorna</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Képek</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Új album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Mappák importálása</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Verzió:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Az Album egy stílusos kezelőeszköz fotók és videók megtekintéséhez és rendszerezéséhez.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 kiadásra került %2 alatt</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Oldalsó panel mutatása</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Oldalsó panel elrejtése</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Eredeti arány</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Négyzet alakú miniatűrök</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>Év</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>Hónap</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>Nap</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Összes</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Kedvenc</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Eltávolítás a kedvencekből</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Elforgatás</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 kép</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 kép(ek)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 videó</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 videó(k)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Nincs keresési eredmény</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 kép</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 kép(ek)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 videó</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 videó(k)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Nincs keresési eredmény</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>Nem található kép vagy videó</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Képernyő Rögzítő</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Rajzoló</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(másolás)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 kép</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 kép(ek)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 videó</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 videó(k)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 kép</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 kép(ek)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1 lemez</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Üres %1 lemez</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1 titkosítva</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>%1 hangerő</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Biztos benne, hogy helyileg törli ezt a fájlt?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Visszaállíthatja a Kukából</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>Biztos benne, hogy helyileg törli a %1 fájlt?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Visszaállíthatja őket a Kukából</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Biztos benne, hogy véglegesen törli ezt a fájlt?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Már nem tudja visszaállítani</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Biztos benne, hogy véglegesen törli a %1 fájlt?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Ezeket többé nem tudja visszaállítani</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 kép</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 kép(ek)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 videó</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 videó(k)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Importálás ide:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Importálás</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Új album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Összes importálása</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>1 elem importálása</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>%1 elem importálása</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Az importálás sikeres</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Nincs keresési eredmény</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Betöltés...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Kihagyás</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>A fájlnév nem lehet üres !</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Név:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Mentés ide:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Képek</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Dokumentumok</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Letöltések</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Asztal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Videók</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Zene</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Más könyvtárak kiválasztása</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Formátum:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Minőség:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Az exportálás sikeres</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Az exportálás sikertelen</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Kilépés a teljes képernyős módból</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Szöveg kibontása</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Diavetítés</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Átnevezés</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Forgatás az óramutató járásával megegyezően</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Forgatás az óramutató járásával ellentétes irányba</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Beállítás háttérképként</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Megjelenítés a fájlkezelőben</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Kép információk</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Előző</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Következő</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Nagyítás</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Kicsinyítés</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Megnyitás</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Kép megtekintése</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Segítség</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Gyorsbillentyűk megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Összes kijelölése</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>Élő szöveg</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Összes</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Képek</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Videók</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>A kép/videó már létezik</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation>A fájl formátuma nem támogatott</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>1 elem kijelölve (1 fénykép)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>1 elem kijelölve (1 videó)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>%1 elem kijelölve (%1 fénykép)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>%1 elem kijelölve (%1 videó)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation>%1 elem kijelölve (1 fénykép, 1 videó)</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>%1 elem kijelölve (1 fénykép, %2 videó)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>%1 elem kijelölve (%2 fénykép, 1 videó)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>%1 elem kijelölve (%2 fénykép, %3 videó)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 kép</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 kép(ek)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 videó</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 videó(k)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Importálás</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>Nincs jogosultsága megtekinteni ezt a képet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>A képfájl nem található</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Képek és Videók importálása</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>Vagy húzza ide a fájlokat</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Importálva ide</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 elem</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 elem(ek)</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Alapvető információk</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>Fájlnév</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Méretek</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Rögzítés dátuma</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Módosítás ideje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Részletek</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Rekeszérték</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Expozíciós program</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Gyújtótávolság</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Expozíciós mód</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Expozíciós idő</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Vaku</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Vaku kompenzálása</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Maximális rekesz</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Színtér</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Mérési mód</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Fehéregyensúly</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Eszköz modell</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Lencse típusa</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>Importálás...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation>Importálva:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Az importálás sikeres</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>Az importálás sikertelen</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Névtelen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Új album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Név:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Megerősítés</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>Nem található kép vagy videó</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Kép kiválasztása</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Az importálás sikeres</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Az importálás sikertelen</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Rendszerlemez</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>A fájl már létezik, kérjük használjon másik nevet</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Kuka</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>A fájl már létezik, kérjük használjon másik nevet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Megerősítés</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 kép</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 kép(ek)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 videó</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 videó(k)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Kuka</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>A fájlok véglegesen törlődnek a megjelenített napok után</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Összes törlése</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Kijelöltek törlése (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Kijelöltek visszaállítása (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Biztos, hogy törölni szeretné ezt az albumot?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>1 képet sikerült találni</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>%1 kép található</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>1 videót sikerült találni</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>%1 videó található</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>%1 elem található</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Keresési eredmények</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Diavetítés</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>Nincs keresési eredmény</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>A “%1” album eltávolítva</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Galéria</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Váogatás</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Importálás</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Kedvencek</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Kuka</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Eszköz</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Albumok</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Album hozzáadása</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Képernyő Rögzítő</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Rajzoló</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Diavetítés</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Exportálás</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Új album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Átnevezés</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Előző</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Szüneteltetés</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Lejátszás</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Következő</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Kilépés</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>Napok</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>Nap</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>Napok</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>Nap</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Az exportálás sikeres</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Az exportálás sikertelen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Nézet</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Diavetítés</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Hozzáadás az albumhoz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Új album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Sikeresen hozzáadva a következőhöz: „%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Exportálás</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Eltávolítás az albumból</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Kedvenc</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Eltávolítás a kedvencekből</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Forgatás az óramutató járásával megegyezően</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Forgatás az óramutató járásával ellentétes irányba</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Beállítás háttérképként</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Megjelenítés a fájlkezelőben</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Helyreállítás</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Kép tulajdonságai</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Videó tulajdonságai</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>Vissza az albumhoz</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Nézet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Előző</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Következő</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Eredeti méret</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Diavetítés</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Igazítás az ablakhoz</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Hozzáadás az albumhoz</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Elforgatás</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Új album</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Sikeresen hozzáadva a következőhöz: „%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exportálás</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Másolás</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Törlés</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Eltávolítás az albumból</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Kedvenc</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Eltávolítás a kedvencekből</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Forgatás az óramutató járásával megegyezően</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Forgatás az óramutató járásával ellentétes irányba</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Beállítás háttérképként</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Megjelenítés a fájlkezelőben</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Helyreállítás</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Kép tulajdonságai</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Videó tulajdonságai</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Az exportálás sikeres</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Az exportálás sikertelen</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Vissza az albumhoz</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Előző</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Következő</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Eredeti méret</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Igazítás az ablakhoz</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Elforgatás</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Kedvenc</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Eltávolítás a kedvencekből</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Szöveg kibontása</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Alapvető információk</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>Fájlnév</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Rögzítés dátuma</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Időtartam</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Elérési útvonal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Kodek tulajdonságai</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>Videó kodek azonosító</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Videó kodek érték</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Arány</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Felbontás</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>Audió kodek azonosító</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Audió kodek érték</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Audió számjegy</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Csatornák</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Mintavétel</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Kilépés a teljes képernyős módból</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Szöveg kibontása</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Diavetítés</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Exportálás</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Átnevezés</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Kedvenc</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Eltávolítás a kedvencekből</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Forgatás az óramutató járásával megegyezően</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Forgatás az óramutató járásával ellentétes irányba</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Navigációs ablak megjelenítése</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Navigációs ablak elrejtése</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Beállítás háttérképként</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Megjelenítés a fájlkezelőben</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Kép információk</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Az exportálás sikeres</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>Az exportálás sikertelen</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Az Album egy stílusos kezelőeszköz fotók és videók megtekintéséhez és rendszerezéséhez.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 elem</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 elem</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Összes Kép és Videó</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Az importálás sikeres</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Az importálás sikertelen</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_id.ts
+++ b/src/translations/deepin-album_id.ts
@@ -1,397 +1,397 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="id_ID">
+<TS version="2.1" language="id">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua foto dan video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Diska sibuk, tidak dapat mencabut sekarang</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Layar penuh</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Keluar mode layarpenuh/slideshow</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Bantuan</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilan pintasan</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan di manajer file</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilan salindia</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>View</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor foto</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor foto/video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih semua</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplikat</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Info foto/video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Atur sebagai wallpaper</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar searah jarum jam</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar berlawanan jarum jam</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Perbesar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Perkecil</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Sebelumnya</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Selanjutnya</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritkan</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal Favorit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album Baru</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Ganti nama album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Halaman atas</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Halaman bawah</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Foto</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Pengaturan</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dinamai</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Gambar</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album Baru</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritkan</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada hasil</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada hasil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ditemukan foto atau video</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,414 +399,414 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Drive</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk %1 Kosong</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Terenkripsi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Volume</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor ke:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album Baru</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor Semua</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor berhasil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ada hasil</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Memuat...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Abaikan</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Simpan ke:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Gambar</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Dokumen</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Unduhan</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Desktop</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Video</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Musik</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih folder lain</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kualitas:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor berhasil</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor gagal</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Layar penuh</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Keluar mode layar penuh</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Tampilan slide</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Ganti nama</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Duplikat</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Hapus</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>Putar searah jarum jam</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Putar berlawanan jarum jam</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Atur sebagai wallpaper</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Tampilkan di manajer file</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Info gambar</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Sebelumnya</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Selanjutnya</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>Perbesar</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>Perkecil</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Bantuan</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilan pintasan</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Pengaturan</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih semua</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Video</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Anda tidak punya izin untuk melihat gambar ini</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor Foto dan Video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Atau seret ke sini</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Telah diimpor di</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informasi Dasar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipe</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Tanggal mengambil foto</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Tanggal diubah</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Detail</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>bukaan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program exposure</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Jarak fokus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode exposure</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Waktu exposure</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Lampu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>kompensasi pencahayaan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>bukaan maks</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>ruang warna</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode pengukuran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>keseimbangan putih</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>model lensa </translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Sedang mengimpor...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Impor berhasil</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor gagal</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dinamai</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album Baru</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ditemukan foto atau video</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Diska Sistem</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempat Sampah</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempat Sampah</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus Semua</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Apakah anda yakin menghapus album ini?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Hasil Pencarian</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilan slide</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak ditemukan hasil</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Album “%1” terhapus</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galeri</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Impor</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempat Sampah</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Perangkat</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilan salindia</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album Baru</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Ganti nama</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Sebelumnya</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Jeda</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Selanjutnya</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Keluar</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>hari</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>hari</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor berhasil</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor gagal</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>View</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Layar penu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilan slide</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Tambahkan ke album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Album Baru</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Berhasil menambahkan ke “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Ekspor</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Duplikat</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus dari album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal Favorit</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Putar searah jarum jam</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar berlawanan jarum jam</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Atur sebagai Wallpaper</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan di manajer file</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Kembalikan</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informasi Foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Info video</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>View</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Layar penuh</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Cetak</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Tampilan salindia</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Tambahkan ke album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Album Baru</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Berhasil menambahkan ke “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Ekspor</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Duplikat</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Hapus</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Hapus dari album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Favoritkan</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Batal Favorit</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Putar searah jarum jam</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Putar berlawanan jarum jam</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Atur sebagai wallpaper</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Tampilkan di manajer file</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Kembalikan</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Informasi Foto</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Info video</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Ekspor berhasil</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Ekspor gagal</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Sebelumnya</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Selanjutnya</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Sesuaikan dengan jendela</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritkan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informasi Dasar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Tanggal mengambil foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipe</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Layar penuh</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Keluar mode layar penuh</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilan salindia</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplikat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Ganti nama</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar searah jarum jam</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar berlawanan jarum jam</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan jendela navigasi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Sembunyikan jendela navigasi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Atur sebagai wallpaper</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampilkan di manajer file</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Info gambar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor berhasil</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspor gagal</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua foto dan video</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_it.ts
+++ b/src/translations/deepin-album_it.ts
@@ -4,199 +4,199 @@
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Tutte le immagini e video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>Disco occupato, impossibile espellere al momento</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Tutto schermo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Esci da schermo intero/presentazione</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Visualizza scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Visualizza nel File Manager</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Presentazione</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Visualizza</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Esporta foto</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Importa foto/video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Seleziona tutte</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Info Foto/Video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Imposta come sfondo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Ruota in senso orario</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Ruota in senso antiorario</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Zoom più</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Zoom meno</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Precedente</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Successiva</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Agg. ai preferiti</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Sposta dai preferiti</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Nuovo album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Rinomina album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Pagina su</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Pagina giu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Immagini</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Cattura schermo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Disegno</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Senza nome</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Canale</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Immagini</translation>
     </message>
@@ -204,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Nuovo album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Importa cartelle</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Versione:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>Album è un elegante strumento di gestione per visualizzare e organizzare foto e video.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1viene rilasciato sotto %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostra il pannello laterale </translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Nacosndi il pannello laterale </translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation>Y</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
-        <translation type="unfinished"></translation>
+        <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
-        <translation type="unfinished"></translation>
+        <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Tutto</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Cerca </translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Agg. ai preferiti</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Sposta dai preferiti</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruota</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
@@ -306,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 immagine</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 immagini</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Nessun risultato</translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 immagine</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 immagini</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Nessun risultato</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>Nessuna immagine o video trovati</translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Cattura schermo</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Disegno</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(copia)</translation>
     </message>
@@ -399,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 immagine</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 immagini</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotografia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
-        <translation type="unfinished"></translation>
+        <translation>%1 fotografie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -439,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>Dispositivo %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Cancella disco %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1 crittografato</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>Volume %1</translation>
     </message>
@@ -462,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Sei sicuro di voler eliminare questo file in locale?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Potrai ripristinarlo dal cestino</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>Sei sicuro di voler eliminare %1 file in locale?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Potrai ripristinarli dal cestino</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Sei sicuro di voler eliminare definitivamente questo file?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Non potrai più ripristinarlo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Sei sicuro di voler eliminare definitivamente %1 file?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Non potrai più ripristinarli</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
@@ -515,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 immagine</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 immagini</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Importa in:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Importa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Nuovo Album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Importa tutti</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
-        <translation type="unfinished"></translation>
+        <translation>Importa 1 elemento </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
-        <translation type="unfinished"></translation>
+        <translation>Importa %1 elementi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Import completato</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Nessun risultato</translation>
     </message>
@@ -580,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Caricamento...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Ignora</translation>
     </message>
@@ -598,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
-        <translation type="unfinished"></translation>
+        <translation>Il nome del file non può essere vuoto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -611,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Salva in:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Immagini</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Documenti</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Desktop</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Musica</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Seleziona un altro percorso</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Formato:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Qualità:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Conferma </translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Esportazione completata</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Esporazione fallita</translation>
     </message>
@@ -690,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Tutto schermo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Esci da schermo intero</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
-        <translation type="unfinished"></translation>
+        <translation>Estrai testo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Presentazione</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Ruota in senso orario</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Ruota in senso antiorario</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Imposta come sfondo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Visualizza nel File Manager</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Info immagine</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Precedente</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Successiva</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Zoom più</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Zoom meno</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Apri </translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Stampa</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Visualizzazione immagine</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Visualizza scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Seleziona tutte</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Tutto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Immagini</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Video</translation>
     </message>
@@ -832,70 +832,81 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>L&apos;immagine/video esiste già</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
-        <translation type="unfinished"></translation>
+        <translation>1 elemento selezionato (1 fotografia)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
-        <translation type="unfinished"></translation>
+        <translation>1 elemento selezionato (1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 elementi selezionati (%1 fotografie)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
+        <translation>%1 elementi selezionati (% video)</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 elementi selezionati (1 fotografia, %2 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 elementi selezionati (%2 fotografie, 1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 elementi selezionati (%2 fotografie, %3 video)</translation>
     </message>
 </context>
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 immagine</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 immagini</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Importa</translation>
     </message>
@@ -903,25 +914,25 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>Non hai il permesso di visualizzare l&apos;immagine</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
-        <translation type="unfinished"></translation>
+        <translation>Il file dell&apos;immagine non è stato trovato</translation>
     </message>
 </context>
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Importa foto e video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>oppure trascinali qui</translation>
     </message>
@@ -929,130 +940,130 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Importati in</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
-        <translation type="unfinished"></translation>
+        <translation>1 elemento </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
-        <translation type="unfinished"></translation>
+        <translation>1% elementi</translation>
     </message>
 </context>
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Info base</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome del file </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Dimensioni</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Data acquisizione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Data modifica</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Dettagli</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Apertura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Programma esposizione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Lunghezza focale</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Modalità esposizione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Tempo di esposizione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Compensazione del flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Apertura massima</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Spazio colore</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Modalità di misurazione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Bilanciamento del bianco</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
-        <translation type="unfinished"></translation>
+        <translation>Modello del device </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Modello lente</translation>
     </message>
@@ -1060,73 +1071,73 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importazione...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"></translation>
+        <translation>Importato:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
-        <translation type="unfinished">%1/%2</translation>
+        <translation>%1%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Import completato</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished">Import fallito</translation>
+        <translation>Import fallito</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished">%1/%2</translation>
+        <translation>%1%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Senza nome</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Nuovo Album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Conferma </translation>
     </message>
 </context>
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>Nessuna immagine o video trovati</translation>
     </message>
@@ -1134,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Import completato</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Import fallito</translation>
+        <translation>Immagini selezionate </translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Disco di Sistema</translation>
     </message>
@@ -1158,41 +1161,41 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
-        <translation type="unfinished"></translation>
+        <translation>Questo file esiste già, per favore usa un altro nome </translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
+        <translation>%1%2%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished">%1</translation>
+        <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished">%1/%2</translation>
+        <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Cestino</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1200,83 +1203,83 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
-        <translation type="unfinished"></translation>
+        <translation>Questo file esiste già, per favore usa un altro nome </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Conferma </translation>
     </message>
 </context>
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 immagine</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 immagini</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Cestino</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>I file verranno eliminati definitivamente dopo i giorni indicati</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Elimina tutte</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancella elemento selezionato (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ripristina elemento selezionato (%1)</translation>
     </message>
 </context>
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Sicuro di voler eliminare questo album?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
@@ -1284,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>1 immagine trovata</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 fotografie trovate </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>1 video trovato</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 video trovati</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 elementi trovati</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Risultati di ricerca</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Presentazione</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>Nessun risultato</translation>
     </message>
@@ -1327,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>Album “%1” rimosso</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Galleria</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
-        <translation type="unfinished"></translation>
+        <translation>Collezioni </translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Importa</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Cestino</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi un Album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Cattura schermo</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Disegno</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Presentazione</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Nuovo album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
@@ -1421,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Precedente</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Pausa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Successiva</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Esci</translation>
     </message>
@@ -1452,178 +1455,305 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>giorni</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>day</source>
-        <translation type="unfinished"></translation>
+        <translation>Giorno</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>giorni</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>day</source>
+        <translation>Giorno</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Esportazione completata</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Esporazione fallita</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Visualizza</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Tutto schermo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Stampa</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Presentazione</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Aggiungi all&apos;album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Nuovo album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Aggiunta con successo in “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Rimuovi dall&apos;album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Agg. ai preferiti</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Sposta dai preferiti</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Ruota in senso orario</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Ruota in senso antiorario</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Imposta come sfondo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Visualizza nel File Manager</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Ripristina</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Info immagine</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Video info</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Visualizza</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Precedente</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Tutto schermo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Successiva</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Stampa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Presentazione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Adatta alla finestra</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Aggiungi all&apos;album</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Nuovo album</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Aggiunta con successo in “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Esporta</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copia</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Elimina</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Rimuovi dall&apos;album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Agg. ai preferiti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Sposta dai preferiti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
-        <source>Extract text</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Ruota in senso orario</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Ruota in senso antiorario</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Imposta come sfondo</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Visualizza nel File Manager</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Ripristina</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Info immagine</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Video info</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Esportazione completata</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Esporazione fallita</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Torna all&apos;album </translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Precedente</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Successiva</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Dimensioni originali</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Adatta alla finestra</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Ruota</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Agg. ai preferiti</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Sposta dai preferiti</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
+        <source>Extract text</source>
+        <translation>Estrai testo</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
@@ -1631,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Info base</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome del file </translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Data acquisizione</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Durata</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Percorso</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Codec info</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>Video CodecID</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Video CodeRate</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Proporzione</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>Audio CodecID</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Audio CodeRate</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Audio digit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Canali</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Campionamento</translation>
     </message>
@@ -1725,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Tutto schermo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Esci da schermo intero</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Stampa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
-        <translation type="unfinished"></translation>
+        <translation>Estrai testo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Presentazione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Agg. ai preferiti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Sposta dai preferiti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Ruota in senso orario</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Ruota in senso antiorario</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Mostra finestra di navigazione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Nascondi finestra di navigazione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Imposta come sfondo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Visualizza nel File Manager</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Info immagine</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Esportazione completata</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>Esporazione fallita</translation>
     </message>
@@ -1828,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>Album è un elegante strumento di gestione per visualizzare e organizzare foto e video.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1841,35 +1971,27 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished">%1</translation>
+        <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
-        <translation type="unfinished"></translation>
+        <translation>1% elementi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
-        <translation type="unfinished"></translation>
+        <translation>1 elemento </translation>
     </message>
 </context>
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Tutte le immagini e video</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Import completato</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Import fallito</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_ka.ts
+++ b/src/translations/deepin-album_ka.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ka_GE">
+<TS version="2.1" language="ka">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>დისკი დაკავებულია, ამჟამად ამოღება შეუძლებელია</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ოკ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>მთელს ეკრანზე</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>მთლიანი ეკრანიდან/სლაიდშოუდან გამოსვლა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>დახმარება</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>შორთქატების ჩვენება</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ფაილების მენეჯერში ნახვა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>სლაიდშოუ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>ნახვა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>ყველას მონიშვნა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>კოპირება</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>ფონად დაყენება</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>საათის ისრის მიმართულებით დაბრუნება</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>საათის ისრის საწინააღმდეგო მიმართულებით დაბრუნება</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>გადიდება</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>დაპატარავება</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>წინა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>შემდეგი</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტი</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტებიდან წაშლა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>ახალი ალბომი</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>ალბომის გადარქმევა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>ზემოთ ასვლა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>ქვემოთ ჩამოსვლა</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>სურათები</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>ალბომები</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>პარამეტრები</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტები</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>უსახელო</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>სურათები</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>ახალი ალბომი</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ალბომი</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტი</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტებიდან წაშლა</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>წაშლა</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 დრაივი</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ბლანკი დისკი</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 დაშიფრული</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ვოლუმი</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>წაშლა</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>იმპორტირება:  </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>იმპორტი</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ახალი ალბომი</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>ყველა</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>იპორტი წარმატებით დასრულდა</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>იგნორირება</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ოკ</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>სახელი:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>საქაღალდე:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>სურათები</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>დოკუმენტები</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>ჩამოტვირთვები</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>ეკრანი</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>ვიდეოები</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>მუსიკები</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>სხვა საქაღალდის არჩევა</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>ფორმატი:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>ხარისხი:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპორტი წარმატებით დასრულდა</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპორტი შეწყდა</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>მთელს ეკრანზე</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>მთლიანი ეკრანის გათიშვა</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>სლაიდშოუ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>გადარქმევა</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>კოპირება</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>საათის ისრის მიმართულებით დაბრუნება</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>საათის ისრის საწინააღმდეგო მიმართულებით დაბრუნება</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>ფონად დაყენება</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ფაილების მენეჯერში ნახვა</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>წინა</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>შემდეგი</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>გადიდება</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>დაპატარავება</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>დაბეჭდვა</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>დახმარება</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>შორთქატების ჩვენება</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>პარამეტრები</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>ყველას მონიშვნა</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>სურათები</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>ვიდეოები</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>იმპორტი</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>თქვენ არ გაქვთ სურათის ნახვის უფლება</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>იმპორტირებულია: </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>საბაზო ინფორმაცია</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>გაფართოება</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>ტიპი</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>გადაღების დრო</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>ცვლილების დრო</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>დეტალები</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>დიაფრაგმა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპოზიციის პროგრამა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>ფოკალური სიგრძე</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპოზიციის რეჟიმი</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპოზიციის დრო</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>ფლეში</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>ფლეშ კომპენსაცია</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>მაქსიმალური დიაფრაგმა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>ფერთა სივრცე</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>დათვლის რეჟიმი</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>თეთრი ფერის ბალანსი</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>ლინზის მოდელი</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>იმპორტი...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>იპორტი წარმატებით დასრულდა</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>იმპორტი შეწყდა</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>უსახელო</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ახალი ალბომი</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>სახელი:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>სისტემური დისკი</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>სანაგვე</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ალბომი</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>სანაგვე</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>გაწმენდა</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>დარწმუნებული ხართ, რომ გსურთ ამ ალბომის წაშლა?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>გაუქმება</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>წაშლა</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>ძებნის რეზულტატი</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>სლაიდშოუ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>არ მოიძებნა არაფერი</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>ალბომი %1 წაიშალა</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>გალერეა</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>იმპორტი</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტები</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>სანაგვე</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>მოწყობილობა</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>ალბომები</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>სლაიდშოუ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპორტი</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>ახალი ალბომი</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>გადარქმევა</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>წინა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>პაუზა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>გაშვება</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>შემდეგი</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>გამოსვლა</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation> დღე</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation> დღე</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპორტი წარმატებით დასრულდა</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპორტი შეწყდა</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>ნახვა</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>მთელს ეკრანზე</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>დაბეჭდვა</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>სლაიდშოუ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>ალბომში დამატება</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>ახალი ალბომი</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>წარმატებით დაემატა &quot;%1&quot;-ში</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>ექსპორტი</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>კოპირება</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>ალბომის წაშლა</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტი</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტებიდან წაშლა</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>საათის ისრის მიმართულებით დაბრუნება</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>საათის ისრის საწინააღმდეგო მიმართულებით დაბრუნება</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>ფონად დაყენება</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ფაილების მენეჯერში ნახვა</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>აღდგენა</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>ინფორმაცია</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>ნახვა</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>მთელს ეკრანზე</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>დაბეჭდვა</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>სლაიდშოუ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>ალბომში დამატება</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>ახალი ალბომი</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>წარმატებით დაემატა &quot;%1&quot;-ში</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>ექსპორტი</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>კოპირება</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>წაშლა</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>ალბომის წაშლა</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>ფავორიტი</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>ფავორიტებიდან წაშლა</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>საათის ისრის მიმართულებით დაბრუნება</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>საათის ისრის საწინააღმდეგო მიმართულებით დაბრუნება</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>ფონად დაყენება</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>ფაილების მენეჯერში ნახვა</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>აღდგენა</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">ექსპორტი წარმატებით დასრულდა</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">ექსპორტი შეწყდა</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>წინა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>შემდეგი</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>ფანჯარაზე მორგება</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტი</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტებიდან წაშლა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>წაშლა</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>საბაზო ინფორმაცია</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>გადაღების დრო</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>ტიპი</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>მთელს ეკრანზე</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>მთლიანი ეკრანის გათიშვა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>დაბეჭდვა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>სლაიდშოუ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპორტი</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>კოპირება</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>გადარქმევა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტი</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ფავორიტებიდან წაშლა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>საათის ისრის მიმართულებით დაბრუნება</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>საათის ისრის საწინააღმდეგო მიმართულებით დაბრუნება</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>ნავიგაციის ფანჯრის ნახვა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>ნავიგაციის ფანჯრის დამალვა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>ფონად დაყენება</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ფაილების მენეჯერში ნახვა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპორტი წარმატებით დასრულდა</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>ექსპორტი შეწყდა</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ალბომი</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_km_KH.ts
+++ b/src/translations/deepin-album_km_KH.ts
@@ -4,329 +4,329 @@
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបថត និងវីដេអូទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>ថាសរវល់មិនអាចច្រានចេញបានទេឥឡូវនេះ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>យល់ព្រម</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ពេញ​អេក្រង់</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>ចេញពីអេក្រង់ពេញ / បញ្ចាំងស្លាយ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>ជំនួយ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្ហាញផ្លូវកាត់</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្ហាញនៅក្នុងកម្មវិធីគ្រប់គ្រងឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>បញ្ចាំងស្លាយ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>មើល</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>ជ្រើស​យក​ទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>ចម្លង</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>លុប</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>កំណត់ជាផ្ទាំងរូបភាព</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្វិលតាមទ្រនិចនាឡិកា</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្វិលច្រាសទ្រនិចនាឡិកា</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>ពង្រីក</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្រួម</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>មុន</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>បន្ទាប់</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ចំណូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>មិនចូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុមថ្មី</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>ប្តូរឈ្មោះអាល់ប៊ុម</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>ទំព័រឡើងលើ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>ទំព័រចុះក្រោម</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបថត</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុម</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>ការកំណត់</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>ចំណូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>ថត​ស្គ្រី​ន</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>កាមេរ៉ា</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>គូរ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>គ្មានឈ្មោះ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបភាព</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុមថ្មី</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុម</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ចំណូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>មិនចូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>លុប</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបភាពមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>វីដេអូមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,245 +334,245 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបភាពមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>វីដេអូមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>រកមិនឃើញរូបថត ឬវីដេអូទេ</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>ថត​ស្គ្រី​ន</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>កាមេរ៉ា</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>គូរ</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(ចម្លង)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបភាពមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>វីដេអូមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ថាស</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ថាសទទេ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 បានអ៊ិនគ្រីប</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ចំនួន</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>តើអ្នកប្រាកដថាចង់លុបឯកសារនេះជារៀងរហូតទេ?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>អ្នកមិនអាចស្តារវាឡើងវិញទៀតទេ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>តើអ្នកប្រាកដថាចង់លុបឯកសារ %1 ជាអចិន្ត្រៃយ៍ទេ?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>អ្នកមិនអាចស្តារពួកវាបានទៀតទេ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>បោះបង់</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>លុប</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបភាពមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>វីដេអូមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចូលទៅ៖</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចូល</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុមថ្មី</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចូលទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចូលបានជោគជ័យ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>កំពុងផ្ទុក...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>បោះបង់</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>មិនអើពើ</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>យល់ព្រម</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>ឈ្មោះ៖</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>រក្សាទុកនៅ៖</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>រូបភាព</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>ឯកសារ</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>ទាញយក</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>ផ្ទៃតុ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>វីដេអូ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>តន្ត្រី</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>ជ្រើសរើសថតផ្សេងទៀត</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>ទ្រង់ទ្រាយ៖</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>គុណភាព៖</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>បោះបង់</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចេញបានជោគជ័យ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចេញបានបរាជ័យ</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ពេញ​អេក្រង់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ចេញពីអេក្រង់ពេញ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>បញ្ចាំងស្លាយ</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>ប្តូរឈ្មោះ</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>ចម្លង</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>លុប</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>បង្វិលតាមទ្រនិចនាឡិកា</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>បង្វិលច្រាសទ្រនិចនាឡិកា</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>កំណត់ជាផ្ទាំងរូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>បង្ហាញនៅក្នុងកម្មវិធីគ្រប់គ្រងឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>ព័ត៌មានរូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>មុន</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>បន្ទាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>ពង្រីក</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>បង្រួម</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>បោះពុម្ព</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>ជំនួយ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្ហាញផ្លូវកាត់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>ការកំណត់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>ជ្រើស​យក​ទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបថត</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>វីដេអូ</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបភាពមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>វីដេអូមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចូល</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>អ្នកគ្មានសិទ្ធិមើលរូបភាពទេ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>ដាក់បញ្ចូលរូបថត និងវីដេអូ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>ឬអូសពួកវាមកទីនេះ</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>បាននាំចូលលើ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>ព័ត៌មានបឋម</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>វិមាត្រ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>ប្រភេទ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>កាលបរិច្ឆេទចាប់យក</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>កាលបរិច្ឆេទបានកែប្រែ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>ព័ត៌មានលម្អិត</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>ជំរៅ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>កម្មវិធីបង្ហាញ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>ប្រវែងប្រសព្វ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>របៀបបង្ហាញ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>រយៈពេល​បង្ហាញ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>ពន្លឺ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>សំណងពន្លឺ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>ជំរៅអតិបរមា</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>ចន្លោះពណ៌</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>ម៉ូតម៉ែត្រ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>តុល្យភាពពណ៌ស</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>ម៉ូដែលកែវ</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>កំពុងនាំចូល...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>នាំចូលបានជោគជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចូលបានបរាជ័យ</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>គ្មានឈ្មោះ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុមថ្មី</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>ឈ្មោះ៖</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>បោះបង់</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>រកមិនឃើញរូបថត ឬវីដេអូទេ</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>ថាសប្រព័ន្ធ</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>សំរាម</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុម</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>បោះបង់</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបភាពមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>វីដេអូមួយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>សំរាម</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>ឯកសារនឹងត្រូវបានលុបជាអចិន្ត្រៃយ៍បន្ទាប់ពីថ្ងៃដែលបានបង្ហាញនៅលើពួកវា</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>លុបទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>តើអ្នកពិតជាចង់លុបអាល់ប៊ុមនេះមែនទេ?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>បោះបង់</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>លុប</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>លទ្ធផលស្វែងរក</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>បញ្ចាំងស្លាយ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>គ្មានលទ្ធផលស្វែងរកទេ</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុម “%1” បានយកចេញ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>វិចិត្រសាល</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចូល</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>ចំណូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>សំរាម</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>ឧបករណ៍</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុម</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>ថត​ស្គ្រី​ន</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>កាមេរ៉ា</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>គូរ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>បញ្ចាំងស្លាយ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចេញ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>លុប</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុមថ្មី</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>ប្តូរឈ្មោះ</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>មុន</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>ផ្អាក</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>ចាក់</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>បន្ទាប់</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>ចេញ</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>ថ្ងៃ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>ថ្ងៃ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចេញបានជោគជ័យ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចេញបានបរាជ័យ</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>មើល</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ពេញ​អេក្រង់</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>បោះពុម្ព</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>បញ្ចាំងស្លាយ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>បន្ថែមទៅអាល់ប៊ុម</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុមថ្មី</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>បន្ថែមដោយជោគជ័យទៅក្នុង “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>នាំចេញ</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>ចម្លង</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>លុប</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>យកចេញពីអាល់ប៊ុម</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ចំណូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>មិនចូលចិត្ត</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>បង្វិលតាមទ្រនិចនាឡិកា</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្វិលច្រាសទ្រនិចនាឡិកា</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>កំណត់ជាផ្ទាំងរូបភាព</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្ហាញនៅក្នុងកម្មវិធីគ្រប់គ្រងឯកសារ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>ស្តារ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>ព័ត៌មានរូបថត</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>ព័ត៌មានវីឌីអូ</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>មើល</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>ពេញ​អេក្រង់</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>បោះពុម្ព</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>បញ្ចាំងស្លាយ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>បន្ថែមទៅអាល់ប៊ុម</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>អាល់ប៊ុមថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>បន្ថែមដោយជោគជ័យទៅក្នុង “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>នាំចេញ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>ចម្លង</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>លុប</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>យកចេញពីអាល់ប៊ុម</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>ចំណូលចិត្ត</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>មិនចូលចិត្ត</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>បង្វិលតាមទ្រនិចនាឡិកា</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>បង្វិលច្រាសទ្រនិចនាឡិកា</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>កំណត់ជាផ្ទាំងរូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>បង្ហាញនៅក្នុងកម្មវិធីគ្រប់គ្រងឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>ស្តារ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>ព័ត៌មានរូបថត</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>ព័ត៌មានវីឌីអូ</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">នាំចេញបានជោគជ័យ</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">នាំចេញបានបរាជ័យ</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>មុន</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>បន្ទាប់</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>សមនឹងបង្អួច</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ចំណូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>មិនចូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>លុប</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>ព័ត៌មានបឋម</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>កាលបរិច្ឆេទចាប់យក</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>ប្រភេទ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ពេញ​អេក្រង់</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>ចេញពីអេក្រង់ពេញ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>បោះពុម្ព</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>បញ្ចាំងស្លាយ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចេញ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>ចម្លង</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>ប្តូរឈ្មោះ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>លុប</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ចំណូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>មិនចូលចិត្ត</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្វិលតាមទ្រនិចនាឡិកា</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្វិលច្រាសទ្រនិចនាឡិកា</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្ហាញផ្ទាំងរុករក</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>លាក់ផ្ទាំងរុករក</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>កំណត់ជាផ្ទាំងរូបភាព</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>បង្ហាញនៅក្នុងកម្មវិធីគ្រប់គ្រងឯកសារ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>ព័ត៌មានរូបភាព</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចេញបានជោគជ័យ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>នាំចេញបានបរាជ័យ</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>អាល់ប៊ុម</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>រូបថត និងវីដេអូទាំងអស់</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_ko.ts
+++ b/src/translations/deepin-album_ko.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ko_KR">
+<TS version="2.1" language="ko">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>디스크가 사용 중이므로, 지금 꺼낼 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>확인</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>전체 화면</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>전체 화면/슬라이드쇼 종료</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>도움말</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>단축키 표시</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>파일 관리자에 표시</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>슬라이드 쇼</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>보기</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>모두 선택</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>복사</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>배경화면으로 설정</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>시계 방향으로 회전</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>시계 반대 방향으로 회전</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>확대</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>축소</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>이전</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>다음</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기 해제</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>새 앨범</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>앨범 이름변경</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>페이지 위로</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>페이지 아래로</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>사진</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>앨범</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>설정</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>이름 미지정</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>사진</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>새 앨범</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>앨범</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기 해제</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 드라이브</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>빈 %1 디스크</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 암호화됨</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 볼륨</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>취소</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>가져오기 대상:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>가져오기</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>새 앨범</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>모두 가져오기</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>가져오기 성공</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>취소</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>무시</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>확인</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>이름:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>저장 대상:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>사진</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>문서</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>다운로드</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>바탕화면</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>동영상</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>음악</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>다른 디렉터리 선택</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>형식:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>화질:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>취소</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>내보내기 성공</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>내보내기 실패</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>전체 화면</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>전체화면 종료</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>슬라이드 쇼</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>이름변경</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>복사</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>시계 방향으로 회전</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>시계 반대 방향으로 회전</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>배경화면으로 설정</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>파일 관리자에 표시</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>이전</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>다음</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>확대</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>축소</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>인쇄</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>도움말</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>단축키 표시</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>설정</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>모두 선택</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>사진</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>동영상</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>가져오기</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>이미지를 볼 수 있는 권한이 없습니다</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>가져온 위치</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>기본 정보</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>치수</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>유형</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>캡처된 날짜</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>수정된 날짜</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>세부 정보</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>조리개</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>노출 프로그램</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>초점</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>노출 모드</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>노출 시간</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>플래시</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>플래시 보정</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>최대 조리개</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>컬러스페이스</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>측광 모드</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>화이트 밸런스</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>렌즈 모델</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>가져오는 중...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>가져오기 성공</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>가져오기 실패</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>이름 미지정</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>새 앨범</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>이름:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>취소</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>시스템 디스크</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>휴지통</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>앨범</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>취소</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>휴지통</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>모두 삭제</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>이 앨범을 삭제하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>취소</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>검색 결과</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>슬라이드 쇼</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>검색 결과 없음</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>앨범 &quot;%1&quot; 제거됨</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>갤러리</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>가져오기</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>휴지통</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>장치</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>앨범</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>슬라이드 쇼</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>내보내기</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>새 앨범</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>이름변경</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>이전</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>일시 중지</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>재생</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>다음</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>종료</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>일간</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>일간</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>내보내기 성공</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>내보내기 실패</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>보기</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>전체 화면</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>인쇄</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>슬라이드 쇼</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>앨범에 추가</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>새 앨범</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>&quot;%1&quot;에 성공적으로 추가되었습니다</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>내보내기</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>복사</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>앨범에서 제거</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기 해제</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>시계 방향으로 회전</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>시계 반대 방향으로 회전</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>배경화면으로 설정</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>파일 관리자에 표시</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>복원</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>사진 정보</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>보기</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>전체 화면</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>인쇄</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>슬라이드 쇼</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>앨범에 추가</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>새 앨범</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>&quot;%1&quot;에 성공적으로 추가되었습니다</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>내보내기</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>복사</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>삭제</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>앨범에서 제거</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>즐겨찾기</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>즐겨찾기 해제</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>시계 방향으로 회전</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>시계 반대 방향으로 회전</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>배경화면으로 설정</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>파일 관리자에 표시</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>복원</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>사진 정보</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">내보내기 성공</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">내보내기 실패</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>이전</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>다음</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>창에 맞추기</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기 해제</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>기본 정보</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>캡처된 날짜</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>유형</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>전체 화면</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>전체화면 종료</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>인쇄</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>슬라이드 쇼</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>내보내기</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>복사</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>이름변경</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>즐겨찾기 해제</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>시계 방향으로 회전</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>시계 반대 방향으로 회전</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>탐색 창 표시</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>탐색 창 숨기기</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>배경화면으로 설정</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>파일 관리자에 표시</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>내보내기 성공</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>내보내기 실패</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>앨범</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_lv.ts
+++ b/src/translations/deepin-album_lv.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="lv_LV">
+<TS version="2.1" language="lv">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Disks ir aizņemts, nevar šobrīd izņemt</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Labi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilnekrāna režīms</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Pārtraukt pilnekrāna režīmu/slaidrādi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Palīdzība</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Rādīt saīsnes</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Apskatīt failu pārvaldniekā</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidrāde</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Apskatīt</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Atlasīt visu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopēt</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Iestatīt kā fona attēlu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pagrieziet pulksteņrādītāja virzienā</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pagrieziet pretēji pulksteņrādītāja virzienam</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Pietuvināt</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Attālināt</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Iepriekšējais</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Nākamais</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Pievienot izlasei</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Noņemt no izlases</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Jauns albums</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Pārsaukt albumu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Lapa uz augšu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Lapa uz leju</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoattēli</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Iestatījumi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Izlase</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Nenosaukts</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Attēli</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Jauns albums</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albums</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Pievienot izlasei</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Noņemt no izlases</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Disks</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Tukšs %1 Disks</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Šifrēts</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Sējums</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Atcelt</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Importēt uz:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importēt</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Jauns albums</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Importēt visu</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Veiksmīgs imports</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Atcelt</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignorēt</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Labi</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nosaukums</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Saglabāt: </translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Attēli</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Dokumenti</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Lejupielādes</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Darbavirsma</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Video</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Mūzika</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Atlasīt citu mapi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Formāts:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kvalitāte: </translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Atcelt</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Veiksmīgs eksports</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksports neizdevās</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilnekrāna režīms</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pārtraukt pilnekrāna režīmu</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidrāde</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Pārsaukt</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopēt</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pagrieziet pulksteņrādītāja virzienā</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pagrieziet pretēji pulksteņrādītāja virzienam</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Iestatīt kā fona attēlu</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Apskatīt failu pārvaldniekā</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Iepriekšējais</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Nākamais</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Pietuvināt</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Attālināt</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Printēt</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Palīdzība</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Rādīt saīsnes</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Iestatījumi</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Atlasīt visu</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoattēli</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Video</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importēt</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Jums nav atļaujas skatīt attēlu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Importēts uz</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Pamatinformācija</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Izmēri</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tips</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzņemšanas datums</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Izmainīšanas datums</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Informācija</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Apertūra</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspozīcijas programma</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Fokusa attālums</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspozīcijas režīms</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekspozīcijas laiks</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Zibspūldze</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Zibspuldzes kompensācija</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Maksimālā apertūra</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Krāsu telpa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mērīšanas režīms</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Baltā balanss</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Objektīva modelis</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiek importēts...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Veiksmīgs imports</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Imports neizdevās</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Nenosaukts</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Jauns albums</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nosaukums</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Atcelt</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistēmas disks</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Miskaste</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albums</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Atcelt</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Miskaste</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst visu</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Vai tiešām vēlaties dzēst šo albumu?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Atcelt</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Meklēšanas rezultāti</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidrāde</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Nav meklēšanas rezultātu</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Albums “%1” izdzēsts</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galerija</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importēt</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Izlase</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Miskaste</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Ierīce</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidrāde</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksportēt</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Jauns albums</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Pārsaukt</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Iepriekšējais</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pauze</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Turpināt</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Nākamais</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Iziet</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>dienas</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dienas</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Veiksmīgs eksports</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksports neizdevās</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Apskatīt</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilnekrāna režīms</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Printēt</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidrāde</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Pievienot albumam</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Jauns albums</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Veiksmīgi pievienots “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Eksportēt</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Kopēt</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Noņemt no albuma</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Pievienot izlasei</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Noņemt no izlases</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Pagrieziet pulksteņrādītāja virzienā</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pagrieziet pretēji pulksteņrādītāja virzienam</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Iestatīt kā fona attēlu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Apskatīt failu pārvaldniekā</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Atjaunot</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoattēla informācija</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Apskatīt</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Pilnekrāna režīms</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Printēt</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Slaidrāde</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Pievienot albumam</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Jauns albums</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Veiksmīgi pievienots “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Eksportēt</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopēt</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Dzēst</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Noņemt no albuma</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Pievienot izlasei</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Noņemt no izlases</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Pagrieziet pulksteņrādītāja virzienā</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Pagrieziet pretēji pulksteņrādītāja virzienam</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Iestatīt kā fona attēlu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Apskatīt failu pārvaldniekā</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Atjaunot</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Fotoattēla informācija</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Veiksmīgs eksports</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Eksports neizdevās</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Iepriekšējais</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Nākamais</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Ietilpināt logā</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Pievienot izlasei</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Noņemt no izlases</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Pamatinformācija</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzņemšanas datums</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tips</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilnekrāna režīms</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pārtraukt pilnekrāna režīmu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Printēt</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slaidrāde</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksportēt</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopēt</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Pārsaukt</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Dzēst</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Pievienot izlasei</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Noņemt no izlases</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pagrieziet pulksteņrādītāja virzienā</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Pagrieziet pretēji pulksteņrādītāja virzienam</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Rādīt navigācijas logu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Slēpt navigācijas logu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Iestatīt kā fona attēlu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Apskatīt failu pārvaldniekā</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Veiksmīgs eksports</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksports neizdevās</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albums</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_ms.ts
+++ b/src/translations/deepin-album_ms.ts
@@ -1,812 +1,812 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ms_MY">
+<TS version="2.1" language="ms">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua foto dan video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Cakera sibuk, tidak dapat lenting sekarang</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Skrin penuh</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Keluar skrin penuh/persembahan slaid</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Bantuan</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Papar pintasan</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Papar dalam pengurus fail</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Persembahan slaid</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Lihat</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport foto</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Import foto/video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih semua</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Maklumat foto/video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Tetap sebagai kertas dinding</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar ikut jam</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar lawan jam</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Zum masuk</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Zum keluar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Kegemaran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyahgemar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album baharu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama semula album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Halaman atas</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Halaman bawah</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Foto</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Tetapan</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Kegemaran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Tangkap Layar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Lukis</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak bernama</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Saluran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Gambar</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album baharu</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Import folder</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Kegemaran</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyahgemar</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Padam</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiada keputusan</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiada keputusan</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiada foto atau video ditemui</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Tangkap Layar</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Lukis</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(salin)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>Pemacu %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Cakera %1 Kosong</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Disulitkan</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Volum %1</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>Anda pasti mahu memadam album ini secara setempat?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>Anda boleh memulihnya di dalam tong sampah</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>Anda pasti mahu memadam %1 fail ini secara setempat?</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>Anda boleh memulihnya di dalam tong sampah</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>Anda pasti mahu memadam fail ini secara kekal?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>Anda tidak boleh memulihnya lagi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>Anda pasti mahu memadam %1 fail ini secara kekal?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>Anda tidak boleh memulihnya lagi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Padam</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Import ke:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album Baharu</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Import Semua</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Import berjaya</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiada keputusan</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Memuatkan...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Abai</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Simpan ke:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Gambar</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Dokumen</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Muat turun</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Atas Meja</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Video</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Muzik</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih direktori lain</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kualiti:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport berjaya</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport gagal</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Skrin penuh</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Keluar dari skrin penuh</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Persembahan slaid</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Nama semula</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Salin</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Padam</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>Putar ikut jam</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Putar lawan jam</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Tetap sebagai kertas dinding</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Papar dalam pengurus fail</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Maklumat imej</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Terdahulu</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Berikutnya</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>Zum masuk</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>Zum keluar</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Bantuan</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Papar pintasan</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Tetapan</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilih semua</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Video</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>Foto/video sudah wujud</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Anda tidak memiliki keizinan untuk melihat imej</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Import Foto dan Video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Atau seret di sini</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Diimport pada</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Maklumat asas</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Jenis</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Tarikh ditangkap</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Tarikh diubah suai</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Perincian</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Bukaan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Program dedahan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Panjang fokus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mod dedahan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Masa dedahan</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Denyar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Pemampasan denyar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Bukaan maks.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruang warna</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mod pemeteran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Imbangan putih</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Model kanta</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Mengimport...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Import berjaya</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Import gagal</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak bernama</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album Baharu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiada foto atau video ditemui</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Cakera Sistem</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Tong Sampah</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Tong Sampah</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>Fail-fail akan kekal terpadam selepas hari ditunjuk padanya</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Padam Semua</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Anda pasti mahu memadam album ini?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Padam</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto ditemui</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video ditemui</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Keputusan gelintar</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Persembahan Slaid</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiada keputusan gelintar</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Album “%1” dibuang</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galeri</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Kegemaran</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Tong Sampah</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Peranti</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Tangkap Layar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Lukis</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Persembahan slaid</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album baharu</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama semula</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Terdahulu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Jeda</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Main</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Berikutnya</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Keluar</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>hari</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>hari</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,393 +1481,507 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport berjaya</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport gagal</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Lihat</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Skrin penuh</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Persembahan slaid</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Tambah ke album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Album baharu</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Berjaya ditambah ke dalam &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Eksport</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Salin</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Buang daripada album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Kegemaran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyahgemar</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Putar ikut jam</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar lawan jam</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Tetap sebagai kertas dinding</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Papar dalam pengurus fail</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Pulih</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Maklumat foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Maklumat video</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Lihat</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Skrin penuh</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Cetak</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Persembahan slaid</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Tambah ke album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Album baharu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Berjaya ditambah ke dalam &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Eksport</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Salin</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Padam</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Buang daripada album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Kegemaran</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Nyahgemar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Putar ikut jam</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Putar lawan jam</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Tetap sebagai kertas dinding</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Papar dalam pengurus fail</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Pulih</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Maklumat foto</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Maklumat video</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Eksport berjaya</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Eksport gagal</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Terdahulu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Berikutnya</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Suai muat tetingkap</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Kegemaran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyahgemar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Padam</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Maklumat asas</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Tarikh ditangkap</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempoh</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Jenis</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Laluan</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>Maklumat kodeks</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>IDKodeks Video</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>KadarKod Video</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>Perkadaran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Resolusi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>IDKodeks Audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>KadarKod Audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>Digit audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>Saluran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>Persampelan</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Skrin penuh</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Keluar dari skrin penuh</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Persembahan slaid</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Nama semula</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Kegemaran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Nyahgemar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar ikut jam</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Putar lawan jam</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Tunjuk tetingkap pengemudian</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Sembunyi tetingkap pengemudian</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Tetap sebagai kertas dinding</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Papar dalam pengurus fail</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Maklumat imej</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport berjaya</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Eksport gagal</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Semua foto dan video</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_ne.ts
+++ b/src/translations/deepin-album_ne.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ne_NP">
+<TS version="2.1" language="ne">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>डिस्क व्यस्त छ,अहिले निकाल्न सक्दैनौ </translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ठिक छ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्णस्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्णस्क्रीन / स्लाइड शो बन्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>मद्दत</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>सर्टकट देखाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>फाइल म्यानेजरमा देखाउनु गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>हेर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>सबै छान्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रतिलिपि / कपी </translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>वालपेपरको रूपमा सेट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घडीको दिशामा घुमाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घडिको उल्टो दिशामा घुमाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>जुम इन गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>जुम आउट गर्नुहोस्  </translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>अघिल्लो</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>अर्को</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>मनपर्ने</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>मन नपर्ने</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>नयाँ एल्बम</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम पुनःनामाकरण गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>पेज उप / पृष्ठ माथि</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation> पेज डाउन  / पृष्ठ तल</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>फोटोहरू</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बमहरू</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>मनपर्ने</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम नभएको</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>चित्रहरु</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>नयाँ एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>मनपर्ने</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>मन नपर्ने</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाउनुहोस्</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>% १ /% २ /%।</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>% १ ड्राइभ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>खाली% १ डिस्क</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>% १ ईन्क्रिप्टेड</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>% १ खण्ड</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाउनुहोस्</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>यसमा आयात गर्नुहोस्:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>नयाँ एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>सबै आयात गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात सफल भयो</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -598,215 +598,215 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ठिक छ</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>यसमा बचत गर्नुहोस्:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>चित्रहरु</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>डोकुमेन्टस </translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>डाउनलोडहरू</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>डेस्कटप</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>भिडियोहरू</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>म्युजिक </translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>अन्य स्थान छान्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>फोर्मत्: </translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>गुणस्तर:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात सफल भयो</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात असफल भयो</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्णस्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्णस्क्रीनबाट बाहिर निस्कनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम बदल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रतिलिपि / कपी </translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घडीको दिशामा घुमाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घडिको उल्टो दिशामा घुमाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>वालपेपरको रूपमा सेट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>फाइल म्यानेजरमा देखाउनु गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>अघिल्लो</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>अर्को</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>जुम इन गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>जुम आउट गर्नुहोस्  </translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रिन्ट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>मद्दत</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>सर्टकट देखाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>सबै छान्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>फोटोहरू</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>भिडियोहरू</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात गर्नुहोस्</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>तपाईंसँग तस्वीर हेर्न अनुमति छैन</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>आधारभूत जानकारी</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>डिमेन्सनस  / आयाम</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>टाईप  / प्रकार </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>मिति कब्जा गरियो</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>मिति परिमार्जित</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>विवरण</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>एपर्चर</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>एक्सपोजर प्रोग्राम</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>फोकल लम्बाई</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>आईएसओ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>एक्सपोजर मोड</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>एक्सपोजर समय</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>फ्ल्यास</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>फ्ल्यास क्षतिपूर्ति</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>अधिकतम एपर्चर</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>कलरस्पेस</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>मिटरिंग मोड</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>सेतो सन्तुलन</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>लेन्स मोडेल</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात गर्दै ...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">% १ /% २ /%। {1/%2?}</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>आयात सफल भयो</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात असफल भयो</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">% १ /% २ /%। {1/%2?}</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम नभएको</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>नयाँ एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रणाली डिस्क</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">% १ /% २ /%। {1/%2/%3 %4:%5?}</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">% १ /% २ /%। {1?}</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">% १ /% २ /%। {1/%2?}</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>% १ /% २ /%।</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>त्रश </translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>त्रश </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>सबै हटाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>के तपाईं पक्का यो एल्बम मेट्न चाहनुहुन्छ?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाउनुहोस्</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>खोज परिणामहरू</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>कुनै खोज परिणामहरू छैनन्</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम &quot;% 1&quot; हटाईयो</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>ग्यालरी</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>आयात गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>मनपर्ने</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>त्रश </translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>उपकरण</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बमहरू</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>नयाँ एल्बम</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम बदल्नुहोस्</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>अघिल्लो</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>रोक्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>खेल्नु</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>अर्को</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>बाहिर निस्कनुहोस्</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>दिनहरु</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>दिनहरु</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात सफल भयो</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात असफल भयो</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>हेर्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्णस्क्रीन</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रिन्ट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बममा थप्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>नयाँ एल्बम</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>सफलतापूर्वक &quot;% 1&quot; मा थपियो</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>निर्यात</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>प्रतिलिपि / कपी </translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बमबाट हटाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>मनपर्ने</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>मन नपर्ने</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>घडीको दिशामा घुमाउनुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घडिको उल्टो दिशामा घुमाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>वालपेपरको रूपमा सेट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>फाइल म्यानेजरमा देखाउनु गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>पुनर्स्थापना गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>फोटो जानकारी</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>हेर्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>पूर्णस्क्रीन</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>प्रिन्ट गर्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>स्लाइड शो</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>एल्बममा थप्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>नयाँ एल्बम</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>सफलतापूर्वक &quot;% 1&quot; मा थपियो</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>निर्यात गर्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>प्रतिलिपि / कपी </translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>हटाउनुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>एल्बमबाट हटाउनुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>मनपर्ने</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>मन नपर्ने</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>घडीको दिशामा घुमाउनुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>घडिको उल्टो दिशामा घुमाउनुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>वालपेपरको रूपमा सेट गर्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>फाइल म्यानेजरमा देखाउनु गर्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>पुनर्स्थापना गर्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>फोटो जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">निर्यात सफल भयो</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">निर्यात असफल भयो</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>अघिल्लो</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>अर्को</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>विन्डोमा फिट</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>मनपर्ने</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>मन नपर्ने</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाउनुहोस्</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>आधारभूत जानकारी</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>मिति कब्जा गरियो</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>टाईप  / प्रकार </translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्णस्क्रीन</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>पूर्णस्क्रीनबाट बाहिर निस्कनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रिन्ट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>स्लाइड शो</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>प्रतिलिपि / कपी </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>नाम बदल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>हटाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>मनपर्ने</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>मन नपर्ने</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घडीको दिशामा घुमाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>घडिको उल्टो दिशामा घुमाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>नेभिगेसन विन्डो देखाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>नेभिगेसन विन्डो लुकाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>वालपेपरको रूपमा सेट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>फाइल म्यानेजरमा देखाउनु गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात सफल भयो</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>निर्यात असफल भयो</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>एल्बम</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">% १ /% २ /%। {1?}</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_nl.ts
+++ b/src/translations/deepin-album_nl.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Alle foto&apos;s en video&apos;s</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>De schijf is bezig en kan daarom niet worden uitgeworpen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Beeldvullende modus verlaten</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Hulp</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Sneltoetsen tonen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Tonen in bestandsbeheerder</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Diavoorstelling</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Bekijken</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Foto&apos;s exporteren</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Foto&apos;s/Video&apos;s importeren</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Alles selecteren</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Foto-/Video-informatie</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Instellen als achtergrond</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Naar rechts draaien</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Naar links draaien</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Inzoomen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Uitzoomen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Vorige</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Volgende</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Toev. aan favorieten</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Verw. uit favorieten</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Nieuw album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Albumnaam wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Pagina omhoog</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Pagina omlaag</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Foto&apos;s</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Albums</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Schermfoto</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Tekenen</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Naamloos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Kanaal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Afbeeldingen</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Nieuw album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Mappen importeren</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Versie:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Album is een mooi vormgegeven programma waarmee je foto&apos;s en video&apos;s kunt bekijken en beheren.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 is uitgebracht onder de %2-licentie</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Zijpaneel tonen</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Zijpaneel verbergen</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Oorspronkelijke beeldverhouding</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Vierkante miniaturen</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>J</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Toev. aan favorieten</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Verw. uit favorieten</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Draaien</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 foto&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 video&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Geen zoekresultaten</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 foto&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 video&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Geen zoekresultaten</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>Geen foto&apos;s of video&apos;s aangetroffen</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Schermfoto</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Tekenen</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(kopie)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 foto&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 video&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 foto&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1-schijf</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Blanco %1-schijf</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1-versleuteld</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>%1-schijf</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Weet je zeker dat je dit bestand lokaal wilt verwijderen?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Je kunt het nadien vanuit de prullenbak herstellen.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>Weet je zeker dat je %1 bestanden lokaal wilt verwijderen?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Je kunt ze nadien vanuit de prullenbak herstellen.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Weet je zeker dat je dit bestand wilt verwijderen?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Je kunt het nadien niet meer herstellen.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Weet je zeker dat je %1 bestanden wilt verwijderen?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Je kunt ze nadien niet meer herstellen.</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 foto&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 video&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Importeren naar:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Importeren</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Nieuw album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Alles importeren</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>1 item importeren</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>%1 items importeren</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Importeren voltooid</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Geen zoekresultaten</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Bezig met laden…</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Negeren</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>Voer een bestandsnaam in</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>Oké</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Opslaan in:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Afbeeldingen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Documenten</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Downloads</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Bureaublad</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Video&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Muziek</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Kies andere mappen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Bestandsformaat:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Kwaliteit:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Exporteren voltooid</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Exporteren mislukt</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Beeldvullende modus verlaten</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Tekst extraheren</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Diavoorstelling</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Naam wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Naar rechts draaien</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Naar links draaien</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Instellen als achtergrond</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Tonen in bestandsbeheerder</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Afbeeldingsinformatie</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Vorige</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Volgende</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Inzoomen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Uitzoomen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Afbeeldingsweergave</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Hulp</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Sneltoetsen tonen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Alles selecteren</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>Live-tekst</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Foto&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Video&apos;s</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>De foto/video is al aanwezig</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>1 item geselecteerd (1 foto)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>1 item geselecteerd (1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>%1 items geselecteerd (%1 foto&apos;s)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>%1 items geselecteerd (%1 video&apos;s)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>%1 items geselecteerd (1 foto, %2 video&apos;s)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>%1 items geselecteerd (%2 foto&apos;s, 1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>%1 items geselecteerd (%2 foto&apos;s, %3 video&apos;s)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 foto&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 video&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Importeren</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>Je bent niet gemachtigd om deze foto te bekijken</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>Geen afbeeldingsbestand aangetroffen</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Importeer foto&apos;s en video&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>of sleep ze hierheen</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Geïmporteerd op</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 item</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 items</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>Bestandsnaam</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Afmetingen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Genomen op</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Aangepast op</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Diafragma</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Belichtingsprogramma</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Brandpuntsafstand</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Belichtingsmodus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Belichtingstijd</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Flits</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Flitscompensatie</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Max. diafragma</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Kleurruimte</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Meetmodus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Witbalans</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Apparaat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Lensmodel</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>Bezig met importeren…</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation>Geïmporteerd:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Importeren voltooid</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>Importeren mislukt</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Naamloos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Nieuw album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Oké</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>Geen foto&apos;s of video&apos;s aangetroffen</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Selecteer afbeeldingen</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Importeren voltooid</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Importeren mislukt</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Systeemschijf</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>Er is al een bestand met deze naam - kies een andere naam</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Prullenbak</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>Er is al een bestand met deze naam - kies een andere naam</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Oké</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 foto&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 video&apos;s</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Prullenbak</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>De bestanden worden verwijderd na het vermelde aantal dagen</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Alles verwijderen</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Selectie verwijderen (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Selectie herstellen (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Weet je zeker dat je dit album wilt verwijderen?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>1 foto gevonden</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>%1 foto&apos;s aangetroffen</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>1 video gevonden</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>%1 video&apos;s aangetroffen</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>%1 items aangetroffen</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Geen zoekresultaten</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Diavoorstelling</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>Geen zoekresultaten</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>Het album &apos;%1&apos; is verwijderd</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Galerij</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Verzameling</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Importeren</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Prullenbak</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Apparaat</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Albums</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Toevoegen aan album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Schermfoto</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Tekenen</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Diavoorstelling</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Nieuw album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Naam wijzigen</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Vorige</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Pauzeren</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Afspelen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Volgende</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Afsluiten</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>dagen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>dag</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dagen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>dag</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Exporteren voltooid</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Exporteren mislukt</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Bekijken</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Diavoorstelling</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Toevoegen aan album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Nieuw album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Toegevoegd aan &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Verwijderen uit album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Toev. aan favorieten</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Verw. uit favorieten</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Naar rechts draaien</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Naar links draaien</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Instellen als achtergrond</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Tonen in bestandsbeheerder</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Herstellen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Foto-informatie</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Video-informatie</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>Terug naar album</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Bekijken</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Vorige</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Volgende</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Afdrukken</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Oorspronkelijke grootte</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Diavoorstelling</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Aanpassen aan venster</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Toevoegen aan album</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Draaien</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Nieuw album</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Toegevoegd aan &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exporteren</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopiëren</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Verwijderen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Verwijderen uit album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Toev. aan favorieten</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Verw. uit favorieten</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Naar rechts draaien</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Naar links draaien</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Instellen als achtergrond</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Tonen in bestandsbeheerder</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Herstellen</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Foto-informatie</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Video-informatie</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Exporteren voltooid</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Exporteren mislukt</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Terug naar album</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Vorige</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Volgende</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Oorspronkelijke grootte</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Aanpassen aan venster</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Draaien</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Toev. aan favorieten</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Verw. uit favorieten</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Tekst extraheren</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>Bestandsnaam</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Genomen op</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Duur</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Locatie</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Codecinformatie</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>Videocodec-id</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Videocoderingssnelheid</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Beeldverhouding</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Resolutie</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>Audiocodec-id</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Audiocoderingssnelheid</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Audio digit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Kanalen</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Sampling</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Beeldvullende modus verlaten</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Tekst extraheren</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Diavoorstelling</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Naam wijzigen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Toev. aan favorieten</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Verw. uit favorieten</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Naar rechts draaien</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Naar links draaien</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Navigatievenster tonen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Navigatievenster verbergen</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Instellen als achtergrond</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Tonen in bestandsbeheerder</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Afbeeldingsinformatie</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Exporteren voltooid</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>Exporteren mislukt</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Album is een mooi vormgegeven programma waarmee je foto&apos;s en video&apos;s kunt bekijken en beheren.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 items</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 item</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Alle foto&apos;s en video&apos;s</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Importeren voltooid</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Importeren mislukt</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_pl.ts
+++ b/src/translations/deepin-album_pl.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Wszystkie zdjęcia i filmy</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>Dysk jest zajęty, nie można go teraz wysunąć</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Opuść pełny ekran/pokaz slajdów</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Wyświetl skróty</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Wyświetl w Menedżerze plików</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Pokaz slajdów</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Wyświetl</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Eksportuj zdjęcia</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Importuj zdjęcia/filmy</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Zaznacz wszystkie</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Zdjęcia/Filmy info</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Ustaw jako tapetę pulpitu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Obróć w prawo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Obróć w lewo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Powiększ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Pomniejsz</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Poprzednie</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Następne</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Ulubione</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Usuń z ulubionych</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Nowy album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Zmień nazwę albumu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Strona w górę</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Strona w dół</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Zdjęcia</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Albumy</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Ulubione</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Przechwytywanie ekranu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Rysowanie</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Bez nazwy</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Kanał</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Zdjęcia</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Nowy album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation>Importuj katalogi</translation>
+        <translation>Importuj foldery</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Wersja:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Album to modne narzędzie do wyświetlania i organizowania zdjęć i filmów.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 został wydany na licencji %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Pokaż panel boczny</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Ukryj panel boczny</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Proporcje oryginalne</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Kwadratowe miniaturki</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Wszystkie</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Szukaj</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Ulubione</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Usuń z ulubionych</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Obróć</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 zdjęcie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 zdjęć</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 film</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 filmów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Brak wyników</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 zdjęcie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 zdjęć</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 film</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 filmów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Brak wyników</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>Nie znaleziono zdjęć i filmów</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Przechwytywanie ekranu</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Rysowanie</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(kopia)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 zdjęcie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 zdjęć</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 film</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 filmów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 zdjęcie </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 zdjęć </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>Dysk %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Pusta płyta %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>Zaszyfrowany %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>Wolumin %1</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Czy na pewno chcesz usunąć ten plik lokalnie?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Możesz przywrócić go z kosza</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>Czy na pewno chcesz usunąć %1 plików lokalnie?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Możesz przywrócić je z kosza</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Czy na pewno chcesz usunąć permanentnie ten plik?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Nie można już go przywrócić</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Czy na pewno chcesz usunąć permanentnie %1 plików?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Nie można już ich przywrócić</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 zdjęcie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 zdjęć</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 film</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 filmów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Importuj do:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Nowy album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Importuj wszystkie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>Importuj 1 przedmiot</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>Importuj %1 przedmiotów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Import zakończony pomyślnie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Brak wyników</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Wczytywanie...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Ignoruj</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>Nazwa pliku nie może być pusta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Nazwa:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Zapisz do:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Zdjęcia</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Dokumenty</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Pobrane</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Pulpit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Filmy</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Muzyka</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Zaznacz inne katalogi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Jakość:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Potwierdź</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Eksport zakończony pomyślnie</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Eksport zakończony niepowodzeniem</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Opuść pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Wydobądź tekst</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Pokaz slajdów</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Zmień nazwę</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Obróć w prawo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Obróć w lewo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Ustaw jako tapetę pulpitu</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Wyświetl w Menedżerze plików</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Informacje o obrazie</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Poprzednie</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Następne</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Powiększ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Pomniejsz</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Drukuj</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Wyświetlanie obrazu</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Wyświetl skróty</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Zaznacz wszystkie</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>Tekst na żywo</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Wszystkie</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Zdjęcia</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Filmy</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>To zdjęcie/film już istnieje</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>Zaznaczono 1 przedmiot (1 zdjęcie)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>Zaznaczono 1 przedmiot (1 film)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>Zaznaczono %1 przedmiotów (%1 zdjęcia)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>Zaznaczono %1 przedmiotów (%1 filmów)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>Zaznaczono %1 przedmiotów (1 zdjęcie, %2 filmów)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>Zaznaczono %1 przedmiotów (%2 zdjęcia, 1 film)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>Zaznaczono %1 przedmiotów (%2 zdjęć, %3 filmów)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 zdjęcie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 zdjęć</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 film</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 filmów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>Nie masz uprawnień do podglądu tego obrazu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>Nie znaleziono pliku obrazu</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Importuj zdjęcia i filmy</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>lub przeciągnij je tutaj</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Zaimportowano dnia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 przedmiot</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 przedmiotów</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Informacje podstawowe</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>Nazwa pliku</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Wymiary</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Data uchwycenia</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Data modyfikacji</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Szczegóły</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Apertura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Program ekspozycji</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Długość ogniskowa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Tryb ekspozycji</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Czas ekspozycji</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Lampa błyskowa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Kompensacja lampy błyskowej</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Maksymalna apertura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Przestrzeń kolorów</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Tryb pomiaru</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Balans bieli</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Model urządzenia</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Model soczewki</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>Importowanie...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation>Zaimportowano:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Import zakończony pomyślnie</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>Import zakończony niepowodzeniem</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Bez nazwy</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Nowy album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Nazwa:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Potwierdź</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>Nie znaleziono zdjęć i filmów</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Wybierz zdjęcia</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Import zakończony pomyślnie</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Import zakończony niepowodzeniem</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Dysk systemowy</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>Plik o tej nazwie już istnieje, użyj innej nazwy</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Kosz</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>Plik o tej nazwie już istnieje, użyj innej nazwy</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Potwierdź</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 zdjęcie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 zdjęć</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 film</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 filmów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Kosz</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>Pliki zostaną usunięte permanentnie po dniach, które na nich widnieją</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Usuń wszystkie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Zaznaczono (%1) do usunięcia</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Zaznaczono (%1) do przywrócenia</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Czy na pewno chcesz usunąć ten album?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>Znaleziono 1 zdjęcie</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>Znaleziono %1 zdjęć</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>Znaleziono 1 film</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>Znaleziono %1 filmów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>Znaleziono %1 przedmiotów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Wyniki wyszukiwania</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Pokaz slajdów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>Brak wyników wyszukiwania</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>Album &quot;%1&quot; został usunięty</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Galeria</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Kolekcja</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Ulubione</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Kosz</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Urządzenie</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Albumy</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Dodaj album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Przechwytywanie ekranu</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Rysowanie</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Pokaz slajdów</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Eksportuj</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Nowy album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Zmień nazwę</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Poprzednie</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Wstrzymaj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Odtwarzaj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Następne</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Wyjdź</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>dni</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>dzień</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dni</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>dzień</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Eksport zakończony pomyślnie</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Eksport zakończony niepowodzeniem</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Wyświetl</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Drukuj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Pokaz slajdów</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Dodaj do albumu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Nowy album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Pomyślnie dodano do &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Eksportuj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Usuń z albumu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Ulubione</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Usuń z ulubionych</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Obróć w prawo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Obróć w lewo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Ustaw jako tapetę pulpitu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Wyświetl w Menedżerze plików</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Przywróć</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Informacje o zdjęciu</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Informacje o filmie</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>Wróć do albumu</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Wyświetl</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Poprzednie</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Następne</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Drukuj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Rozmiar oryginalny</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Pokaz slajdów</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Dopasuj do okna</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Dodaj do albumu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Obróć</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Nowy album</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Pomyślnie dodano do &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Eksportuj</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopiuj</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Usuń</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Usuń z albumu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Ulubione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Usuń z ulubionych</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Obróć w prawo</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Obróć w lewo</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Ustaw jako tapetę pulpitu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Wyświetl w Menedżerze plików</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Przywróć</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Informacje o zdjęciu</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Informacje o filmie</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Eksport zakończony pomyślnie</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Eksport zakończony niepowodzeniem</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Wróć do albumu</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Poprzednie</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Następne</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Rozmiar oryginalny</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Dopasuj do okna</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Obróć</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Ulubione</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Usuń z ulubionych</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Wydobądź tekst</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Informacje podstawowe</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>Nazwa pliku</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Data uchwycenia</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Czas trwania</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Ścieżka</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Informacje o kodeku</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>Kodek wideo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Bitrate</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Proporcje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Rozdzielczość</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>Kodek audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Bitrate audio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Dźwięk cyfrowy</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Kanały</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Próbowanie</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Opuść pełny ekran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Drukuj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Wydobądź tekst</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Pokaz slajdów</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Eksportuj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Zmień nazwę</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Ulubione</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Usuń z ulubionych</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Obróć w prawo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Obróć w lewo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Wyświetl okno nawigacji</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Ukryj okno nawigacji</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Ustaw jako tapetę pulpitu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Wyświetl w Menedżerze plików</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Informacje o obrazie</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Eksport zakończony pomyślnie</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>Eksport zakończony niepowodzeniem</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Album to stylowe narzędzie do przeglądania i organizowania zdjęć i filmów.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 przedmiotów</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 przedmiot</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Wszystkie zdjęcia i filmy</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Import zakończony pomyślnie</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Import zakończony niepowodzeniem</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_pt.ts
+++ b/src/translations/deepin-album_pt.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Todas as fotos e vídeos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>O disco está ocupado, não pode ejetar agora</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation>OK</translation>
+        <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Sair de ecrã inteiro/apresentação</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atalhos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Mostrar no gestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Apresentação</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Exportar fotos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Importar fotos/vídeos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Informação de foto/vídeo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Definir como papel de parede</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Rodar para a direita</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Rodar para a esquerda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Aumentar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Diminuir</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Adicionar aos favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Remover dos favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Renomear álbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Página para acima</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Página para baixo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Álbuns</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Captura de ecrã</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Câmara</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Desenho</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Sem nome</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Canal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Imagens</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Importar ficheiros</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Álbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Versão:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>O Álbum é uma ferramenta de gestão elegante para ver e organizar fotos e vídeos.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 é lançado sob %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Mostrar painel lateral</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Ocultar painel lateral</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Proporção original</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Miniaturas quadradas</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Tudo</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Adicionar aos favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Remover dos favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Rodar</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Sem resultados</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Sem resultados</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>Não foram encontradas fotos ou vídeos</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Captura de ecrã</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Câmara</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Desenho</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(copiar)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 foto </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1 Unidade</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Disco %1 vazio</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1 Encriptado</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>Volume %1</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
-        <translation>Deseja eliminar este ficheiro localmente?</translation>
+        <translation>Eliminar este ficheiro localmente?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Pode restaurá-lo no lixo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
-        <translation>Deseja eliminar %1 ficheiros localmente?</translation>
+        <translation>Eliminar %1 ficheiros localmente?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Pode restaurá-los no lixo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Eliminar permanentemente este ficheiro?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Já não pode restaurar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Eliminar permanentemente %1 ficheiros?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Já não os pode restaurar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Importar para:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Importar tudo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>Importar 1 item</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>Importar %1 Itens</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Importação bem sucedida</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Sem resultados</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>A carregar...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Ignorar</translation>
     </message>
@@ -596,91 +598,91 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
-        <translation>O nome do ficheiro não pode estar em branco!</translation>
+        <translation>O nome do ficheiro não pode ficar em branco!</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation>OK</translation>
+        <translation>Aceitar</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Guardar em:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Imagens</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Documentos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Transferências</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Ambiente de trabalho</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Selecionar outros diretórios</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Formato:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Qualidade:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Exportação bem sucedida</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>A exportação falhou</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Sair de ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Extrair texto</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Apresentação</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Rodar para a direita</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Rodar para a esquerda</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Definir como papel de parede</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Mostrar no gestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Informação da imagem</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Aumentar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Diminuir</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Visualização da imagem</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atalhos</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>Texto ao vivo</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Tudo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Vídeos</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>A foto/vídeo já existe</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>1 item selecionado (1 foto)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>1 item selecionado (1 vídeo)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>%1 itens selecionados (%1 fotos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>%1 itens selecionados (%1 vídeos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>%1 itens selecionados (1 foto, %2 vídeos)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>%1 itens selecionados (%2 fotos, 1 vídeo)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>%1 itens selecionados (%2 fotos, %3 vídeos)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>Não tem permissão para ver a imagem</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>Imagem não encontrada</translation>
     </message>
@@ -914,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Importar Fotos e Vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation>ou arraste-os para aqui</translation>
+        <translation>ou arrastar para aqui</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Importado em</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 item</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 itens</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Informação básica</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>Nome do ficheiro</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Dimensões</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Data de captura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Data de modificação</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Detalhes</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Abertura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Programa de exposição</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Distância focal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Modo de exposição</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Tempo de exposição</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Compensação do flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Abertura máxima</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Espaço de cor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Modo de medição</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Equilíbrio de branco</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Modelo do dispositivo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Modelo de lente</translation>
     </message>
@@ -1058,41 +1071,36 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>A importar... </translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation>Importado:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Importação bem sucedida</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation>A importação falhou</translation>
+        <translation>Falha ao importar</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Sem nome</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>Não foram encontradas fotos ou vídeos</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Selecionar imagens</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Importação bem sucedida</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">A importação falhou</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Disco do sistema</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>O ficheiro já existe. Utilize outro nome</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%3/%2/%1 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Lixo</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Álbum</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>O ficheiro já existe. Utilize outro nome</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Lixo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>Os ficheiros serão eliminados permanentemente após os dias neles indicados</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Eliminar tudo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Eliminar selecionado (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Restaurar selecionado (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Tem a certeza que deseja eliminar este álbum?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>1 foto encontrada</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>%1 fotos encontradas</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>1 vídeo encontrado</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>%1 vídeos encontrados</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>%1 itens encontrados</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Resultados da pesquisa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Apresentação</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>Nenhum resultado correspondente à pesquisa</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>Álbum “%1” removido</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Galeria</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Coleção</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Lixo</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Álbuns</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Adicionar um álbum</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Captura de ecrã</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Câmara</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Desenho</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Apresentação</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Pausa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Reproduzir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Sair</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>dias</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>dia</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dias</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>dia</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Exportação bem sucedida</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>A exportação falhou</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Apresentação</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Adicionar ao álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Adicionado com sucesso a &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Remover do álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Adicionar aos favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Remover dos favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Rodar para a direita</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Rodar para a esquerda</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Definir como papel de parede</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Mostrar no gestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Informações da foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Informações do vídeo</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>Voltar ao álbum</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Anterior</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Próximo</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Tamanho original</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Apresentação</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Ajustar à janela</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Adicionar ao álbum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Rodar</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Adicionado com sucesso a &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Remover do álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Adicionar aos favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Remover dos favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Rodar para a direita</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Rodar para a esquerda</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Definir como papel de parede</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Mostrar no gestor de ficheiros</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Restaurar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Informações da foto</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Informações do vídeo</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Exportação bem sucedida</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">A exportação falhou</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Voltar ao álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Anterior</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Próximo</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Tamanho original</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Ajustar à janela</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Rodar</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Adicionar aos favoritos</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Remover dos favoritos</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Extrair texto</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Informação básica</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>Nome do ficheiro</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Data de captura</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Duração</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Caminho</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Informação do codec</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>ID do código de vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Taxa do código de vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Proporção</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Resolução</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>ID do Codec de áudio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Taxa do código de áudio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Dígito do áudio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Canais</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Amostragem</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Sair de ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Extrair texto</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Apresentação</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Adicionar aos favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Remover dos favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Rodar para a direita</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Rodar para a esquerda</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Mostrar janela de navegação</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Ocultar janela de navegação</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Definir como papel de parede</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Mostrar no gestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Informação da imagem</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Exportação bem sucedida</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>A exportação falhou</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>O Álbum é uma ferramenta de gestão elegante para ver e organizar fotos e vídeos.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Álbum</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 itens</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 item</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Todas as fotos e vídeos</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Importação bem sucedida</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">A importação falhou</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_pt_BR.ts
+++ b/src/translations/deepin-album_pt_BR.ts
@@ -4,870 +4,881 @@
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Todas as fotos e os vídeos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>O disco está em uso, e não pode ser ejetado no momento</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tela cheia</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Sair da Tela Cheia / Apresentação de Slides</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Exibir atalhos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Exibir no Gerenciador de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Apresentação de slides</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Visualizar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar fotos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar fotos/vídeos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informações da foto/vídeo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Definir como papel de parede</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Girar no sentido horário</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Girar no sentido anti-horário</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Aumentar zoom</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Reduzir zoom</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Remover dos Favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomear álbum</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Página acima</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Página abaixo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbuns</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Captura de tela</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Câmera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Desenhar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Sem Nome</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Canal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Imagens</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar pastas</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Versão:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum é um gerenciador elegante para ver e organizar fotos e vídeos.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 é lançado sob %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar painel lateral</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Ocultar painel lateral</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
-        <translation type="unfinished"></translation>
+        <translation>Proporção original</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
-        <translation type="unfinished"></translation>
+        <translation>Miniaturas quadradas</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation>A</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
-        <translation type="unfinished"></translation>
+        <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
-        <translation type="unfinished"></translation>
+        <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tudo</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Pesquisar</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritar</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Remover dos Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
-        <translation type="unfinished"></translation>
+        <translation>Rodar</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Apagar</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Não há resultados</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
-        <source>1 photo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
-        <source>%1 photos</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
-        <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <source>1 photo</source>
+        <translation>1 foto</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <source>%1 photos</source>
+        <translation>%1 fotos</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
+        <source>1 video</source>
+        <translation>1 vídeo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Não há resultados</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Nenhuma foto ou vídeo encontrado</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Captura de tela</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Câmera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Desenhar</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(cópia)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
-        <translation type="unfinished"></translation>
+        <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>Unidade %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Disco em Branco %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>Criptografado %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume %1</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>Tem certeza de que deseja excluir este arquivo localmente?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>Você pode restaurá-lo na lixeira</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>Tem certeza de que deseja excluir %1 arquivos localmente?</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>Você pode restaurá-los na lixeira</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>Tem certeza de que deseja excluir este arquivo permanentemente?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>Você não pode mais restaurá-lo</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>Tem certeza de que deseja excluir permanentemente %1 arquivos?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>Você não pode mais restaurá-los</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Apagar</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
-        <source>1 photo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
-        <source>%1 photos</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
-        <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <source>1 photo</source>
+        <translation>1 foto</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <source>%1 photos</source>
+        <translation>%1 fotos</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
+        <source>1 video</source>
+        <translation>1 vídeo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar para:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo Álbum</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar Tudo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar 1 item</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar %1 Itens</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Importação Bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Não há resultados</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Carregando...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignorar</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
-        <translation type="unfinished"></translation>
+        <translation>O nome de arquivo não pode ficar em branco</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Ok</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Salvar em:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Imagens</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Documentos</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Downloads</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Área de Trabalho</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Vídeos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Música</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecionar outros diretórios</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Formato:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Qualidade:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportação Bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Falha na exportação</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
-        <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
-        <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
-        <source>Extract text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <source>Fullscreen</source>
+        <translation>Tela cheia</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <source>Exit fullscreen</source>
+        <translation>Sair da Tela Cheia</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <source>Extract text</source>
+        <translation>Extrair texto</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Apresentação de Slides</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Renomear</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Apagar</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
-        <source>Open</source>
-        <translation type="unfinished"></translation>
+        <source>Rotate clockwise</source>
+        <translation>Girar no sentido horário</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1244"/>
-        <source>Print</source>
-        <translation type="unfinished"></translation>
+        <source>Rotate counterclockwise</source>
+        <translation>Girar no sentido anti-horário</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Definir como papel de parede</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Exibir no Gerenciador de Arquivos</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Informações da imagem</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Anterior</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Próximo</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1268"/>
-        <source>Image Viewing</source>
-        <translation type="unfinished"></translation>
+        <source>Zoom in</source>
+        <translation>Aumentar zoom</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1272"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
+        <source>Zoom out</source>
+        <translation>Reduzir zoom</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1276"/>
+        <source>Open</source>
+        <translation>Abrir</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
+        <source>Print</source>
+        <translation>Imprimir</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
+        <source>Image Viewing</source>
+        <translation>Visualização da Imagem</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
+        <source>Help</source>
+        <translation>Ajuda</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Exibir atalhos</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Texto ao vivo</translation>
     </message>
 </context>
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tudo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Vídeos</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>A foto/vídeo já existe</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
-        <translation type="unfinished"></translation>
+        <translation>1 item selecionado (1 foto)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 fotos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>O usuário não tem permissão para visualizar a imagem</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar Fotos e Vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Ou arraste-os pra cá</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Importado em</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,194 +958,194 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informações básicas</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome do arquivo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensões</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Data de captura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Última modificação</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Detalhes</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Abertura</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Programa de exposição</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Distância focal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Modo de exposição</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempo de exposição</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Compensação do flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Abertura máxima</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Espaço de Cores</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Modo de medida</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Balanço de branco</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
-        <translation type="unfinished"></translation>
+        <translation>Modelo do dispositivo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Modelo de lente</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importando...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Importação Bem-sucedida</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Falha na importação</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Sem Nome</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo Álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmar</translation>
     </message>
 </context>
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Nenhuma foto ou vídeo encontrado</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Disco do Sistema</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,99 +1169,99 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Lixeira</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmar</translation>
     </message>
 </context>
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
-        <source>1 photo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
-        <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <source>1 photo</source>
+        <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
-        <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
+        <source>%1 photos</source>
+        <translation>%1 fotos</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <source>1 video</source>
+        <translation>1 vídeo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 vídeos</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Lixeira</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>Os arquivos serão excluídos permanentemente após os dias mostrados neles</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Excluir Tudo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Excluir este álbum?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Apagar</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 foto encontrada</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 vídeo encontrado</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Resultados da pesquisa</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Apresentação de Slides</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Nenhum resultado encontrado</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum “%1” excluído</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galeria</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Lixeira</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbuns</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Captura de tela</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Câmera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Desenhar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Apresentação de slides</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomear</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pausar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Reproduzir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Sair</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>dias</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dias</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,393 +1481,507 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportação Bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Falha na exportação</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Visualizar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Apresentação de Slides</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Adicionar ao álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Novo álbum</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Adicionado em &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Excluir</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Remover do álbum</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Remover dos Favoritos</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Girar no sentido horário</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Girar no sentido anti-horário</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Definir como papel de parede</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Exibir no Gerenciador de Arquivos</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informações da foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Detalhes do vídeo</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Visualizar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Tela cheia</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Imprimir</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Apresentação de slides</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Adicionar ao álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Novo álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Adicionado em &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Apagar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Remover do álbum</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Favoritar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Remover dos Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Girar no sentido horário</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Girar no sentido anti-horário</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Definir como papel de parede</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Exibir no Gerenciador de Arquivos</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Restaurar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Informações da foto</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Detalhes do vídeo</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Exportação Bem-sucedida</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Falha na exportação</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajustar à janela</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
-        <translation type="unfinished"></translation>
+        <translation>Rodar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoritar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Remover dos Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
-        <translation type="unfinished"></translation>
+        <translation>Extrair texto</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Apagar</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informações básicas</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome do arquivo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Data de captura</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Duração</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Caminho</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>Detalhes do codec</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>ID do codec de vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Taxa do vídeo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>Quadros Por Segundo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>Proporção</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Resolução</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>ID do codec de áudio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Taxa do áudio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>Dígito do áudio</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>Canais</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>Amostragem</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tela cheia</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Sair da Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
-        <translation type="unfinished"></translation>
+        <translation>Extrair texto</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Apresentação de slides</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorito</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Remover dos Favoritos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Girar no sentido horário</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Girar no sentido anti-horário</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Exibir janela de navegação</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Ocultar janela de navegação</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Definir como papel de parede</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Exibir no Gerenciador de Arquivos</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informações da imagem</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportação Bem-sucedida</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Falha na exportação</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum é um gerenciador elegante para ver e organizar fotos e vídeos.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Álbum</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Todas as fotos e os vídeos</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_ro.ts
+++ b/src/translations/deepin-album_ro.ts
@@ -1,332 +1,332 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ro_RO">
+<TS version="2.1" language="ro">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Discul este ocupat, momentan nu se poate evacua </translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Ecran complet</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Ieșire ecran complet/prezentare</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajutor</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Afișare etichete</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Afișează în managerul de  fișiere</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Prezentare </translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Vizionare</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Selectează tot</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiere</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge </translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Setează ca imagine de fundal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotește în sensul acelor de ceasornic</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotește în sens opus acelor de ceasornic </translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Mărește</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Micșorează</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Precedent</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Următor</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulează favorit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album nou</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Redenumește album </translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Pagina sus</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Pagina jos</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Poze</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albume</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Anonim</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Poze</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album nou</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulează favorit</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge </translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -334,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -367,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,180 +399,180 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Disc</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Disc %1 Gol</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Criptat</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Volum</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge </translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Importă la:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importă</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album nou</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Importă tot</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Importare cu succes</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -580,233 +580,233 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Ignoră</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nume:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Salvează în:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Poze</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Documente</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Descărcări</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Desktop</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Video</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Muzică</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Selectați alte directoare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Calitate:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportare cu succes</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportare eșuată</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Ecran complet</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Ieșire ecran complet</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Prezentare</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Redenumire</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiere</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge </translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotește în sensul acelor de ceasornic</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotește în sens opus acelor de ceasornic </translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Setează ca imagine de fundal</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Afișează în managerul de  fișiere</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Precedent</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Următor</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Mărește</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Micșorează</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Printare</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajutor</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Afișare etichete</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Selectează tot</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Poze</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Video</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importă</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Nu aveți permisiunea de a vizualiza imaginea</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -929,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Importat la</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informații de bază</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimensiunile</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tip</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Data capturării</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Data modificării</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Detalii</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Vizor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Programul de expunere</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Distanța focală</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Modul de expunere</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Timpul de expunere</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Bliț</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Compensare bliț</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Vizor maximal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Spațiul de culori</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mod de măsurare</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Balansul de alb</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Model lentile</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importare...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Importare cu succes</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Importare eșuată</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Anonim</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album nou</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nume:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,7 +1145,7 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Disc Sistem</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunoi</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunoi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge Tot</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Doriți să ștergeți acest album?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge </translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Rezultatele căutării</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Prezentare</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Nici-un rezultat</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumul “%1” eliminat</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galerie</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Importă</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Gunoi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Dispozitiv </translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albume</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Prezentare </translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportă</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge </translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album nou</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Redenumire</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Precedent</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pauză</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Redare</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Următor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Ieșire</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>zile</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>zile</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,259 +1481,373 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportare cu succes</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportare eșuată</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Vizionare</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Ecran complet</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Printare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Prezentare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Adăugare la album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Album nou</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Adăugat cu succes la “%1” </translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Exportă</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Copiere</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminare din album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulează favorit</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Rotește în sensul acelor de ceasornic</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotește în sens opus acelor de ceasornic </translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Setează ca imagine de fundal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Afișează în managerul de fișiere</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Restabilire</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informații poză</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Vizionare</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Ecran complet</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Printare</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Prezentare </translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Adăugare la album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Album nou</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Adăugat cu succes la “%1” </translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Exportă</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Copiere</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Șterge </translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Eliminare din album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Favorit</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Anulează favorit</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Rotește în sensul acelor de ceasornic</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Rotește în sens opus acelor de ceasornic </translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Setează ca imagine de fundal</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Afișează în managerul de  fișiere</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Restabilire</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Informații poze</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Exportare cu succes</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Exportare eșuată</translation>
+    </message>
+</context>
+<context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Precedent</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Următor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Potrivire la fereastră</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulează favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge </translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informații de bază</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Data capturării</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tip</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,133 +1855,133 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Ecran complet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Ieșire ecran complet</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Printare</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Prezentare </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportă</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiere</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Redenumire</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Șterge </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Anulează favorit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotește în sensul acelor de ceasornic</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotește în sens opus acelor de ceasornic </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Afișează fereastră de navigare</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Ascunde fereastră de navigare</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Setează ca imagine de fundal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Afișează în managerul de  fișiere</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportare cu succes</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportare eșuată</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,7 +1989,7 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/deepin-album_ru.ts
+++ b/src/translations/deepin-album_ru.ts
@@ -1,1859 +1,1997 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ru_RU">
+<TS version="2.1" language="ru">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Все фото и видео</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Диск занят, в данный момент невозможно извлечь</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>На весь экран</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Выход из полноэкранного режиме / слайд-шоу</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Помощь</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Отображать ярлыки</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Отображать в файловом менеджере</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Слайд-шоу</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт фото</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Импорт фото/видео</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрать все</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Информация о фото/видео</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Установить в качестве обоев</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Повернуть по часовой стрелке</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Повернуть против часовой стрелки</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Приблизить</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Уменьшить</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Предыдущий</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Следующий</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить в избранное</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить из избранного</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый альбом</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименовать альбом</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Листать вверх</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Листать вниз</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Фотографии</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Альбомы</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Избранные</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Снимок экрана</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Рисунок</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Безымянный</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Канал</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Изображения</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый альбом</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Импорт папок</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Альбом</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Версия:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>Альбом — это стильный инструмент управления для просмотра и систематизации фотографий и видео.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 выпущен под %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать боковую панель</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
-        <translation type="unfinished"></translation>
+        <translation>Скрыть боковую панель</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходное соотношение</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
-        <translation type="unfinished"></translation>
+        <translation>Квадратные эскизы</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation>Г</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
-        <translation type="unfinished"></translation>
+        <translation>М</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
-        <translation type="unfinished"></translation>
+        <translation>Д</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Всё</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Поиск</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить в избранное</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить из избранного</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
-        <translation type="unfinished"></translation>
+        <translation>Повернуть</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет результатов</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
-        <source>1 photo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
-        <source>%1 photos</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
-        <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <source>1 photo</source>
+        <translation>1 фото</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <source>%1 photos</source>
+        <translation>%1 фото</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
+        <source>1 video</source>
+        <translation>1 видео</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет результатов</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Фото или видео не найдено</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Снимок экрана</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Рисунок</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(копия)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
-        <translation type="unfinished"></translation>
+        <translation>1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
-        <translation type="unfinished"></translation>
+        <translation>%1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Диск</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Пустой % 1 Диск</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>% 1 Зашифровано</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Том</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>Вы уверены, что хотите локально удалить этот файл?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>Вы можете восстановить их в корзину</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>Вы уверены, что хотите локально удалить %1 файлов?</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>Вы можете восстановить их в корзину</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>Вы уверены, что хотите навсегда удалить этот файл?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>Его будет невозможно восстановить</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>Вы уверены, что хотите безвозвратно удалить %1 файлов?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>Их будет невозможно восстановить</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
-        <source>1 photo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
-        <source>%1 photos</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
-        <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <source>1 photo</source>
+        <translation>1 фото</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <source>%1 photos</source>
+        <translation>%1 фото</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
+        <source>1 video</source>
+        <translation>1 видео</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортировать в:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортировать</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый альбом</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортировать всё</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортировать 1 элемент</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортировать %1 элементов</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Импорт успешно завершен</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет результатов</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Загрузка...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Игнорировать</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла не может быть пустым!</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>ОК</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить в:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Изображения</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Документы</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Загрузки</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Рабочий стол</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Видео</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Музыка</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрать другие папки</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Формат:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Качество:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Подтвердить</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт успешно завершен</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось экспортировать</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
-        <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
-        <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
-        <source>Extract text</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <source>Fullscreen</source>
+        <translation>На весь экран</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <source>Exit fullscreen</source>
+        <translation>Выход из полноэкранного режима</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <source>Extract text</source>
+        <translation>Извлечь текст</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Слайд-шоу</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Переименовать</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Копировать</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Удалить</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
-        <source>Open</source>
-        <translation type="unfinished"></translation>
+        <source>Rotate clockwise</source>
+        <translation>Повернуть по часовой стрелке</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1244"/>
-        <source>Print</source>
-        <translation type="unfinished"></translation>
+        <source>Rotate counterclockwise</source>
+        <translation>Повернуть против часовой стрелки</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Установить в качестве обоев</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Отображать в файловом менеджере</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Сведения об изображении</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Предыдущий</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Следующий</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1268"/>
-        <source>Image Viewing</source>
-        <translation type="unfinished"></translation>
+        <source>Zoom in</source>
+        <translation>Увеличить</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1272"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
+        <source>Zoom out</source>
+        <translation>Уменьшить</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1276"/>
+        <source>Open</source>
+        <translation>Открыть</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
+        <source>Print</source>
+        <translation>Печать</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
+        <source>Image Viewing</source>
+        <translation>Просмотр изображения</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
+        <source>Help</source>
+        <translation>Помощь</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Отображать ярлыки</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрать все</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Живой текст</translation>
     </message>
 </context>
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Всё</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Фотографии</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Видео</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>Фото/видео уже существует</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбран 1 элемент (1 фото)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбран 1 элемент (1 видео)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрано элементов: %1 (%1 фото)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
+        <translation>Выбрано элементов: %1 (%1 видео)</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрано элементов: %1 (1 фото, %2 видео)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрано элементов: %1 (%2 фото, 1 видео)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрано элементов: %1 (%2 фото, %3 видео)</translation>
     </message>
 </context>
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортировать</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>У вас нет разрешения на просмотр изображения</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл изображения не найден</translation>
     </message>
 </context>
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Импорт фото и видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Или перетащите их сюда</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортировано на</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
-        <translation type="unfinished"></translation>
+        <translation>1 элемент</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
-        <translation type="unfinished"></translation>
+        <translation>Элементов: %1</translation>
     </message>
 </context>
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Основная информация</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Размеры</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Дата создания</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Дата изменения</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Подробные сведения</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Диафрагма</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Программа экспозиции</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Фокусное расстояние</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Режим экспозиции</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Время экспозиции</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Вспышка</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Компенсация вспышки</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Максимальная Диафрагма</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Цветовое пространство</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Режим измерения</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Баланс белого</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
-        <translation type="unfinished"></translation>
+        <translation>Модель устройства</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Модель объектива</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортирование...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортировано:</translation>
     </message>
     <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation>%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Импорт успешно завершен</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось импортировать</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Безымянный</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый альбом</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Подтвердить</translation>
     </message>
 </context>
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Ни фото, ни видео не найдено</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Выберите изображения</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Системный диск</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл уже существует, используйте другое имя</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Корзина</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Альбом</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл уже существует, используйте другое имя</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <translation>Подтвердить</translation>
     </message>
 </context>
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
-        <source>1 photo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
-        <source>%1 photos</source>
-        <translation type="unfinished"></translation>
+        <source>1 photo</source>
+        <translation>1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
-        <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
+        <source>%1 photos</source>
+        <translation>%1 фото</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <source>1 video</source>
+        <translation>1 видео</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Корзина</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы будут безвозвратно удалены по истечении указанных дней.</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить всё</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить выбранное (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Восстановить выбранное (%1)</translation>
     </message>
 </context>
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вы уверены, что хотите удалить этот альбом?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>Найдено 1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Найдено %1 фото</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>Найдено 1 видео</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
+        <source>%1 videos found</source>
+        <translation>Найдено %1 видео</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
-        <source>%1 videos found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
         <source>%1 items found</source>
-        <translation type="unfinished"></translation>
+        <translation>Найдено элементов: %1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Результаты поиска</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Cлайд-шоу</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Нет результатов поиска</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Альбом “%1” удален</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Галерея</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
-        <translation type="unfinished"></translation>
+        <translation>Коллекция</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Импортировать</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Избранные</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Корзина</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Устройство</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Альбомы</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить альбом</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Снимок экрана</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Рисунок</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Слайд-шоу</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый альбом</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименовать</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Предыдущий</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Пауза</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Воспроизвести</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Следующий</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Выход</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>дней</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>day</source>
-        <translation type="unfinished"></translation>
+        <translation>день</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>дней</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>day</source>
+        <translation>день</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт успешно завершен</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось экспортировать</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Показать</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>На весь экран</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Печать</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Слайд-шоу</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить в альбом</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Новый альбом</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Успешно добавлено в “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Экспорт</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Копировать</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить из альбома</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Избранное</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить из избранного</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Повернуть по часовой стрелке</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Повернуть против часовой стрелки</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Установить в качестве обоев</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Отображать в файловом менеджере</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Восстановить</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Информация о фотографии</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Информация о  видео</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Показать</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>На весь экран</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Печать</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Слайд-шоу</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Добавить в альбом</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Новый альбом</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Успешно добавлено в “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Экспорт</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Копировать</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Удалить из альбома</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Добавить в избранное</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Удалить из избранного</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Повернуть по часовой стрелке</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Повернуть против часовой стрелки</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Установить в качестве обоев</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Отображать в файловом менеджере</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Восстановить</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Информация о фотографии</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Информация о  видео</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Экспорт успешно завершен</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Не удалось экспортировать</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Назад к альбому</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Предыдущий</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Следующий</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
-        <translation type="unfinished"></translation>
+        <translation>Исходный размер</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Подходит для окна</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
-        <translation type="unfinished"></translation>
+        <translation>Повернуть</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Добавить в избранное</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить из избранного</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
-        <translation type="unfinished"></translation>
+        <translation>Извлечь текст</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Основная информация</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя файла</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Дата создания</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Продолжительность</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Путь</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>Информация о кодеке</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Идентификатор видеокодека</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Битрейт</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>Кадров в секунду</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>Соотношение сторон</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Разрешение</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Идентификатор аудиокодека</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Битрейт</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>Цифровое аудио</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>Каналы</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>Сэмплирование</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>На весь экран</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Выход из полноэкранного режима</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Печать</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
-        <translation type="unfinished"></translation>
+        <translation>Извлечь текст</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Слайд-шоу</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Переименовать</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Избранное</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Удалить из избранного</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Повернуть по часовой стрелке</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Повернуть против часовой стрелки</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать окно навигации</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Скрыть окно навигации</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Установить в качестве обоев</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Отображать в файловом менеджере</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Сведения об изображении</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Экспорт успешно завершен</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось экспортировать</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
-        <translation type="unfinished"></translation>
+        <translation>Альбом — это стильный инструмент управления для просмотра и систематизации фотографий и видео.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Альбом</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
-        <translation type="unfinished"></translation>
+        <translation>Элементов: %1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
-        <translation type="unfinished"></translation>
+        <translation>1 элемент</translation>
     </message>
 </context>
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Все фото и видео</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_sl.ts
+++ b/src/translations/deepin-album_sl.ts
@@ -1,812 +1,812 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sl_SI">
+<TS version="2.1" language="sl">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Vse slike in videi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk deluje in ga trenutno ni mogoče izvreči</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Celozaslonsko</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Zapri celozaslonski način/diaprojekcijo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>omoč</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži bljižnice</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži v upravljalniku datotek</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaprojekcija</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaz</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvozi slike</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozi slike/videe</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Izberi vse</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Podatki o sliki/videu</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Določi kot ozadje namizja</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Obrni proti smeri urinega kazalca</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Obrni proti smeri urinega kazalca</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Približaj</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Oddalji</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Nazaj</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Naprej</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Priljubljeno</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Nepriljubljeno</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nov album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Preimenuj album</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Prejšnja stran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Naslednja stran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Slike</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastavitve</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Priljubljeno</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Zajemi Zaslon</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Riši</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>brez imena</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Slike</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nov album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Vse</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Priljubljeno</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Nepriljubljeno</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ena slika</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>en video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Ni rezultatov</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ena slika</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>en video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Ni rezultatov</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Ni najdenih slik ali videev</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Zajemi Zaslon</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Riši</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(kopiraj)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ena slika</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>en video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 pogon</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Prazen %1 disk</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 šifrirano</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 nosilec</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ena slika</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>en video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozi v:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nov album</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozi vse</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvažanje je uspelo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Ni rezultatov</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Nalaganje...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Prezri</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>V redu</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ime:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Shrani v:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Slike</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Dokumenti</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Prenosi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Namizje</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Video posnetki</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Glasba</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Izberi druge mape</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kakovost:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvažanje je uspelo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvažanje ni uspelo</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Celozaslonsko</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Zapri celozaslonski način</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Diaprojekcija</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Preimenuj</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Kopiraj</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Izbriši</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>Obrni proti smeri urinega kazalca</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Obrni proti smeri urinega kazalca</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Določi kot ozadje namizja</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Prikaži v upravljalniku datotek</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Podatki o sliki</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Nazaj</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Naprej</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>Približaj</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>Oddalji</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiskanje</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>omoč</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži bljižnice</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastavitve</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Izberi vse</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Vse</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Slike</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Video posnetki</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>Slika/video že obstaja</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ena slika</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>en video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozi</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Nimate pravic za ogled slike</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozite slike in videe</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Ali jih povlecite sem</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvoženo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Osnovni podatki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Dimenzije</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Vrsta</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Datum snemanja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Datum spremembe</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Podrobnosti</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaslonka</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Progam osvetljevanja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Goriščna razdalja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Način osvetljevanja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Čas osvetljevanja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Bliskavica</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Kompenzacija bliskavice</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Največja zaslonka</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Barvni prostor</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Način merjenja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Ravnovesje beline</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Model objektiva</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvažanje...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Uvažanje je uspelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvažanje ni uspelo</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>brez imena</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nov album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ime:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Ni najdenih slik ali videev</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistemski disk</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Smetnjak</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>ena slika</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>en video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Smetnjak</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>Datoteke bodo trajno izbrisane po preteku prikazanega števila dni</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši vse</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Ali ste prepričani, da želite izbrisati ta album?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>en najdena slika</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>en najden video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Rezultati iskanj</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaprojekcija</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Ni najdenih</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Album “%1” je bil odstranjen</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galerija</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Uvozi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Priljubljeno</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Smetnjak</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Naprava</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albumi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Zajemi Zaslon</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Riši</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaprojekcija</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvozi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Nov album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Preimenuj</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Nazaj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pavza</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Predvajaj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Naprej</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Izhod</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>dni</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>dni</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,393 +1481,507 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvažanje je uspelo</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvažanje ni uspelo</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Prikaz</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Celozaslonsko</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiskanje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaprojekcija</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Dodaj v album</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Nov album</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Uspešno dodano k &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Izvozi</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Kopiraj</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Odstrani iz albuma</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Priljubljeno</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Nepriljubljeno</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Obrni proti smeri urinega kazalca</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Obrni proti smeri urinega kazalca</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Določi kot ozadje namizja</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži v upravljalniku datotek</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Obnovi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Podatki o sliki</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Podatki o videu</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Prikaz</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Celozaslonsko</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Tiskanje</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Diaprojekcija</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Dodaj v album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Nov album</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Uspešno dodano k &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Izvozi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopiraj</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Izbriši</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Odstrani iz albuma</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Priljubljeno</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Nepriljubljeno</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Obrni proti smeri urinega kazalca</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Obrni proti smeri urinega kazalca</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Določi kot ozadje namizja</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Prikaži v upravljalniku datotek</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Obnovi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Podatki o sliki</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Podatki o videu</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Izvažanje je uspelo</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Izvažanje ni uspelo</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Nazaj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Naprej</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Prilagodi oknu</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Priljubljeno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Nepriljubljeno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Osnovni podatki</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Datum snemanja</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Čas trajanja</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Vrsta</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Pot</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>Podatki o kodeku</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Video naziv kodeka</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Video kakovost kodeka</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>Slik/s</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>Razmerje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Ločljivost</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Zvok naziv kodeka</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Zvok kakovost kodeka</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>Zvok decimalke</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>ali</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>Vzorčenje</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Celozaslonsko</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Zapri celozaslonski način</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Tiskanje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Diaprojekcija</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvozi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Preimenuj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Priljubljeno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Nepriljubljeno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Obrni proti smeri urinega kazalca</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Obrni proti smeri urinega kazalca</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži navigacijsko okno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Skrij navigacijsko okno</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Določi kot ozadje namizja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Prikaži v upravljalniku datotek</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Podatki o sliki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvažanje je uspelo</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvažanje ni uspelo</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Album</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Vse slike in videi</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_sq.ts
+++ b/src/translations/deepin-album_sq.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Krejt fotot dhe videot</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>Disku është i zënë, s’nxirret dot tani</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Dil nga mënyra Sa krejt ekrani/Shfaqje si diapozitiva</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Ndihmë</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Shfaq shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Shfaqe te përgjegjës kartelash</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Shfaqje si diapozitiva</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Shihni</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Eksporto foto</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Importo foto/video</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Përzgjidhi krejt</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Hollësi fotosh/videosh</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Vëre si sfond</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Rrotulloje në kahun orar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Rrotulloje në kahun anti-orar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Zmadhoje</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Zvogëloje</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>E mëparshmja</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Pasuesja</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Vëre si të parapëlqyer</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Hiqe nga të parapëlqyerat</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Album i ri</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Riemërtoni albumin</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Tasti “Page up”</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Tasti “Page down”</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Foto</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Albume</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Të parapëlqyerit</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Kamerë</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>I paemër</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Kanal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Foto</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Album i ri</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Importo dosje</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Version:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Album-i është  një mjet i hijshëm administrimi për të parë dhe sistemuar foto dhe video.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 hidhet në qarkullim sipas %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Shfaq kuadrat anësor</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Fshihe kuadratin anësor</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Përpjestimi origjinal</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Miniatura katrore</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Krejt</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Kërko</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Vëre si të parapëlqyer</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Hiqe nga të parapëlqyerat</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Rrotulloje</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Pa përfundime</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Pa përfundime</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>S’u gjetën foto apo video</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Kamerë</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(kopje)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>Pajisja %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Zbardh Diskun %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1 i Fshehtëzuar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>Vëllim %1</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Jeni i sigurt se doni të fshihet kjo kartelë lokalisht?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Mund ta riktheni që nga hedhurinat</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>Jeni i sigurt se doni të fshihen %1 kartela lokalisht?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Mund t’i riktheni që nga hedhurinat</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Jeni i sigurt se doni të fshihet përgjithnjë kjo kartelë?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>S’mund të riktheni më</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Jeni i sigurt se doni të fshihen përgjithnjë %1 kartela?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>S’mund t’i riktheni më</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Importo te:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Importo</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Album i Ri</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Importoji Krejt</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>Importo 1 objekt</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>Importo %1 objekte</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Importim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Pa përfundime</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Po ngarkohet…</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Shpërfille</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>Emri i kartelës s’mund të jetë i zbrazët!</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Emër:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Ruaje te:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Dokumente</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Shkarkime</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Ekran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Muzikë</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Përzgjidhni drejtori të tjera</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Format:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Cilësi:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Ripohojeni</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Eksportim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Eksportimi dështoi</translation>
     </message>
@@ -688,141 +690,141 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Dil nga mënyra Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Përfto tekst</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Shfaqje si diapozitiva</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Riemërtoje</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Rrotulloje në kahun orar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Rrotulloje në kahun anti-orar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Vëre si sfond</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Shfaqe te përgjegjës kartelash</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Hollësi figure</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>E mëparshmja</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Pasuesja</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Zmadhoje</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Zvogëloje</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Hape</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Shtype</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Parje Figurash</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Ndihmë</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Shfaq shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Përzgjidhni krejt</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Krejt</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Foto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Video</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>Fotoja/videoja ekziston tashmë</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>1 objekt i përzgjedhur (1 foto)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>1 objekt i përzgjedhur (1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>%1 objekte të përzgjedhur (%1 foto)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>%1 objekte të përzgjedhur (%1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>%1 objekte të përzgjedhur (1 foto, %2 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>%1 objekte të përzgjedhur (%2 foto, 1 video)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>%1 objekte të përzgjedhur (%2 foto, %3 video)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Importo</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>S’keni leje për të parë figurën</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>S’u gjet kartelë figurë</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Importoni Foto dhe Video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>Ose tërhiqini këtu</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Importuar më</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 objekt</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 objekte</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Të dhëna elementare</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>Emër kartele</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Përmasa</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Lloj</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Datë e bërjes</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Datë e ndryshimit</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Hollësi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Hapje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Program ekspozimi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Rreze vatrore</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Mënyrë ekspozimi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Kohë ekspozimi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Flash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Kompensim flashi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Hapje maksimale</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Sistem ngjyrash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Mënyrë matjeje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Balancë të bardhe</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Model pajisjeje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Model thjerrash</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>Po importohet…</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Importim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>Importimi dështoi</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>I paemër</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Album i Ri</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Emër:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Ripohojeni</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>S’u gjetën foto ose video</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Përzgjidhni foto</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Importim i suksesshëm</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Importimi dështoi</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Disk Sistemi</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>Kartela ekziston tashmë, ju lutemi, përdorni tjetër emër</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Shpjere te hedhurinat</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>Kartela ekziston tashmë, ju lutemi, përdorni tjetër emër</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Ripohojeni</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Shpjere te hedhurinat</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>Kartelat do të fshihen përgjithmonë, pas ditëve të treguara në to</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Fshiji Krejt</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Fshiji të Përzgjedhurat (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Rikthe të Përzgjedhurat (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>A jeni i sigurt se doni të fshihet ky album?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>U gjet 1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>U gjetën %1 foto</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>U gjet 1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>U gjetën %1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>U gjetën %1 objekte</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Përfundime kërkimi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Shfaqje Si Diapozitiva</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>S’ka përfundime kërkimi</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>Albumi “%1” u hoq</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Galeri</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Koleksion</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Importo</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Të parapëlqyerit</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Shpjere te hedhurinat</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Pajisje</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Albume</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Shtoni një album</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Kamerë</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Shfaqje si diapozitiva</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Eksporto</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Album i ri</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Riemërtoje</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>E mëparshmja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Pauzë</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Luaje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Pasuesja</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Dalje</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>ditë</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>ditë</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>ditë</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>ditë</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Eksportim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Eksportimi dështoi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Shihni</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Shtype</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Shfaqje si diapozitiva</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Shtoje te albumi </translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Album i ri</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>U shtua me sukses te “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Eksporto</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Hiqe nga albumi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Vëre si të parapëlqyer</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Hiqe nga të parapëlqyerat</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Rrotulloje në kahun orar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Rrotulloje në kahun anti-orar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Vëre si sfond</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Shfaqe te përgjegjës kartelash</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Riktheje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Të dhëna fotoje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Hollësi videoje</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>Mbrapsht te Albumi</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Shihni</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>E mëparshmja</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Pasuesja</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Shtype</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Madhësia origjinale</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Shfaqje si diapozitiva</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Sa dritarja</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Shtoje te albumi </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Rrotulloje</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Album i ri</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>U shtua me sukses te “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Eksporto</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopjoje</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Fshije</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Hiqe nga albumi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Vëre si të parapëlqyer</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Hiqe nga të parapëlqyerat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Rrotulloje në kahun orar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Rrotulloje në kahun anti-orar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Vëre si sfond</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Shfaqe te përgjegjës kartelash</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Riktheje</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Të dhëna fotoje</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Hollësi videoje</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Eksportim i suksesshëm</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Eksportimi dështoi</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Mbrapsht te Albumi</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>E mëparshmja</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Pasuesja</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Madhësia origjinale</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Sa dritarja</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Rrotulloje</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Vëre si të parapëlqyer</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Hiqe nga të parapëlqyerat</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Përfto tekst</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
@@ -1634,196 +1761,196 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Hollësi elementare</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>Emër kartele</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Datë e bërjes</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Kohëzgjatje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Lloj</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Shteg</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Hollësi kodeku</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>CodecID Videoje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>CodeRate Videoje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>KPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Përpjestim</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Qartësi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>CodecID Audioje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>CodeRate Audioje</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Kanale</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Dil nga mënyra “Sa krejt ekrani”</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Shtype</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Përfto tekst</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Shfaqje si diapozitiva</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Eksporto</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Riemërtoje</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Vëre si të parapëlqyer</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Hiqe nga të parapëlqyerat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Rrotulloje në kahun orar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Rrotulloje në kahun anti-orar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Shfaq dritare lëvizjesh</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Fshih dritare lëvizjesh</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Vëre si sfond</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Shfaqe te përgjegjës kartelash</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Hollësi figure</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Eksportim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>Eksportimi dështoi</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>Album-i është  një mjet i hijshëm administrimi për të parë dhe sistemuar foto dhe video.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 objekte</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 objekt</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Krejt fotot dhe videot</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Importim i suksesshëm</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Importimi dështoi</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_sr.ts
+++ b/src/translations/deepin-album_sr.ts
@@ -1,812 +1,812 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sr_RS">
+<TS version="2.1" language="sr">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Све слике и видео записи</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Диск је заузет, не може се избацити сад</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>У реду</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Цео екран</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Напусти цео екран/покретни приказ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Помоћ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикажи пречице</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикажи у управнику података</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Покретни приказ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикажи</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Извези слике</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Увези слике/видео снимке</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Изабаери све</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Копирај</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Обриши</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Информације о слици/видео снимку</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Постави као позадину</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Ротирај удесно</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Ротирај улево</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Увећај</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Умањи</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Претходно</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Следеће</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>У омиљено</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Из омиљеног</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Нови албум</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Преименуј албум</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Страница нагоре</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Страница надоле</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Слике</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Албуми</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Подешавања</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Омиљено</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Сними екран</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Цртеж</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Неименовано</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Канал</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Слике</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Нови албум</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Увези фасцикле</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Албум</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Све</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>У омиљено</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Из омиљеног</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Обриши</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 слика</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Нема резултата</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 слика</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Нема резултата</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Нису пронађене слике или видео записи</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Сними екран</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Цртеж</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(копија)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 слика</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 уређај</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Пеазан %1 диск</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 шифровано</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 диск</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>Заиста желите да обришете ову дадотеку локално?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>Можете га вратити из канте</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>Заиста желите да обришете %n дадотекa локално?</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>Можете их вратити из канте</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>Заиста желите да трајно обришете ову дадотеку?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>Не можете више да га вратите</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>Заиста желите да трајно обришете %n дадотека?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>Не можете их више вратити</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Обриши</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 слика</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Увези у:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Увезено</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Нови албум</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Увези све</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Успешно увезено</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Нема резултата</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Учитавање...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Занемари</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>У реду</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Име:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Сачувај у:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Слике</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Документи</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>Преузимања</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Радна површина</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Видео</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Музика</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Изабери друге директоријуме</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Формат:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Квалитет:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Успешно извезено</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Неуспешан извоз</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Цео екран</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Напусти цео екран</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Покретни приказ</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Преименуј</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Копирај</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Обриши</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>Ротирај удесно</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Ротирај улево</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Постави као позадину</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Прикажи у управнику података</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Информације о слици</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Претходно</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Следеће</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>Увећај</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>Умањи</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Штампај</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Помоћ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикажи пречице</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Подешавања</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Изабаери све</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Све</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Слике</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Видео</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>Слика или видео већ постоји</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 слика</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Увезено</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Немате дозволу да видите слику</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Увези слике и видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Или их превуци овде</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>Увезено</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Основни подаци</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Димензије</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Врста</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Датум усликавања</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Датум измене</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Детаљи</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Бленда</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Програм експозиције </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Жижна даљина</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ИСО</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Режим експозиције</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Трајање експозиције </translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Блиц</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Компензација блица</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Највећа бленда</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Опсег боја</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Режим мерача</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Баланс беле</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Модел сочива</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Увоз...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>Успешно увезено</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Неуспешан увоз</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Неименовано</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Нови албум</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Име:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Нису пронађене слике или видео записи</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Системски диск</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Смеће</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Албум</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 слика</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Смеће</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>Дадотеке ће бити трајно обрисане након неколико дана приказано на истим</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Обриши све</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Заиста желите да обришете овај албум?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Обриши</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 слика пронађена</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 видео пронађен</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Резултати претраге</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Покретни приказ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Нема резултата претраге</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Албум “%1” уклоњен</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Галерија</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>Увезено</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Омиљено</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Смеће</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Уређај</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Албуми</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Сними екран</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Цртеж</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Покретни приказ</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Извези</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Обриши</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Нови албум</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Преименуј</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Претходно</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Паузирај</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Пусти</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Следеће</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Изађи</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>дана</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>дана</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,393 +1481,507 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Успешно извезено</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Неуспешан извоз</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Прикажи</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Цео екран</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Штампај</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Покретни приказ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Додај у албум</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Нови албум</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Успешно додато у “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Извези</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Копирај</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Обриши</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Уклини из албума</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>У омиљено</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Из омиљеног</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Ротирај удесно</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Ротирај улево</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Постави као позадину</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикажи у управнику података</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Врати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Подаци слике</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Подаци видеа</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Прикажи</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Цео екран</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Штампај</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Покретни приказ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Додај у албум</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Нови албум</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Успешно додато у “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Извези</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Копирај</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Обриши</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Уклоини из албума</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>У омиљено</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Из омиљеног</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Ротирај удесно</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Ротирај улево</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Постави као позадину</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Прикажи у управнику података</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Врати</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Подаци слике</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Подаци видеа</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Успешно извезено</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Неуспешан извоз</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Претходно</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Следеће</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Уклопи у прозор</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>У омиљено</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Из омиљеног</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Обриши</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Основни подаци</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Датум усликавања</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Трајање</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Врста</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Путања</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>Информације кодека</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>CodecID видео снимка</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>CodeRate видео снимка</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>Размера</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Резолуција</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>CodecID аудио дадотеке</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>CodeRate аудио дадотеке</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>Цифра аудио дадотеке</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>Канали</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикупљање узорака</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Цео екран</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Напусти цео екран</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Штампај</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Покретни приказ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Извези</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Копирај</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Преименуј</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Обриши</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>У омиљено</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Из омиљеног</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Ротирај удесно</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Ротирај улево</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикажи навигациони прозор</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Сакриј навигациони прозор</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Постави као позадину</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Прикажи у управнику података</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Информације о слици</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Успешно извезено</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Неуспешан извоз</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Албум</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Све слике и видео записи</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_tr.ts
+++ b/src/translations/deepin-album_tr.ts
@@ -1,812 +1,812 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="tr_TR">
+<TS version="2.1" language="tr">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm fotoğraflar ve videolar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk meşgul, şimdi çıkartılamıyor</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamam</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>Çıkış tam ekran/slayt gösterisi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Yardım</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Kısayolları görüntüle</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya yöneticisinde görüntüle</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slayt gösterisi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Görünüm</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoğrafları dışa aktar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoğrafları/videoları içe aktar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Tümünü seç</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoğraf/Video bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Duvar kağıdı yap</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Saat yönünde döndür</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Saat yönünün tersine döndür</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>Yakınlaştır</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzaklaştır</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Önceki</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonraki</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori değil</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni albüm</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albümü adlandır</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>Sayfa yukarı</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>Sayfa aşağı</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoğraflar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albümler</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoriler</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekran görüntüsü</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Çiz</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>İsimsiz</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanal</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Resimler</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni albüm</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Klasörleri içe aktar</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albüm</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tümü</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori değil</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotoğraf</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonuç yok</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotoğraf</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonuç yok</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoğraf veya video bulunamadı</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekran görüntüsü</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Çiz</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(kopyala)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotoğraf</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Disk %1 Boş</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1  Şifreli </translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 Birim</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>Bu dosyayı yerel olarak silmek istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>Çöp kutusundan geri yükleyebilirsiniz</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>%1 dosyasını yerel olarak silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>Onları çöp kutusundan geri yükleyebilirsiniz</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>Bu dosyayı kalıcı olarak silmek istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>Artık geri yükleyemezsiniz</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>%1 dosyasını kalıcı olarak silmek istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>Artık onları geri yükleyemezsiniz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotoğraf</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>Şuradan içe aktar:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>İçe aktar</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Albüm</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tümünü İçe Aktar</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>İçe aktarma başarılı</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonuç yok</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>Yoksay</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamam</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>İsim:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Şuraya kaydet:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>Resimler</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>Belgeler</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>İndirilenler</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>Masaüstü</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>Videolar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>Müzik</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>Diğer dizinleri seç</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>Biçim:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>Kalite:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktarma başarılı</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktarma başarısız</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam ekrandan çık</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>Slayt gösterisi</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>Adlandır</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>Kopyala</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>Sil</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>Saat yönünde döndür</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Saat yönünün tersine döndür</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>Duvar kağıdı yap</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>Dosya yöneticisinde görüntüle</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>Resim bilgisi</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>Önceki</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>Sonraki</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>Yakınlaştır</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>Uzaklaştır</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Yazdır</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
-        <translation type="unfinished"></translation>
+        <translation>Resim Görüntüleniyor</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Yardım</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>Kısayolları görüntüle</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>Tümünü seç</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tümü</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoğraflar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Videolar</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>Fotoğraf/video zaten var</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotoğraf</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>İçe aktar</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Resmi görüntüleme izniniz yok</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoğrafları ve Videoları İçe Aktar</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>Veya onları buraya sürükleyin</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>İçe aktarıldı</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Temel bilgi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>Boyutlar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tür</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Alındığı tarih</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>Değiştirilme tarihi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayrıntılar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Açıklık</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>Pozlama programı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>Odak uzaklığı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Pozlama kipi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>Pozlama zamanı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>Flaş</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>Flaş telafisi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>Azami açıklık</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Renk alanı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Ölçme kipi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>Beyaz dengesi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>Lens modeli</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>İçe aktarılıyor...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>İçe aktarma başarılı</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>İçe aktarma başarısız</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>İsimsiz</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Albüm</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>İsim:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoğraf veya video bulunamadı</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem Diski</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Çöp kutusu</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albüm</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotoğraf</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Çöp kutusu</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyalar, üzerlerinde gösterilen günlerden sonra kalıcı olarak silinecek</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>Tümünü Sil</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu albümü silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 fotoğraf bulundu</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 video bulundu</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Arama sonuçları</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slayt Gösterisi</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>Arama sonucu bulunamadı</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Albüm “%1” kaldırıldı</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>Galeri</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>İçe aktar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>Favoriler</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>Çöp kutusu</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Aygıt</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>Albümler</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>Ekran görüntüsü</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>Çiz</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slayt gösterisi</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktar</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni albüm</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Adlandır</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Önceki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Duraklat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Oynat</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonraki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>Çıkış</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>gün</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>gün</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,393 +1481,507 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktarma başarılı</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktarma başarısız</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>Görünüm</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Yazdır</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slayt gösterisi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albüme ekle</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni albüm</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>Başarıyla eklendi “%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>Dışa aktar</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>Kopyala</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albümden kaldır</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori değil</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>Saat yönünde döndür</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Saat yönünün tersine döndür</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Duvar kağıdı yap</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya yöneticisinde göster</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Kurtar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>Fotoğraf bilgisi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>Video bilgisi</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Görünüm</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>Tam ekran</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Yazdır</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Slayt gösterisi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Albüme ekle</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Yeni albüm</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Başarıyla eklendi “%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Dışa aktar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Kopyala</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Sil</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Albümden kaldır</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>Favori</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>Favori değil</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Saat yönünde döndür</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Saat yönünün tersine döndür</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Duvar kağıdı yap</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Dosya yöneticisinde görüntüle</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Kurtar</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Fotoğraf bilgisi</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Video bilgisi</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Dışa aktarma başarılı</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Dışa aktarma başarısız</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Önceki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Sonraki</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>Pencereye sığdır</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori değil</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>Temel bilgi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>Alındığı tarih</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>Süre</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tür</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Yol</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>Codec bilgisi</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Video Kodek Kimliği</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Video Kodu Oranı</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>FPS</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>Oran</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>Çözünürlük</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>Ses Kodek Kimliği</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>Ses Kodu Oranı</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>Ses basamağı</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>Kanallar</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>Örnekleme</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam ekrandan çık</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Yazdır</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>Slayt gösterisi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktar</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>Adlandır</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>Favori değil</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Saat yönünde döndür</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>Saat yönünün tersine döndür</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Gezinme penceresini göster</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>Gezinme penceresini gizle</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>Duvar kağıdı yap</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosya yöneticisinde görüntüle</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>Resim bilgisi</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktarma başarılı</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktarma başarısız</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>Albüm</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm fotoğraflar ve videolar</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_ug.ts
+++ b/src/translations/deepin-album_ug.ts
@@ -1,812 +1,812 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ug_CN">
+<TS version="2.1" language="ug">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>بارلىق سۈرەت ۋە سىن</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
-        <translation type="unfinished"></translation>
+        <translation>دىسكا ئالدىراش ، ھازىر چىقىرىۋېتەلمەيدۇ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>تاماملاندى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>تولۇق ئېكران</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
-        <translation type="unfinished"></translation>
+        <translation>پۈتۈن ئېكران / تام تەسۋىردىن چېكىنىڭ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>ياردەم</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>تېزلەتمە كۆرسەت</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ھۆججەت باشقۇرغۇچتا كۆرسىتىلىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>تام تەسۋىر</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>كۆرۈش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەت چىقىرىش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەت ۋە سىن كىرگۈزۈش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>ھەممىنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەت/سىن ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>تام قەغىزى قىلىپ تەڭشەڭ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>سائەت يۆنىلىشىدە ئايلاندۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>سائەتكە قارشى يۆنىلىشنى ئايلاندۇرۇڭ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <translation>چوڭايتىش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <translation>چوڭايتىڭ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالدىنقى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>كىيىنكى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقتۇرغانلىرىم</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقمىغانلىرى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>يىڭى ئالبۇم</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبومغا قايتا نام بېرىش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
-        <translation type="unfinished"></translation>
+        <translation>بەت ئۈستى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
-        <translation type="unfinished"></translation>
+        <translation>بەت ئاستى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەتلەر</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبۇملار</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقتۇرغانلىرى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>ئېكراننى تۇتۇش</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>كامېرا</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>سىزمىچىلىق تاختىسى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>نامسىز</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>ئاۋاز يولى</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>رەسىملەر</translation>
     </message>
 </context>
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>يىڭى ئالبۇم</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
-        <translation type="unfinished"></translation>
+        <translation>ھۆججەت قىسقۇچتىن ئەكىرىش</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبۇم</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>بارلىق تۈرلەر</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقتۇرغانلىرىم</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقمىغانلىرى</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆچۈرۈش</translation>
     </message>
 </context>
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 پارچە سۈرەت</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 سىن</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>نەتىجە يوق</translation>
     </message>
 </context>
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 پارچە سۈرەت</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 سىن</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>نەتىجە يوق</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەت ياكى سىن ھۆججىتى بايقالمىدى</translation>
     </message>
 </context>
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>ئېكراننى تۇتۇش</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>كامېرا</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>سىزمىچىلىق تاختىسى</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
-        <translation type="unfinished"></translation>
+        <translation>(قوشۇمچە نۇسخا)</translation>
     </message>
 </context>
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 پارچە سۈرەت</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 سىن</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
 </context>
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>بوش %1 دېسكا</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 شىفىرلانغان</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 سىغىمى</translation>
     </message>
 </context>
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
-        <source>Are you sure you want to delete this file locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
-        <source>You can restore it in the trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
-        <source>Are you sure you want to delete %1 files locally?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
-        <source>You can restore them in the trash</source>
-        <translation type="unfinished"></translation>
+        <source>Are you sure you want to delete this file locally?</source>
+        <translation>سىز بۇ ھۆججەتنى يەرلىكتىن ئۆچۈرەمسىز؟ </translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
+        <source>You can restore it in the trash</source>
+        <translation>&quot;يېقىندا ئۆچۈرۈلگەنلىرى&apos; دىن ئەسلىگە كەلتۈرەلەيسىز</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
+        <source>Are you sure you want to delete %1 files locally?</source>
+        <translation>بۇ %1 ھۆججەتنى يەرلىكتىن مەڭگۈلۈك ئۆچۈرەمسىز؟</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
-        <source>Are you sure you want to permanently delete this file?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
-        <source>You cannot restore it any longer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
-        <source>Are you sure you want to permanently delete %1 files?</source>
-        <translation type="unfinished"></translation>
+        <source>You can restore them in the trash</source>
+        <translation>&quot;يېقىندا ئۆچۈرۈلگەنلىرى&apos; دىن ئەسلىگە كەلتۈرەلەيسىز</translation>
     </message>
     <message>
         <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <source>Are you sure you want to permanently delete this file?</source>
+        <translation>بۇ ھۆججەتنى مەڭگۈلۈك ئۆچۈرەمسىز؟</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
+        <source>You cannot restore it any longer</source>
+        <translation>ئۆچۈرگەندىن كېيىن ئەسلىگە كەلتۈرگىلى بولمايدۇ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
+        <source>Are you sure you want to permanently delete %1 files?</source>
+        <translation>بۇ %1 ھۆججەتنى مەڭگۈلۈك ئۆچۈرەمسىز؟</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆچۈرگەندىن كېيىن ئەسلىگە كەلتۈرگىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆچۈرۈش</translation>
     </message>
 </context>
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 پارچە سۈرەت</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 سىن</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەكىرگىنىڭىز:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەكىرىش</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>يىڭى ئالبۇم</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
-        <translation type="unfinished"></translation>
+        <translation>ھەممىنى ئەكىرىش</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەكىرىش مۇۋەپپەقىيەتلىك بولدى </translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
-        <translation type="unfinished"></translation>
+        <translation>نەتىجە يوق</translation>
     </message>
 </context>
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>يۈكلىنىۋاتىدۇ، سەل ساقلاڭ...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
-        <translation type="unfinished"></translation>
+        <translation>پەرۋا قىلماڭ</translation>
     </message>
 </context>
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>تاماملاندى</translation>
     </message>
 </context>
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>نامى:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
-        <source>Pictures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
-        <source>Documents</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
-        <source>Downloads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
-        <source>Desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>ساقلاش:</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="93"/>
-        <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <source>Pictures</source>
+        <translation>رەسىملەر</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="94"/>
-        <source>Music</source>
-        <translation type="unfinished"></translation>
+        <source>Documents</source>
+        <translation>ھۆججەتلەر</translation>
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <source>Downloads</source>
+        <translation>چۈشۈرۈلمىلەر</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
+        <source>Desktop</source>
+        <translation>ئۈستەل يۈزى</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
+        <source>Videos</source>
+        <translation>ۋىدىيو</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
+        <source>Music</source>
+        <translation>مۇزىكا</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
-        <translation type="unfinished"></translation>
+        <translation>باشقا مۇندەرىجىلەرنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
-        <translation type="unfinished"></translation>
+        <translation>فورماتى:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈپىتى:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>چىقىرۋېتىش مۇۋەپپەقىيەتلىك بولدى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>چىقىرۋېتىش مەغلۇپ بولدى</translation>
     </message>
 </context>
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>تولۇق ئېكران</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>پۈتۈن ئېكراندىن چېكىنىش</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
-        <source>Slide show</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
-        <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
-        <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
-        <source>Image info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/filecontrol.cpp" line="1224"/>
-        <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <source>Slide show</source>
+        <translation>تام تەسۋىر</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1228"/>
-        <source>Next</source>
-        <translation type="unfinished"></translation>
+        <source>Rename</source>
+        <translation>نامىنى ئۆزگەرتىش</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1232"/>
-        <source>Zoom in</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
+        <source>Copy</source>
+        <translation>كۆچۈرۈش</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1236"/>
-        <source>Zoom out</source>
-        <translation type="unfinished"></translation>
+        <source>Delete</source>
+        <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="1240"/>
+        <source>Rotate clockwise</source>
+        <translation>سائەت يۆنىلىشىدە ئايلاندۇرۇش</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <source>Rotate counterclockwise</source>
+        <translation>سائەتكە قارشى يۆنىلىشنى ئايلاندۇرۇڭ</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
+        <source>Set as wallpaper</source>
+        <translation>تام قەغىزى قىلىپ تەڭشەڭ</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
+        <source>Display in file manager</source>
+        <translation>ھۆججەت باشقۇرغۇچتا كۆرسىتىلىدۇ</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
+        <source>Image info</source>
+        <translation>رەسىم ئۇچۇرى</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
+        <source>Previous</source>
+        <translation>ئالدىنقى</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
+        <source>Next</source>
+        <translation>كىيىنكى</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <source>Zoom in</source>
+        <translation>چوڭايتىش</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <source>Zoom out</source>
+        <translation>چوڭايتىڭ</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>بېسىپ چىقىرىش</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>ياردەم</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>تېزلەتمە كۆرسەت</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
-        <translation type="unfinished"></translation>
+        <translation>ھەممىنى تاللاش</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -814,60 +814,71 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>بارلىق تۈرلەر</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەتلەر</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>ۋىدىيو</translation>
     </message>
 </context>
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
+        <translation>سۈرەت/سىن مەۋجۇت</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -875,40 +886,40 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 پارچە سۈرەت</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 سىن</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەكىرىش</translation>
     </message>
 </context>
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
-        <translation type="unfinished"></translation>
+        <translation>رەسىمنى كۆرۈش ھوقۇقىڭىز يوق</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -916,30 +927,30 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەت ۋە سىن كىرگۈزۈش</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەت ۋە سىننى بۇ يەرگە سىيرىسىڭىزمۇ بولىدۇ</translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەكىرگىنىڭىز:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
@@ -947,178 +958,178 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>ئاساسىي ئۇچۇرلار</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
-        <translation type="unfinished"></translation>
+        <translation>رازمېرى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>تىپى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>تارتىلغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆزگەرتىلگەن چېسلا</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>تەپسىلاتى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>يورۇقلۇق چەمبىرىنىڭ چوڭ-كىچىكلىكى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
-        <translation type="unfinished"></translation>
+        <translation>ئاشكارىلاش پىروگراممىسى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
-        <translation type="unfinished"></translation>
+        <translation>فوكۇس ئارىلىقى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
-        <translation type="unfinished"></translation>
+        <translation>يورۇقلۇق سېزىش دەرىجىسى ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
-        <translation type="unfinished"></translation>
+        <translation>ئاشكارىلاش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
-        <translation type="unfinished"></translation>
+        <translation>ئاشكارلىنىش ۋاقتى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
-        <translation type="unfinished"></translation>
+        <translation>كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>چاقماق لامپىلىق تولۇقلىما</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەڭ چوڭ يورۇقلۇق چەمبەر قىممىتى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
-        <translation type="unfinished"></translation>
+        <translation>رەڭ بوشلۇقى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
-        <translation type="unfinished"></translation>
+        <translation>نۇر ئۆلچەش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
-        <translation type="unfinished"></translation>
+        <translation>ئاق تەڭپۇڭلۇق</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
-        <translation type="unfinished"></translation>
+        <translation>لىنزا مودىلى</translation>
     </message>
 </context>
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەكىرۋاتىدۇ...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
-        <source>%1/%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
-        <source>Import successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <source>%1/%2</source>
+        <translation type="unfinished">%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
+        <source>Import successful</source>
+        <translation>ئەكىرىش مۇۋەپپەقىيەتلىك بولدى </translation>
+    </message>
+    <message>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەكىرىش مەغلۇپ بولدى</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
 </context>
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
-        <translation type="unfinished"></translation>
+        <translation>نامسىز</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
-        <translation type="unfinished"></translation>
+        <translation>يىڭى ئالبۇم</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>نامى:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1126,15 +1137,15 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەت ياكى سىن ھۆججىتى بايقالمىدى</translation>
     </message>
 </context>
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1142,15 +1153,15 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
-        <translation type="unfinished"></translation>
+        <translation>سىستېما دىسكىسى</translation>
     </message>
 </context>
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1158,51 +1169,51 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەخلەت ساندۇقى</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبۇم</translation>
     </message>
 </context>
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1210,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
-        <translation type="unfinished"></translation>
+        <translation>1 پارچە سۈرەت</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
-        <translation type="unfinished"></translation>
+        <translation>1 سىن</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەخلەت ساندۇقى</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
-        <translation type="unfinished"></translation>
+        <translation>ھۆججەت ئۆچۈرۈلۈشتىن بۇرۇن ئېشىپ قالغان كۈن سانى كۆرۈنىدۇ، كېيىن مەڭگۈلۈك ئۆچۈرۈلىدۇ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
-        <translation type="unfinished"></translation>
+        <translation>ھەممىنى ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1258,198 +1269,211 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
-        <translation type="unfinished"></translation>
+        <translation>بۇ ئالبۇمنى راستىنلا ئۆچۈرەمسىز؟</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆچۈرۈش</translation>
     </message>
 </context>
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 پارچە سۈرەت بايقالدى</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
-        <translation type="unfinished"></translation>
+        <translation>1 سىن بايقالدى</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation type="unfinished"></translation>
+        <translation>ئىزدەش نەتىجىسى</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
-        <translation type="unfinished"></translation>
+        <translation>پرويېكسىيە قويۇش</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
-        <translation type="unfinished"></translation>
+        <translation>ئىزدەش نەتىجىسى يوق</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبوم «%1» ئۆچۈرۈلدى</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبوم</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەكىرىش</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقتۇرغانلىرى</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەخلەت ساندۇقى</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۈسكۈنە</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبۇملار</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
-        <translation type="unfinished"></translation>
+        <translation>ئېكراننى تۇتۇش</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
-        <translation type="unfinished"></translation>
+        <translation>كامېرا</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
-        <translation type="unfinished"></translation>
+        <translation>سىزمىچىلىق تاختىسى</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>تام تەسۋىر</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>چىقىرىش</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
+        <translation>يىڭى ئالبۇم</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>نامىنى ئۆزگەرتىش</translation>
     </message>
 </context>
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالدىنقى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>توختىتىش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>قويۇش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>كىيىنكى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation>چېكىنىش</translation>
     </message>
 </context>
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
-        <translation type="unfinished"></translation>
+        <translation>كۈن</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>كۈن</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,393 +1481,507 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>چىقىرۋېتىش مۇۋەپپەقىيەتلىك بولدى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>چىقىرۋېتىش مەغلۇپ بولدى</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <source>View</source>
+        <translation>كۆرۈش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>تولۇق ئېكران</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>بېسىپ چىقىرىش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>تام تەسۋىر</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبومغا قوشۇش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
-        <source>Successfully added to “%1”</source>
-        <translation type="unfinished"></translation>
+        <translation>يىڭى ئالبۇم</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
-        <source>Export</source>
-        <translation type="unfinished"></translation>
+        <source>Successfully added to “%1”</source>
+        <translation>«%1»گە قوشۇلدى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
-        <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
+        <source>Export</source>
+        <translation>چىقىرىش</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <source>Copy</source>
+        <translation>كۆچۈرۈش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبومغا قايتا نام بېرىش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقتۇرغانلىرىم</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
-        <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقمىغانلىرى</translation>
     </message>
     <message>
         <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <source>Rotate clockwise</source>
+        <translation>سائەت يۆنىلىشىدە ئايلىنىدۇ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>سائەتكە قارشى يۆنىلىشنى ئايلاندۇرۇڭ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>تام قەغىزى قىلىپ تەڭشەڭ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ھۆججەت باشقۇرغۇچتا كۆرسىتىلىدۇ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation>ئەسلىگە كەلتۈرۈش</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
-        <translation type="unfinished"></translation>
+        <translation>سۈرەت ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
-        <translation type="unfinished"></translation>
+        <translation>سىن ئۇچۇرى</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>كۆرۈش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>تولۇق ئېكران</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>بېسىپ چىقىرىش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>تام تەسۋىر</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>ئالبومغا قوشۇش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>يىڭى ئالبۇم</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>«%1»گە قوشۇلدى</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>چىقىرىش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>كۆچۈرۈش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>ئۆچۈرۈش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>ئالبومغا قايتا نام بېرىش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
+        <source>Favorite</source>
+        <translation>ياقتۇرغانلىرىم</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
+        <source>Unfavorite</source>
+        <translation>ياقمىغانلىرى</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>سائەت يۆنىلىشىدە ئايلاندۇرۇش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>سائەتكە قارشى يۆنىلىشنى ئايلاندۇرۇش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>تام قەغىزى قىلىپ تەڭشەڭ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>ھۆججەت باشقۇرغۇچتا كۆرسىتىلىدۇ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>ئەسلىگە كەلتۈرۈش</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>سۈرەت ئۇچۇرى</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>سىن ئۇچۇرى</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">چىقىرۋېتىش مۇۋەپپەقىيەتلىك بولدى</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">چىقىرۋېتىش مەغلۇپ بولدى</translation>
     </message>
 </context>
 <context>
     <name>ToolBarThumbnailListView</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
         <source>Back to Album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالدىنقى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>كىيىنكى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
         <source>Original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
         <source>Fit to window</source>
-        <translation type="unfinished"></translation>
+        <translation>ماس كۆزنەك</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقتۇرغانلىرىم</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقمىغانلىرى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆچۈرۈش</translation>
     </message>
 </context>
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
-        <translation type="unfinished"></translation>
+        <translation>ئاساسىي ئۇچۇرلار</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
-        <translation type="unfinished"></translation>
+        <translation>تارتىلغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۇزۇنلۇقى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation>تىپى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
-        <translation type="unfinished"></translation>
+        <translation>ھۆججەت ئورنى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
-        <translation type="unfinished"></translation>
+        <translation>كود ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>سىن مىقدارى ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>سىننىڭ كودلىنىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>سىننىڭ كاندۇك نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
-        <translation type="unfinished"></translation>
+        <translation>كۆرسىتىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
-        <translation type="unfinished"></translation>
+        <translation>ئېنىقلىقى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
-        <translation type="unfinished"></translation>
+        <translation>كود ئۇسلۇبى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
-        <translation type="unfinished"></translation>
+        <translation>كودلىنىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۈننىڭ بىت سانى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation>ئاۋاز يولى سانى</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
-        <translation type="unfinished"></translation>
+        <translation>نۇسخا ئېلىش سانى</translation>
     </message>
 </context>
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>تولۇق ئېكران</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>پۈتۈن ئېكراندىن چېكىنىش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation>بېسىپ چىقىرىش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
-        <translation type="unfinished"></translation>
+        <translation>تام تەسۋىر</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation>چىقىرىش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation>نامىنى ئۆزگەرتىش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقتۇرغانلىرىم</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
-        <translation type="unfinished"></translation>
+        <translation>ياقمىغانلىرى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>سائەت يۆنىلىشىدە ئايلاندۇرۇش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>سائەتكە قارشى يۆنىلىشنى ئايلاندۇرۇڭ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>يول باشلاش كۆزنىكىنى كۆرسەتسۇن</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
-        <translation type="unfinished"></translation>
+        <translation>يول باشلاش كۆزنىكىنى يوشۇرۇش</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished"></translation>
+        <translation>تام قەغىزى قىلىپ تەڭشەڭ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"></translation>
+        <translation>ھۆججەت باشقۇرغۇچتا كۆرسىتىلىدۇ</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
-        <translation type="unfinished"></translation>
+        <translation>رەسىم ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
-        <translation type="unfinished"></translation>
+        <translation>چىقىرۋېتىش مۇۋەپپەقىيەتلىك بولدى</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
-        <translation type="unfinished"></translation>
+        <translation>چىقىرۋېتىش مەغلۇپ بولدى</translation>
     </message>
 </context>
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
-        <translation type="unfinished"></translation>
+        <translation>ئالبوم</translation>
     </message>
 </context>
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1851,9 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
-        <translation type="unfinished"></translation>
+        <translation>بارلىق سۈرەت ۋە سىن</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_uk.ts
+++ b/src/translations/deepin-album_uk.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>Усі фотографії і відео</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>Диск зайнято — зараз його не можна від&apos;єднувати</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>Вийти з повноекранного режиму або показу слайдів</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>Показати клавіатурні скорочення</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>Показати у менеджері файлів</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>Показ слайдів</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>Перегляд</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>Експортувати фотографії</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>Імпортувати фотографії/відео</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>Позначити все</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>Дані щодо фотографій/відео</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>Встановити зображенням тла</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>Обертати за годинниковою стрілкою</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>Обертати проти годинникової стрілки</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>Збільшити</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>Зменшити</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>Далі</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>Додати до вибраних</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>Вилучити з вибраних</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>Новий альбом</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>Перейменувати альбом</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>Сторінка вгору</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>Сторінка вниз</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>Фотографії</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>Альбоми</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>Вибрані</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>Захолення з екрана</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>Малювання</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>Без назви</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>Канал</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>Зображення</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>Новий альбом</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>Імпортувати теки</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>Альбом</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>Версія:</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>«Альбом» — стильний інструмент керування для перегляду і упорядковування фотографій і відео.</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1 випущено за умов дотримання %2</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>Показати бічну панель</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>Приховати бічну панель</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>Початкове співвідношення</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>Квадратні мініатюри</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>Р</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>М</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>Д</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>Усе</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>Шукати</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>Додати до вибраних</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>Вилучити з вибраних</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>Обертати</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>1 фотографія</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>%1 фотографій</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>%1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>Немає результатів</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>1 фотографія</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>%1 фотографій</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>%1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>Немає результатів</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>Не знайдено жодної фотографії або відео</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>Захолення з екрана</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>Малювання</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(копія)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>1 фотографія</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>%1 фотографій</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>%1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>1 фотографія</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>%1 фотографій</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>Диск %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>Порожній диск %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>Зашифрований %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>Гучність %1</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>Ви справді хочете вилучити цей файл локально?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>Ви зможете відновити його зі смітника</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>Ви справді хочете вилучити ці %1 файлів локально?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>Ви зможете відновити їх зі смітника</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>Ви справді хочете остаточно вилучити цей файл?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>Надалі, ви не зможете його відновити</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>Ви справді хочете остаточно вилучити %1 файлів?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>Надалі, ви не зможете їх відновити</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>1 фотографія</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>%1 фотографій</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>%1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>Імпортувати до:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>Імпортувати</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>Новий альбом</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>Імпортувати все</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>Імпорт 1 запису</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>Імпорт %1 записів</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>Успішне імпортування</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>Немає результатів</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>Завантаження…</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>Ігнорувати</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>Назва файла не може бути порожньою!</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>Гаразд</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>Назва:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>Зберегти у:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>Зображення</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>Документи</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>Завантаження</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>Стільниця</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>Відео</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>Музика</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>Виберіть інші каталоги</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>Формат:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>Якість:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>Підтвердити</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>Успішне експортування</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>Не вдалося експортувати</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>Звичайний режим</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>Видобути текст</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>Показ слайдів</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>Перейменувати</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>Обертати за годинниковою стрілкою</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>Обертати проти годинникової стрілки</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>Встановити зображенням тла</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>Показати у менеджері файлів</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>Дані щодо зображення</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>Далі</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>Збільшити</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>Зменшити</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>Надрукувати</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>Перегляд зображень</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>Показати клавіатурні скорочення</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>Позначити все</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>Інтерактивний текст</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>Усе</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>Фотографії</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>Відео</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>Така фотографія або відео вже існує</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>Позначено 1 запис (1 фото)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>Позначено 1 запис (1 відео)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>Позначено %1 записів (%1 фотографій)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>Позначено %1 записів (%1 відео)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>Позначено %1 записів (1 фотографію, %2 відео)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>Позначено %1 записів (%2 фотографій, 1 відео)</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>Позначено %1 записів (%2 фото, %3 відео)</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>1 фотографія</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>%1 фотографій</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>%1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>Імпортувати</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>У вас немає прав доступу до перегляду цього зображення</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>Файл зображення не знайдено</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>Імпортуйте фотографії та відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>Або перетягніть їх сюди</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>Імпортовано</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>1 запис</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>%1 записів</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>Базові відомості</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>Назва файла</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>Розміри</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>Дата створення</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>Дата зміни</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>Подробиці</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>Діафрагма</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>Програма експозиції</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>Фокальна відстань</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>Режим експозиції</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>Час експозиції</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>Спалах</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>Компенсація спалаху</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>Макс. апертура</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>Простір кольорів</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>Режим вимірювання</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>Баланс білого</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>Модель пристрою</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>Модель об&apos;єктива</translation>
     </message>
@@ -1058,41 +1071,36 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>Імпортування…</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
-        <translation type="unfinished"/>
+        <translation>Імпортовано:</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>Успішне імпортування</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
-        <translation>Імпортування зазнало невдачі</translation>
+        <translation>Імпортування зазнало&#xa0;невдачі</translation>
     </message>
 </context>
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>Без назви</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>Новий альбом</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>Назва:</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>Підтвердити</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>Не знайдено жодної фотографії або відео</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>Виберіть знімки</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Успішне імпортування</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Імпортування зазнало невдачі</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>Системний диск</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>Файл вже існує. Будь ласка, скористайтеся іншою назвою</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1-%2-%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>Смітник</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>Альбом</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>Файл вже існує. Будь ласка, скористайтеся іншою назвою</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>Підтвердити</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>1 фотографія</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>%1 фотографій</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>%1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>Смітник</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>Кількість днів, за яку файли буде остаточно вилучено, показано на мініатюрах</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>Вилучити всі</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>Вилучити позначені (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>Відновити позначені (%1)</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>Ви справді хочете вилучити цей альбом?</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>Знайдено 1 фотографію</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>Знайдено %1 фотографій</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>Знайдено 1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>Знайдено %1 відео</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>Знайдено %1 записів</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>Результати пошуку</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>Показ слайдів</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>Нічого не знайдено</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>Альбом «%1» вилучено</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>Галерея</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>Збірка</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>Імпортувати</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>Вибрані</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>Смітник</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>Пристрій</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>Альбоми</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>Додат альбом</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>Захолення з екрана</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>Малювання</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>Показ слайдів</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>Експортувати</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>Новий альбом</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>Перейменувати</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>Пауза</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>Відтворити</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>Далі</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>Вийти</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>днів</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>день</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>днів</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>день</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>Успішне експортування</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>Не вдалося експортувати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>Перегляд</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>Надрукувати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>Показ слайдів</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>Додати до альбому</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>Новий альбом</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>Успішно додано до «%1»</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>Експортувати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>Вилучити з альбому</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>Додати до вибраних</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>Вилучити з вибраних</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>Обертати за годинниковою стрілкою</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>Обертати проти годинникової стрілки</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>Встановити зображенням тла</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>Показати у менеджері файлів</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>Відновити</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>Дані щодо фотографії</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>Дані щодо відео</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>Назад до альбому</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>Перегляд</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>Назад</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>Далі</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>Надрукувати</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>Початковий розмір</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>Показ слайдів</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>Вмістити у вікно</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>Додати до альбому</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>Обертати</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>Новий альбом</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>Успішно додано до «%1»</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>Експортувати</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>Копіювати</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>Вилучити</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>Вилучити з альбому</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>Додати до вибраних</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>Вилучити з вибраних</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>Обертати за годинниковою стрілкою</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>Обертати проти годинникової стрілки</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>Встановити зображенням тла</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>Показати у менеджері файлів</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>Відновити</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>Дані щодо фотографії</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>Дані щодо відео</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">Успішне експортування</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">Не вдалося експортувати</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>Назад до альбому</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>Назад</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>Далі</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>Початковий розмір</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>Вмістити у вікно</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>Обертати</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>Додати до вибраних</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>Вилучити з вибраних</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>Видобути текст</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>Базові відомості</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>Назва файла</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>Дата створення</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>Тривалість</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>Шлях</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>Дані щодо кодека</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>Ідентифікатор відеокодека</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>Швидкість відеоданих</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>Частота кадрів</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>Пропорції</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>Роздільність</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>Ідентифікатор аудіокодека</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>Швидкість звукових даних</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>Цифровий звук</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>Канали</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>Дискретизація</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>Звичайний режим</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>Надрукувати</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>Видобути текст</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>Показ слайдів</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>Експортувати</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>Перейменувати</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>Додати до вибраних</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>Вилучити з вибраних</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>Обертати за годинниковою стрілкою</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>Обертати проти годинникової стрілки</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>Показати навігаційне вікно</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>Приховати навігаційне вікно</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>Встановити зображенням тла</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>Показати у менеджері файлів</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>Дані щодо зображення</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>Успішне експортування</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>Не вдалося експортувати</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>«Альбом» — стильний інструмент керування для перегляду і упорядковування фотографій і відео.</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>Альбом</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>%1 записів</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>1 запис</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>Усі фотографії і відео</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">Успішне імпортування</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">Імпортування зазнало невдачі</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_zh_CN.ts
+++ b/src/translations/deepin-album_zh_CN.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>所有照片和视频</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>磁盘文件被占用，无法弹出</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>退出全屏/幻灯片放映</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中显示</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>幻灯片放映</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>导出照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>导入照片和视频</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>照片/视频信息</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>设为壁纸</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>顺时针旋转</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>逆时针旋转</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>放大照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>缩小照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>上一张</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>下一张</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>新建相册</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>重命名相册</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>向上滚动一屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>向下滚动一屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>相册</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>我的收藏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>截图录屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>相机</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>画板</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>未命名相册</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>声道</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>图片</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>新建相册</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>从文件夹导入</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>相册</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>相册是一款可多种方式浏览、整理照片和视频的管理工具。</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1遵循%2协议发布</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>展开侧边栏</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>关闭侧边栏</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>显示为原始比例</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>显示为方图</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>年</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>月</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>日</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>所有项目</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>旋转</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>共1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>共%1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>共1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>共%1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>无结果</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>共1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>共%1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>共1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>共%1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>无结果</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>未发现照片或视频文件</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>截图录屏</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>相机</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>画板</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(副本)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>共1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>共%1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>共1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>共%1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>共1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>共%1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1年%2月%3日</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1驱动器</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>空白%1光盘</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1已加密</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>%1卷</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>您确定要从本地删除此文件吗？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>您可以在“最近删除”中进行恢复</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>您确定要从本地删除这%1个文件吗？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>您可以在“最近删除”中进行恢复</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>您确定要永久删除此文件吗？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>删除后不可恢复</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>您确定要永久删除这%1个文件吗？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>删除后不可恢复</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>共1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>共%1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>共1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>共%1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>导入到：</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>导入</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>新建相册</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>全部导入</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>导入1项</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>导入%1项</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>导入成功</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>无结果</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>正在加载，请稍候...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>文件名不能为空</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>文件名：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>保存到：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>图片</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>文档</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>桌面</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>视频</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>音乐</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>选择其他目录</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>文件格式：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>照片质量：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>导出成功</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>导出失败</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>识别文字</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>幻灯片放映</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>顺时针旋转</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>逆时针旋转</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>设为壁纸</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中显示</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>图片信息</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>上一张</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>下一张</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>放大照片</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>缩小照片</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>查看图片</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>实况文本</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>所有项目</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>照片</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>视频</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>照片/视频已存在</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation>该文件格式不支持</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>已选择1项（1张照片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>已选择1项（1个视频）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>已选择%1项（%1张照片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>已选择%1项（%1个视频）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation>已选择%1项（1张照片，1个视频）</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>已选择%1项（1张照片，%2个视频）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>已选择%1项（%2张照片，1个视频）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>已选择%1项（%2张照片，%3个视频）</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>共1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>共%1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>共1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>共%1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>已导入</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>您没有权限查看此图片</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>未发现图片文件</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>导入照片和视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>您也可以拖拽照片和视频到此</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>导入于</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>共1项</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>共%1项</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>基本信息</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>照片尺寸</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>文件类型</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>拍摄日期</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>修改日期</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>详细信息</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>光圈大小</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>曝光程序</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>焦距</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO感光度</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>曝光模式</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>曝光时间</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>闪光灯</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>闪光灯补偿</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>最大光圈值</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>颜色空间</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>测光模式</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>白平衡</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>设备型号</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>镜头型号</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>正在导入，请稍候...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation>已导入：</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation>0</translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>导入成功</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>导入失败</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>未命名相册</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>新建相册</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>文件名：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>确定</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>未发现照片或视频文件</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>选择图片</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">导入成功</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">导入失败</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>系统盘</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>该文件已存在，请使用其他名称</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1年%2月%3日</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>最近删除</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>相册</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>该文件已存在，请使用其他名称</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>确定</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>共1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>共%1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>共1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>共%1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>最近删除</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>文件在删除前会显示剩余天数，之后将永久删除</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>全部删除</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>删除%1项</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>恢复%1项</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>您确定要删除此相册吗？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>共找到1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>共找到%1张照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>共找到1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>共找到%1个视频</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>共找到%1项</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>搜索结果</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>幻灯片放映</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>无搜索结果</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>已成功删除“%1”相册</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>照片库</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>合集</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>已导入</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>我的收藏</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>最近删除</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>设备</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>相册</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>新建相册</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>截图录屏</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>相机</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>画板</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>幻灯片放映</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>新建相册</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>上一张</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>暂停</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>播放</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>下一张</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>天</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>天</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>天</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>天</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>导出成功</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>导出失败</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>幻灯片放映</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>添加到相册</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>新建相册</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>成功添加到“%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>从相册中移除</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>顺时针旋转</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>逆时针旋转</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>设为壁纸</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中显示</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>恢复</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>照片信息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>视频信息</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>返回相册</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>查看</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>上一张</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>下一张</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>打印</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>原始大小</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>幻灯片放映</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>适应窗口</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>添加到相册</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>旋转</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>新建相册</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>成功添加到“%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>导出</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>复制</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>删除</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>从相册中移除</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>顺时针旋转</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>逆时针旋转</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>设为壁纸</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>在文件管理器中显示</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>恢复</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>照片信息</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>视频信息</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">导出成功</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">导出失败</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>返回相册</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>上一张</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>下一张</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>原始大小</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>适应窗口</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>旋转</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>收藏</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>取消收藏</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>识别文字</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>基本信息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>拍摄日期</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>时长</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>文件类型</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>文件路径</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>编码信息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>视频流信息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>视频码率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>视频帧率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>显示比例</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>编码样式</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>编码码率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>音频位数</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>声道数</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>采样数</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>识别文字</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>幻灯片放映</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>顺时针旋转</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>逆时针旋转</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>显示导航窗口</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>隐藏导航窗口</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>设为壁纸</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中显示</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>图片信息</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>导出成功</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>导出失败</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>相册是一款可多种方式浏览、整理照片和视频的管理工具。</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>相册</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>共%1项</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>共1项</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>所有照片和视频</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">导入成功</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">导入失败</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_zh_HK.ts
+++ b/src/translations/deepin-album_zh_HK.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>所有照片和影片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>磁盤文件被佔用，無法彈出</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>退出全螢幕/幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>導出照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>導入照片和影片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>照片/影片訊息</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>設為壁紙</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>順時針旋轉</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>逆時針旋轉</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>放大照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>縮小照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>上一張</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>下一張</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>新建相冊</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>重命名相冊</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>向上滾動一屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>向下滾動一屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>相冊</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>我的收藏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>截圖錄屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>相機</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>畫板</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>未命名相冊</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>聲道</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>圖片</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>新建相冊</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>從文件夾導入</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>相冊</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>相冊是一款可多種方式瀏覽、整理照片和影片的管理工具。</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1遵循%2協議發佈</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>展開側邊欄</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>關閉側邊欄</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>顯示為原始比例</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>顯示為方圖</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>年</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>月</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>日</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>所有項目</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>無結果</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>無結果</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>未發現照片或影片文件</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>截圖錄屏</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>相機</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>畫板</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(副本)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1年%2月%3日</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1驅動器</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>空白%1光盤</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1已加密</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>%1卷</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>您確定要從本地刪除此文件嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>您可以在“最近刪除”中進行恢復</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>您確定要從本地刪除這%1個文件嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>您可以在“最近刪除”中進行恢復</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>您確定要永久刪除此文件嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>刪除後不可恢復</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>您確定要永久刪除這%1個文件嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>刪除後不可恢復</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>導入到：</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>導入</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>新建相冊</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>全部導入</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>導入1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>導入%1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>導入成功</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>無結果</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>正在加載，請稍候...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>文件名不能為空</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>文件名：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>保存到：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>圖片</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>文檔</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>下載</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>桌面</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>影片</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>音樂</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>選擇其他目錄</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>文件格式：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>照片質量：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>導出成功</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>導出失敗</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>識別文字</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>順時針旋轉</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>逆時針旋轉</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>設為壁紙</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>圖片訊息</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>上一張</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>下一張</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>放大照片</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>縮小照片</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>打開</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>查看圖片</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>實況文本</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>所有項目</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>照片</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>影片</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>照片/影片已存在</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation>該文件格式不支持</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>已選擇1項（1張照片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>已選擇1項（1個影片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>已選擇%1項（%1張照片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>已選擇%1項（%1個影片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation>已選擇%1項（1張照片，1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>已選擇%1項（1張照片，%2個影片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>已選擇%1項（%2張照片，1個影片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>已選擇%1項（%2張照片，%3個影片）</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>已導入</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>您沒有權限查看此圖片</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>未發現圖片文件</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>導入照片和影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>您也可以拖拽照片和影片到此</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>導入於</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>共1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>共%1項</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>基本訊息</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>照片尺寸</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>文件類型</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>拍攝日期</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>修改日期</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>詳細訊息</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>光圈大小</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>曝光程序</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>焦距</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO感光度</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>曝光模式</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>曝光時間</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>閃光燈</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>閃光燈補償</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>最大光圈值</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>顏色空間</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>測光模式</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>白平衡</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>設備型號</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>鏡頭型號</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>正在導入，請稍候...</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation>已導入：</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation>0</translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>導入成功</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>導入失敗</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>未命名相冊</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>新建相冊</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>文件名：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>確定</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>未發現照片或影片文件</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>選擇圖片</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">導入成功</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">導入失敗</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>系統盤</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>該文件已存在，請使用其他名稱</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1年%2月%3日</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>最近刪除</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>相冊</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>該文件已存在，請使用其他名稱</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>確定</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>最近刪除</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>文件在刪除前會顯示剩餘天數，之後將永久刪除</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>全部刪除</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>刪除%1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>恢復%1項</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>您確定要刪除此相冊嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>共找到1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>共找到%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>共找到1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>共找到%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>共找到%1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>搜索結果</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>無搜索結果</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>已成功刪除“%1”相冊</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>照片庫</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>合集</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>已導入</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>我的收藏</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>最近刪除</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>設備</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>相冊</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>新建相冊</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>截圖錄屏</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>相機</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>畫板</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>導出</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>新建相冊</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>上一張</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>暫停</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>播放</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>下一張</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>天</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>天</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>天</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>天</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>導出成功</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>導出失敗</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>添加到相冊</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>新建相冊</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>成功添加到“%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>導出</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>從相冊中移除</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>順時針旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>逆時針旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>設為壁紙</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>恢復</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>照片訊息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>影片訊息</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>返回相冊</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>查看</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>上一張</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>下一張</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>打印</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>原始大小</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>適應窗口</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>添加到相冊</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>旋轉</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>新建相冊</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>成功添加到“%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>導出</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>從相冊中移除</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>順時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>逆時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>設為壁紙</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>在文件管理器中顯示</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>恢復</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>照片訊息</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>影片訊息</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">導出成功</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">導出失敗</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>返回相冊</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>上一張</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>下一張</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>原始大小</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>適應窗口</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>旋轉</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>收藏</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>取消收藏</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>識別文字</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>基本訊息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>拍攝日期</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>時長</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>文件類型</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>文件路徑</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>編碼訊息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>影片流訊息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>影片碼率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>影片幀率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>顯示比例</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>編碼樣式</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>編碼碼率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>音頻位數</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>聲道數</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>採樣數</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>識別文字</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>導出</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>順時針旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>逆時針旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>顯示導航窗口</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>隱藏導航窗口</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>設為壁紙</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>圖片訊息</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>導出成功</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>導出失敗</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>相冊是一款可多種方式瀏覽、整理照片和影片的管理工具。</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>相冊</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>共%1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>共1項</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>所有照片和影片</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">導入成功</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">導入失敗</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/deepin-album_zh_TW.ts
+++ b/src/translations/deepin-album_zh_TW.ts
@@ -1,200 +1,202 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="255"/>
+        <location filename="../src/albumControl.cpp" line="264"/>
         <source>All photos and videos</source>
         <translation>所有照片和影片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="304"/>
-        <location filename="../src/albumControl.cpp" line="329"/>
+        <location filename="../src/albumControl.cpp" line="313"/>
+        <location filename="../src/albumControl.cpp" line="338"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>磁碟文件被占用，無法彈出</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="305"/>
-        <location filename="../src/albumControl.cpp" line="330"/>
+        <location filename="../src/albumControl.cpp" line="314"/>
+        <location filename="../src/albumControl.cpp" line="339"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1001"/>
+        <location filename="../src/albumControl.cpp" line="1020"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1004"/>
+        <location filename="../src/albumControl.cpp" line="1023"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>退出全螢幕/幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1010"/>
+        <location filename="../src/albumControl.cpp" line="1029"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1013"/>
+        <location filename="../src/albumControl.cpp" line="1032"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1016"/>
+        <location filename="../src/albumControl.cpp" line="1035"/>
         <source>Display in file manager</source>
         <translation>在檔案管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1019"/>
+        <location filename="../src/albumControl.cpp" line="1038"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1022"/>
+        <location filename="../src/albumControl.cpp" line="1041"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1025"/>
+        <location filename="../src/albumControl.cpp" line="1044"/>
         <source>Export photos</source>
         <translation>匯出照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1028"/>
+        <location filename="../src/albumControl.cpp" line="1047"/>
         <source>Import photos/videos</source>
         <translation>匯入照片和影片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1031"/>
+        <location filename="../src/albumControl.cpp" line="1050"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1034"/>
+        <location filename="../src/albumControl.cpp" line="1053"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1037"/>
+        <location filename="../src/albumControl.cpp" line="1056"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1040"/>
+        <location filename="../src/albumControl.cpp" line="1059"/>
         <source>Photo/Video info</source>
         <translation>照片/影片訊息</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1043"/>
+        <location filename="../src/albumControl.cpp" line="1062"/>
         <source>Set as wallpaper</source>
         <translation>設為桌布</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1046"/>
+        <location filename="../src/albumControl.cpp" line="1065"/>
         <source>Rotate clockwise</source>
         <translation>順時針旋轉</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1049"/>
+        <location filename="../src/albumControl.cpp" line="1068"/>
         <source>Rotate counterclockwise</source>
         <translation>逆時針旋轉</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1055"/>
+        <location filename="../src/albumControl.cpp" line="1074"/>
         <source>Zoom in</source>
         <translation>放大照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1058"/>
+        <location filename="../src/albumControl.cpp" line="1077"/>
         <source>Zoom out</source>
         <translation>縮小照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1061"/>
+        <location filename="../src/albumControl.cpp" line="1080"/>
         <source>Previous</source>
         <translation>上一張</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1064"/>
+        <location filename="../src/albumControl.cpp" line="1083"/>
         <source>Next</source>
         <translation>下一張</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1067"/>
+        <location filename="../src/albumControl.cpp" line="1086"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1070"/>
+        <location filename="../src/albumControl.cpp" line="1089"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1092"/>
         <source>New album</source>
         <translation>建立相冊</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1076"/>
+        <location filename="../src/albumControl.cpp" line="1095"/>
         <source>Rename album</source>
         <translation>重新命名相冊</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1079"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>Page up</source>
         <translation>向上滾動一屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1082"/>
+        <location filename="../src/albumControl.cpp" line="1101"/>
         <source>Page down</source>
         <translation>向下滾動一屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1124"/>
+        <location filename="../src/albumControl.cpp" line="1143"/>
         <source>Photos</source>
         <translation>照片</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1127"/>
+        <location filename="../src/albumControl.cpp" line="1146"/>
         <source>Albums</source>
         <translation>相冊</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1130"/>
+        <location filename="../src/albumControl.cpp" line="1149"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1647"/>
+        <location filename="../src/albumControl.cpp" line="1698"/>
         <source>Favorites</source>
         <translation>我的收藏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1649"/>
+        <location filename="../src/albumControl.cpp" line="1700"/>
         <source>Screen Capture</source>
         <translation>截圖錄屏</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1651"/>
+        <location filename="../src/albumControl.cpp" line="1702"/>
         <source>Camera</source>
         <translation>相機</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1653"/>
+        <location filename="../src/albumControl.cpp" line="1704"/>
         <source>Draw</source>
         <translation>畫板</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1718"/>
+        <location filename="../src/albumControl.cpp" line="1797"/>
         <source>Unnamed</source>
         <translation>未命名相冊</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2194"/>
+        <location filename="../src/albumControl.cpp" line="2309"/>
         <source>Channel</source>
         <translation>聲道</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2349"/>
+        <location filename="../src/albumControl.cpp" line="2493"/>
         <source>Pictures</source>
         <translation>圖片</translation>
     </message>
@@ -202,101 +204,101 @@
 <context>
     <name>AlbumTitle</name>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="80"/>
+        <location filename="../qml/AlbumTitle.qml" line="91"/>
         <source>New album</source>
         <translation>建立相冊</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="93"/>
+        <location filename="../qml/AlbumTitle.qml" line="104"/>
         <source>Import folders</source>
         <translation>從資料夾匯入</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="108"/>
+        <location filename="../qml/AlbumTitle.qml" line="119"/>
         <source>Album</source>
         <translation>相冊</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="110"/>
+        <location filename="../qml/AlbumTitle.qml" line="121"/>
         <source>Version:</source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="111"/>
+        <location filename="../qml/AlbumTitle.qml" line="122"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>相冊是一款可多種方式瀏覽、整理照片和影片的管理工具。</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="114"/>
+        <location filename="../qml/AlbumTitle.qml" line="125"/>
         <source>%1 is released under %2</source>
         <translation>%1遵循%2協議發布</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Show side pane</source>
         <translation>展開側邊欄</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="148"/>
+        <location filename="../qml/AlbumTitle.qml" line="159"/>
         <source>Hide side pane</source>
         <translation>關閉側邊欄</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Original ratio</source>
         <translation>顯示為原始比例</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="188"/>
+        <location filename="../qml/AlbumTitle.qml" line="201"/>
         <source>Square thumbnails</source>
         <translation>顯示為方圖</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="221"/>
-        <location filename="../qml/AlbumTitle.qml" line="295"/>
+        <location filename="../qml/AlbumTitle.qml" line="235"/>
+        <location filename="../qml/AlbumTitle.qml" line="311"/>
         <source>Y</source>
         <translation>年</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="232"/>
-        <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="246"/>
+        <location filename="../qml/AlbumTitle.qml" line="312"/>
         <source>M</source>
         <translation>月</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="242"/>
-        <location filename="../qml/AlbumTitle.qml" line="297"/>
+        <location filename="../qml/AlbumTitle.qml" line="256"/>
+        <location filename="../qml/AlbumTitle.qml" line="313"/>
         <source>D</source>
         <translation>日</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="252"/>
-        <location filename="../qml/AlbumTitle.qml" line="298"/>
+        <location filename="../qml/AlbumTitle.qml" line="267"/>
+        <location filename="../qml/AlbumTitle.qml" line="314"/>
         <source>All</source>
         <translation>所有項目</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="322"/>
+        <location filename="../qml/AlbumTitle.qml" line="338"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="408"/>
+        <location filename="../qml/AlbumTitle.qml" line="424"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="440"/>
+        <location filename="../qml/AlbumTitle.qml" line="456"/>
         <source>Rotate</source>
         <translation>旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/AlbumTitle.qml" line="460"/>
+        <location filename="../qml/AlbumTitle.qml" line="476"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -304,27 +306,27 @@
 <context>
     <name>AllCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="58"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="60"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="75"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="68"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="77"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="70"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="191"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="170"/>
         <source>No results</source>
         <translation>無結果</translation>
     </message>
@@ -332,32 +334,32 @@
 <context>
     <name>CustomAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="68"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="86"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="88"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="195"/>
         <source>No results</source>
         <translation>無結果</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="208"/>
         <source>No photos or videos found</source>
         <translation>未發現照片或影片檔案</translation>
     </message>
@@ -365,31 +367,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="450"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="492"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="507"/>
         <source>Screen Capture</source>
         <translation>截圖錄屏</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="451"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="468"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="483"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="512"/>
         <source>Camera</source>
         <translation>相機</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="452"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="502"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="517"/>
         <source>Draw</source>
         <translation>畫板</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1822"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1842"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1846"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1848"/>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1854"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1941"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1961"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1965"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1967"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="1973"/>
         <source>(copy)</source>
         <translation>(副本)</translation>
     </message>
@@ -397,39 +399,39 @@
 <context>
     <name>DayCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="76"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="80"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="78"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="82"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="86"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="90"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="566"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="88"/>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="92"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="568"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="554"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="560"/>
         <source>1 photo </source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="556"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="562"/>
         <source>%1 photos </source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="569"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/DayCollection.qml" line="575"/>
         <source>%1/%2/%3</source>
         <translation>%1年%2月%3日</translation>
     </message>
@@ -437,22 +439,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1189"/>
+        <location filename="../src/albumControl.cpp" line="1208"/>
         <source>%1 Drive</source>
         <translation>%1驅動器</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1193"/>
+        <location filename="../src/albumControl.cpp" line="1212"/>
         <source>Blank %1 Disc</source>
         <translation>空白%1光碟</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1197"/>
+        <location filename="../src/albumControl.cpp" line="1216"/>
         <source>%1 Encrypted</source>
         <translation>%1已加密</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1200"/>
+        <location filename="../src/albumControl.cpp" line="1219"/>
         <source>%1 Volume</source>
         <translation>%1卷</translation>
     </message>
@@ -460,52 +462,52 @@
 <context>
     <name>DeleteDialog</name>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="37"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
         <source>Are you sure you want to delete this file locally?</source>
         <translation>您確定要從本機刪除此文件嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="42"/>
         <source>You can restore it in the trash</source>
         <translation>您可以在“最近刪除”中進行復原</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="40"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="44"/>
         <source>Are you sure you want to delete %1 files locally?</source>
         <translation>您確定要從本機刪除這%1個文件嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="41"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
         <source>You can restore them in the trash</source>
         <translation>您可以在“最近刪除”中進行復原</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="45"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
         <source>Are you sure you want to permanently delete this file?</source>
         <translation>您確定要永久刪除此文件嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="46"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="50"/>
         <source>You cannot restore it any longer</source>
         <translation>刪除後不可復原</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="48"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="52"/>
         <source>Are you sure you want to permanently delete %1 files?</source>
         <translation>您確定要永久刪除這%1個文件嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="49"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="53"/>
         <source>You cannot restore them any longer</source>
         <translation>刪除後不可復原</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="84"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="88"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeleteDialog.qml" line="99"/>
+        <location filename="../qml/Control/DeleteDialog.qml" line="103"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -513,64 +515,64 @@
 <context>
     <name>DeviceAlbum</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="55"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="73"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="65"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="75"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="162"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="174"/>
         <source>Import to:</source>
         <translation>匯入到：</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>Import</source>
         <translation>匯入</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="172"/>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="184"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="187"/>
         <source>New Album</source>
         <translation>建立相冊</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="199"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="211"/>
         <source>Import All</source>
         <translation>全部匯入</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="200"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="212"/>
         <source>Import 1 Item</source>
         <translation>匯入1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="201"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="213"/>
         <source>Import %1 Items</source>
         <translation>匯入%1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="208"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="220"/>
         <source>Import successful</source>
         <translation>匯入成功</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="255"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="268"/>
         <source>No results</source>
         <translation>無結果</translation>
     </message>
@@ -578,17 +580,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="38"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
         <source>Loading...</source>
         <translation>正在載入，請稍候...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="47"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="55"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
@@ -596,12 +598,12 @@
 <context>
     <name>EmptyWarningDialog</name>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="23"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="27"/>
         <source>File name cannot be empty!</source>
         <translation>檔案名不能為空</translation>
     </message>
     <message>
-        <location filename="../qml/Control/EmptyWarningDialog.qml" line="32"/>
+        <location filename="../qml/Control/EmptyWarningDialog.qml" line="36"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
@@ -609,78 +611,78 @@
 <context>
     <name>ExportDialog</name>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="45"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="49"/>
         <source>Name:</source>
         <translation>檔案名：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="74"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="78"/>
         <source>Save to:</source>
         <translation>儲存到：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="89"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
         <source>Pictures</source>
         <translation>圖片</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="90"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
         <source>Documents</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="91"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
         <source>Downloads</source>
         <translation>下載</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="92"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="96"/>
         <source>Desktop</source>
         <translation>桌面</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="93"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="97"/>
         <source>Videos</source>
         <translation>影片</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="94"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="98"/>
         <source>Music</source>
         <translation>音樂</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="95"/>
-        <location filename="../qml/Control/ExportDialog.qml" line="112"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="99"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="116"/>
         <source>Select other directories</source>
         <translation>選擇其他目錄</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="134"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="138"/>
         <source>Format:</source>
         <translation>檔案格式：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="169"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="173"/>
         <source>Quality:</source>
         <translation>照片質量：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="206"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="210"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="221"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="225"/>
         <source>Confirm</source>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="236"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="240"/>
         <source>Export successful</source>
         <translation>匯出成功</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ExportDialog.qml" line="238"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="242"/>
         <source>Export failed</source>
         <translation>匯出失敗</translation>
     </message>
@@ -688,123 +690,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1176"/>
+        <location filename="../src/filecontrol.cpp" line="1212"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1180"/>
+        <location filename="../src/filecontrol.cpp" line="1216"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1184"/>
+        <location filename="../src/filecontrol.cpp" line="1220"/>
         <source>Extract text</source>
         <translation>識別文字</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1188"/>
+        <location filename="../src/filecontrol.cpp" line="1224"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1192"/>
+        <location filename="../src/filecontrol.cpp" line="1228"/>
         <source>Rename</source>
         <translation>重新命名</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1196"/>
-        <location filename="../src/filecontrol.cpp" line="1288"/>
+        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1324"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1200"/>
+        <location filename="../src/filecontrol.cpp" line="1236"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1204"/>
+        <location filename="../src/filecontrol.cpp" line="1240"/>
         <source>Rotate clockwise</source>
         <translation>順時針旋轉</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1208"/>
+        <location filename="../src/filecontrol.cpp" line="1244"/>
         <source>Rotate counterclockwise</source>
         <translation>逆時針旋轉</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1212"/>
+        <location filename="../src/filecontrol.cpp" line="1248"/>
         <source>Set as wallpaper</source>
         <translation>設為桌布</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1216"/>
+        <location filename="../src/filecontrol.cpp" line="1252"/>
         <source>Display in file manager</source>
         <translation>在檔案管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1220"/>
+        <location filename="../src/filecontrol.cpp" line="1256"/>
         <source>Image info</source>
         <translation>圖片訊息</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1224"/>
+        <location filename="../src/filecontrol.cpp" line="1260"/>
         <source>Previous</source>
         <translation>上一張</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1228"/>
+        <location filename="../src/filecontrol.cpp" line="1264"/>
         <source>Next</source>
         <translation>下一張</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1232"/>
+        <location filename="../src/filecontrol.cpp" line="1268"/>
         <source>Zoom in</source>
         <translation>放大照片</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1236"/>
+        <location filename="../src/filecontrol.cpp" line="1272"/>
         <source>Zoom out</source>
         <translation>縮小照片</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1240"/>
+        <location filename="../src/filecontrol.cpp" line="1276"/>
         <source>Open</source>
         <translation>打開</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1244"/>
+        <location filename="../src/filecontrol.cpp" line="1280"/>
         <source>Print</source>
         <translation>列印</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1268"/>
+        <location filename="../src/filecontrol.cpp" line="1304"/>
         <source>Image Viewing</source>
         <translation>查看圖片</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1272"/>
+        <location filename="../src/filecontrol.cpp" line="1308"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1276"/>
+        <location filename="../src/filecontrol.cpp" line="1312"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1284"/>
+        <location filename="../src/filecontrol.cpp" line="1320"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1292"/>
+        <location filename="../src/filecontrol.cpp" line="1328"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="1300"/>
+        <location filename="../src/filecontrol.cpp" line="1336"/>
         <source>Live Text</source>
         <translation>實況文字</translation>
     </message>
@@ -812,17 +814,17 @@
 <context>
     <name>FilterComboBox</name>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="15"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="19"/>
         <source>All</source>
         <translation>所有項目</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="16"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="20"/>
         <source>Photos</source>
         <translation>照片</translation>
     </message>
     <message>
-        <location filename="../qml/Control/FilterComboBox.qml" line="17"/>
+        <location filename="../qml/Control/FilterComboBox.qml" line="21"/>
         <source>Videos</source>
         <translation>影片</translation>
     </message>
@@ -830,42 +832,53 @@
 <context>
     <name>GlobalVar</name>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="162"/>
+        <location filename="../qml/GlobalVar.qml" line="181"/>
         <source>The photo/video already exists</source>
         <translation>照片/影片已存在</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="199"/>
+        <location filename="../qml/GlobalVar.qml" line="189"/>
+        <location filename="../qml/GlobalVar.qml" line="197"/>
+        <source>The file format is not supported</source>
+        <translation>該檔案格式不支援</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="239"/>
         <source>1 item selected (1 photo)</source>
         <translation>已選擇1項（1張照片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="201"/>
+        <location filename="../qml/GlobalVar.qml" line="241"/>
         <source>1 item selected (1 video)</source>
         <translation>已選擇1項（1個影片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="203"/>
+        <location filename="../qml/GlobalVar.qml" line="243"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>已選擇%1項（%1張照片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="205"/>
+        <location filename="../qml/GlobalVar.qml" line="245"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>已選擇%1項（%1個影片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="207"/>
+        <location filename="../qml/GlobalVar.qml" line="247"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation>已選擇%1項（1張照片，1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../qml/GlobalVar.qml" line="249"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>已選擇%1項（1張照片，%2個影片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="209"/>
+        <location filename="../qml/GlobalVar.qml" line="251"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>已選擇%1項（%2張照片，1個影片）</translation>
     </message>
     <message>
-        <location filename="../qml/GlobalVar.qml" line="211"/>
+        <location filename="../qml/GlobalVar.qml" line="253"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>已選擇%1項（%2張照片，%3個影片）</translation>
     </message>
@@ -873,27 +886,27 @@
 <context>
     <name>HaveImportedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="57"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="61"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="59"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="63"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="67"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="71"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="73"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="103"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml" line="107"/>
         <source>Import</source>
         <translation>已匯入</translation>
     </message>
@@ -901,12 +914,12 @@
 <context>
     <name>ImageViewer</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="651"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="655"/>
         <source>You have no permission to view the image</source>
         <translation>您沒有權限檢視此圖片</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="687"/>
+        <location filename="../qml/PreviewImageViewer/ImageViewer.qml" line="691"/>
         <source>Image file not found</source>
         <translation>未發現圖片文件</translation>
     </message>
@@ -914,12 +927,12 @@
 <context>
     <name>ImportView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="27"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="30"/>
         <source>Import Photos and Videos</source>
         <translation>匯入照片和影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="45"/>
+        <location filename="../qml/ThumbnailImageView/ImportView.qml" line="48"/>
         <source>Or drag them here</source>
         <translation>您也可以拖曳照片和影片到此</translation>
     </message>
@@ -927,17 +940,17 @@
 <context>
     <name>ImportedlListView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>Imported on</source>
         <translation>匯入於</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>1 item</source>
         <translation>共1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="404"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="411"/>
         <source>%1 items</source>
         <translation>共%1項</translation>
     </message>
@@ -945,112 +958,112 @@
 <context>
     <name>InfomationDialog</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="64"/>
         <source>Basic info</source>
         <translation>基本訊息</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="66"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="70"/>
         <source>File name</source>
         <translation>檔案名</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="77"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="81"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="82"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="86"/>
         <source>Dimensions</source>
         <translation>照片尺寸</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="91"/>
         <source>Type</source>
         <translation>文件類型</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="97"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="101"/>
         <source>Date captured</source>
         <translation>拍攝日期</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="104"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="108"/>
         <source>Date modified</source>
         <translation>修改日期</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="111"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="115"/>
         <source>Details</source>
         <translation>詳細訊息</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="119"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="123"/>
         <source>Aperture</source>
         <translation>光圈大小</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="125"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="129"/>
         <source>Exposure program</source>
         <translation>曝光程式</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="131"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="135"/>
         <source>Focal length</source>
         <translation>焦距</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="142"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="146"/>
         <source>ISO</source>
         <translation>ISO感光度</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="148"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="152"/>
         <source>Exposure mode</source>
         <translation>曝光模式</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="154"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="158"/>
         <source>Exposure time</source>
         <translation>曝光時間</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="163"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="167"/>
         <source>Flash</source>
         <translation>閃光燈</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="172"/>
         <source>Flash compensation</source>
         <translation>閃光燈補償</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="174"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="178"/>
         <source>Max aperture</source>
         <translation>最大光圈值</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="183"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="187"/>
         <source>Colorspace</source>
         <translation>顏色空間</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="189"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="193"/>
         <source>Metering mode</source>
         <translation>測光模式</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="195"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="199"/>
         <source>White balance</source>
         <translation>白平衡</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="203"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="207"/>
         <source>Device model</source>
         <translation>裝置型號</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="208"/>
+        <location filename="../qml/PreviewImageViewer/InfomationDialog.qml" line="212"/>
         <source>Lens model</source>
         <translation>鏡頭型號</translation>
     </message>
@@ -1058,33 +1071,28 @@
 <context>
     <name>MainAlbumView</name>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="159"/>
+        <location filename="../qml/MainAlbumView.qml" line="179"/>
         <source>Importing...</source>
         <translation>正在匯入，請稍候…</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="160"/>
-        <location filename="../qml/MainAlbumView.qml" line="172"/>
+        <location filename="../qml/MainAlbumView.qml" line="180"/>
+        <location filename="../qml/MainAlbumView.qml" line="192"/>
         <source>Imported:</source>
         <translation>已匯入：</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="161"/>
-        <source>0</source>
-        <translation>0</translation>
-    </message>
-    <message>
-        <location filename="../qml/MainAlbumView.qml" line="173"/>
+        <location filename="../qml/MainAlbumView.qml" line="193"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="184"/>
+        <location filename="../qml/MainAlbumView.qml" line="204"/>
         <source>Import successful</source>
         <translation>匯入成功</translation>
     </message>
     <message>
-        <location filename="../qml/MainAlbumView.qml" line="193"/>
+        <location filename="../qml/MainAlbumView.qml" line="213"/>
         <source>Import failed</source>
         <translation>匯入失敗</translation>
     </message>
@@ -1092,7 +1100,7 @@
 <context>
     <name>MonthCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="129"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/MonthCollection.qml" line="141"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
@@ -1100,28 +1108,28 @@
 <context>
     <name>NewAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="36"/>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="74"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="40"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="78"/>
         <source>Unnamed</source>
         <translation>未命名相冊</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="51"/>
         <source>New Album</source>
         <translation>建立相冊</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="60"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="64"/>
         <source>Name:</source>
         <translation>檔案名：</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="87"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="91"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/NewAlbumDialog.qml" line="102"/>
+        <location filename="../qml/Control/NewAlbumDialog.qml" line="106"/>
         <source>Confirm</source>
         <translation>確定</translation>
     </message>
@@ -1129,7 +1137,7 @@
 <context>
     <name>NoPictureView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="29"/>
+        <location filename="../qml/ThumbnailImageView/NoPictureView.qml" line="32"/>
         <source>No photos or videos found</source>
         <translation>未發現照片或影片檔案</translation>
     </message>
@@ -1137,23 +1145,15 @@
 <context>
     <name>OpenImageWidget</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="59"/>
+        <location filename="../qml/PreviewImageViewer/OpenImageWidget.qml" line="63"/>
         <source>Select pictures</source>
         <translation>選擇圖片</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">匯入成功</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">匯入失敗</translation>
     </message>
 </context>
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1176"/>
+        <location filename="../src/albumControl.cpp" line="1195"/>
         <source>System Disk</source>
         <translation>系統盤</translation>
     </message>
@@ -1161,7 +1161,7 @@
 <context>
     <name>PropertyActionItemDelegate</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="83"/>
+        <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
         <source>The file already exists, please use another name</source>
         <translation>該文件已存在，請使用其他名稱</translation>
     </message>
@@ -1169,33 +1169,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="664"/>
-        <location filename="../src/albumControl.cpp" line="713"/>
+        <location filename="../src/albumControl.cpp" line="673"/>
+        <location filename="../src/albumControl.cpp" line="722"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1/%2/%3 %4:%5</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="695"/>
+        <location filename="../src/albumControl.cpp" line="704"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="701"/>
+        <location filename="../src/albumControl.cpp" line="710"/>
         <source>%1/%2</source>
         <translation>%1/%2</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="707"/>
+        <location filename="../src/albumControl.cpp" line="716"/>
         <source>%1/%2/%3</source>
         <translation>%1年%2月%3日</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1409"/>
+        <location filename="../src/albumControl.cpp" line="1434"/>
         <source>Trash</source>
         <translation>最近刪除</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="54"/>
+        <location filename="../main.cpp" line="55"/>
         <source>Album</source>
         <translation>相冊</translation>
     </message>
@@ -1203,17 +1203,17 @@
 <context>
     <name>ReName</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="60"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="64"/>
         <source>The file already exists, please use another name</source>
         <translation>該文件已存在，請使用其他名稱</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="76"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="80"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ReName.qml" line="90"/>
+        <location filename="../qml/PreviewImageViewer/ReName.qml" line="94"/>
         <source>Confirm</source>
         <translation>確定</translation>
     </message>
@@ -1221,47 +1221,47 @@
 <context>
     <name>RecentlyDeletedView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="51"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
         <source>1 photo</source>
         <translation>共1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="53"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="55"/>
         <source>%1 photos</source>
         <translation>共%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="61"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
         <source>1 video</source>
         <translation>共1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="63"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="65"/>
         <source>%1 videos</source>
         <translation>共%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
         <source>Trash</source>
         <translation>最近刪除</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="126"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="129"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>文件在刪除前會顯示剩餘天數，之後將永久刪除</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="138"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
         <source>Delete All</source>
         <translation>全部刪除</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="174"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="177"/>
         <source>Delete Selected (%1)</source>
         <translation>刪除%1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="195"/>
         <source>Restore Selected (%1)</source>
         <translation>復原%1項</translation>
     </message>
@@ -1269,17 +1269,17 @@
 <context>
     <name>RemoveAlbumDialog</name>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="36"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="40"/>
         <source>Are you sure you want to delete this album?</source>
         <translation>您確定要刪除此相冊嗎？</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="47"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="51"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="62"/>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="66"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -1287,42 +1287,42 @@
 <context>
     <name>SearchView</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="58"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
         <source>1 photo found</source>
         <translation>共找到1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="60"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="55"/>
         <source>%1 photos found</source>
         <translation>共找到%1張照片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>1 video found</source>
         <translation>共找到1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="61"/>
         <source>%1 videos found</source>
         <translation>共找到%1個影片</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="69"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="66"/>
         <source>%1 items found</source>
         <translation>共找到%1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="94"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
         <translation>搜尋結果</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="117"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="110"/>
         <source>Slide Show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="175"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="181"/>
         <source>No search results</source>
         <translation>無搜尋結果</translation>
     </message>
@@ -1330,93 +1330,93 @@
 <context>
     <name>Sidebar</name>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="109"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="133"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="117"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="141"/>
         <source>Album “%1” removed</source>
         <translation>已成功刪除“%1”相冊</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="157"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="165"/>
         <source>Gallery</source>
         <translation>照片庫</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="160"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="168"/>
         <source>Collection</source>
         <translation>合集</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="161"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="169"/>
         <source>Import</source>
         <translation>已匯入</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="162"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="170"/>
         <source>Favorites</source>
         <translation>我的收藏</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="163"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="171"/>
         <source>Trash</source>
         <translation>最近刪除</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="183"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="194"/>
         <source>Device</source>
         <translation>裝置</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="241"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="252"/>
         <source>Albums</source>
         <translation>相冊</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="259"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="273"/>
         <source>Add an album</source>
         <translation>建立相冊</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="285"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="299"/>
         <source>Screen Capture</source>
         <translation>截圖錄屏</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="289"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="303"/>
         <source>Camera</source>
         <translation>相機</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="293"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="307"/>
         <source>Draw</source>
         <translation>畫板</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="400"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="479"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="414"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="439"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="493"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="411"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="437"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="511"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="425"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="451"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="525"/>
         <source>Export</source>
         <translation>匯出</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="445"/>
-        <location filename="../qml/SideBar/Sidebar.qml" line="520"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="459"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="488"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="502"/>
         <source>New album</source>
         <translation>建立相冊</translation>
     </message>
     <message>
-        <location filename="../qml/SideBar/Sidebar.qml" line="499"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="513"/>
         <source>Rename</source>
         <translation>重新命名</translation>
     </message>
@@ -1424,30 +1424,30 @@
 <context>
     <name>SliderShow</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="145"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="149"/>
         <source>Previous</source>
         <translation>上一張</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Pause</source>
         <translation>暫停</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="162"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="166"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="216"/>
         <source>Play</source>
         <translation>播放</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="184"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="188"/>
         <source>Next</source>
         <translation>下一張</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="201"/>
-        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="230"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="205"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="234"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
@@ -1455,12 +1455,25 @@
 <context>
     <name>ThumbnailListDelegate</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
         <source>days</source>
         <translation>天</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="224"/>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate.qml" line="229"/>
+        <source>day</source>
+        <translation>天</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListDelegate2</name>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
+        <source>days</source>
+        <translation>天</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListDelegate2.qml" line="290"/>
         <source>day</source>
         <translation>天</translation>
     </message>
@@ -1468,165 +1481,279 @@
 <context>
     <name>ThumbnailListView</name>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="192"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="198"/>
         <source>Export successful</source>
         <translation>匯出成功</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="194"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="200"/>
         <source>Export failed</source>
         <translation>匯出失敗</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="691"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="700"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="709"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="717"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="726"/>
         <source>Print</source>
         <translation>列印</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="736"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="745"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="764"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="773"/>
         <source>Add to album</source>
         <translation>添加到相冊</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="767"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="776"/>
         <source>New album</source>
         <translation>建立相冊</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="790"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
         <source>Successfully added to “%1”</source>
         <translation>成功添加到“%1”</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="799"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="808"/>
         <source>Export</source>
         <translation>匯出</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="818"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="827"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="836"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="837"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="846"/>
         <source>Remove from album</source>
         <translation>從相冊中移除</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="854"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="863"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="864"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="873"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="878"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
         <source>Rotate clockwise</source>
         <translation>順時針旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="887"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="896"/>
         <source>Rotate counterclockwise</source>
         <translation>逆時針旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="902"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="905"/>
         <source>Set as wallpaper</source>
         <translation>設為桌布</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="921"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="924"/>
         <source>Display in file manager</source>
         <translation>在檔案管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="940"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="943"/>
         <source>Restore</source>
         <translation>復原</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="951"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="954"/>
         <source>Photo info</source>
         <translation>照片訊息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="970"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView.qml" line="973"/>
         <source>Video info</source>
         <translation>影片訊息</translation>
     </message>
 </context>
 <context>
-    <name>ToolBarThumbnailListView</name>
+    <name>ThumbnailListView2</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="118"/>
-        <source>Back to Album</source>
-        <translation>返回相冊</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="776"/>
+        <source>View</source>
+        <translation>查看</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="160"/>
-        <source>Previous</source>
-        <translation>上一張</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="785"/>
+        <source>Fullscreen</source>
+        <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="187"/>
-        <source>Next</source>
-        <translation>下一張</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="802"/>
+        <source>Print</source>
+        <translation>列印</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="208"/>
-        <source>Original size</source>
-        <translation>原始大小</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="821"/>
+        <source>Slide show</source>
+        <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="229"/>
-        <source>Fit to window</source>
-        <translation>適應視窗</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="847"/>
+        <source>Add to album</source>
+        <translation>添加到相冊</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="255"/>
-        <source>Rotate</source>
-        <translation>旋轉</translation>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="850"/>
+        <source>New album</source>
+        <translation>建立相冊</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="873"/>
+        <source>Successfully added to “%1”</source>
+        <translation>成功添加到“%1”</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="882"/>
+        <source>Export</source>
+        <translation>匯出</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="901"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="910"/>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="920"/>
+        <source>Remove from album</source>
+        <translation>從相冊中移除</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="935"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="288"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="945"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="429"/>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="959"/>
+        <source>Rotate clockwise</source>
+        <translation>順時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="968"/>
+        <source>Rotate counterclockwise</source>
+        <translation>逆時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>設為桌布</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="996"/>
+        <source>Display in file manager</source>
+        <translation>在檔案管理器中顯示</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1015"/>
+        <source>Restore</source>
+        <translation>復原</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1024"/>
+        <source>Photo info</source>
+        <translation>照片訊息</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/ListView/ThumbnailListView2.qml" line="1043"/>
+        <source>Video info</source>
+        <translation>影片訊息</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListViewTools</name>
+    <message>
+        <source>Export successful</source>
+        <translation type="vanished">匯出成功</translation>
+    </message>
+    <message>
+        <source>Export failed</source>
+        <translation type="vanished">匯出失敗</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarThumbnailListView</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="122"/>
+        <source>Back to Album</source>
+        <translation>返回相冊</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="164"/>
+        <source>Previous</source>
+        <translation>上一張</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="191"/>
+        <source>Next</source>
+        <translation>下一張</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="212"/>
+        <source>Original size</source>
+        <translation>原始大小</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="233"/>
+        <source>Fit to window</source>
+        <translation>適應視窗</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="259"/>
+        <source>Rotate</source>
+        <translation>旋轉</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Favorite</source>
+        <translation>收藏</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="292"/>
+        <source>Unfavorite</source>
+        <translation>取消收藏</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="433"/>
         <source>Extract text</source>
         <translation>識別文字</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="456"/>
+        <location filename="../qml/PreviewImageViewer/ToolBarThumbnailListView.qml" line="460"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -1634,93 +1761,93 @@
 <context>
     <name>VideoInfoDialog</name>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="57"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="61"/>
         <source>Basic info</source>
         <translation>基本訊息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="62"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="66"/>
         <source>File name</source>
         <translation>檔案名</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="72"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="76"/>
         <source>Date captured</source>
         <translation>拍攝日期</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="79"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="83"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="84"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="88"/>
         <source>Duration</source>
         <translation>時長</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="89"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="93"/>
         <source>Type</source>
         <translation>文件類型</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="99"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="103"/>
         <source>Path</source>
         <translation>文件路徑</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="106"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="110"/>
         <source>Codec info</source>
         <translation>編碼訊息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="114"/>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="154"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="118"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="158"/>
         <source>Video CodecID</source>
         <translation>影片軌訊息</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="120"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="124"/>
         <source>Video CodeRate</source>
         <translation>影片碼率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="126"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
         <source>FPS</source>
         <translation>影片幀率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="137"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="141"/>
         <source>Proportion</source>
         <translation>顯示比例</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="144"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="148"/>
         <source>Resolution</source>
         <translation>解析度</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="162"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="166"/>
         <source>Audio CodecID</source>
         <translation>編碼樣式</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="168"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="172"/>
         <source>Audio CodeRate</source>
         <translation>編碼碼率</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="174"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="178"/>
         <source>Audio digit</source>
         <translation>音訊位數</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="185"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="189"/>
         <source>Channels</source>
         <translation>聲道數</translation>
     </message>
     <message>
-        <location filename="../qml/Control/VideoInfoDialog.qml" line="192"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="196"/>
         <source>Sampling</source>
         <translation>採樣數</translation>
     </message>
@@ -1728,102 +1855,102 @@
 <context>
     <name>ViewRightMenu</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="18"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="22"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="37"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="41"/>
         <source>Print</source>
         <translation>列印</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="55"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="59"/>
         <source>Extract text</source>
         <translation>識別文字</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="74"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="78"/>
         <source>Slide show</source>
         <translation>幻燈片放映</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="99"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="103"/>
         <source>Export</source>
         <translation>匯出</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="116"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="120"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="137"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="141"/>
         <source>Rename</source>
         <translation>重新命名</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="168"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="172"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="196"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="200"/>
         <source>Favorite</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="206"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="210"/>
         <source>Unfavorite</source>
         <translation>取消收藏</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="222"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="226"/>
         <source>Rotate clockwise</source>
         <translation>順時針旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="241"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="245"/>
         <source>Rotate counterclockwise</source>
         <translation>逆時針旋轉</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Show navigation window</source>
         <translation>顯示導航視窗</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="262"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="266"/>
         <source>Hide navigation window</source>
         <translation>隱藏導航視窗</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="286"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="290"/>
         <source>Set as wallpaper</source>
         <translation>設為桌布</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="305"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="309"/>
         <source>Display in file manager</source>
         <translation>在檔案管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="323"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="327"/>
         <source>Image info</source>
         <translation>圖片訊息</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="344"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="348"/>
         <source>Export successful</source>
         <translation>匯出成功</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="346"/>
+        <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="350"/>
         <source>Export failed</source>
         <translation>匯出失敗</translation>
     </message>
@@ -1831,12 +1958,12 @@
 <context>
     <name>ViewTopTitle</name>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="85"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="89"/>
         <source>Album is a stylish management tool for viewing and organizing photos and videos.</source>
         <translation>相冊是一款可多種方式瀏覽、整理照片和影片的管理工具。</translation>
     </message>
     <message>
-        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="87"/>
+        <location filename="../qml/PreviewImageViewer/ViewTopTitle.qml" line="91"/>
         <source>Album</source>
         <translation>相冊</translation>
     </message>
@@ -1844,17 +1971,17 @@
 <context>
     <name>YearCollection</name>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="112"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="125"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>%1 items</source>
         <translation>共%1項</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="123"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/YearCollection.qml" line="136"/>
         <source>1 item</source>
         <translation>共1項</translation>
     </message>
@@ -1862,17 +1989,9 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../qml/main.qml" line="91"/>
+        <location filename="../qml/main.qml" line="86"/>
         <source>All photos and videos</source>
         <translation>所有照片和影片</translation>
-    </message>
-    <message>
-        <source>Import successful</source>
-        <translation type="vanished">匯入成功</translation>
-    </message>
-    <message>
-        <source>Import failed</source>
-        <translation type="vanished">匯入失敗</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
QML改造，重构QML代码（除日视图、已导入视图）
1.使用V20方式，缓存缩略图，提升图片加载速度
2.调整模型/视图实现方式，model数据由C++后端提供，前端由QML实现
3.重写单个列表框选实现方式，支持单个列表滚动向上/向下框选
4.UI效果优化，年视图圆角效果优化，移除相册启动时视图切换动画
5.修复功能性bug

Log: QML改造，重构QML代码（除日视图、已导入视图）
Influence: 界面展示 数据交互