### PR TITLE
fix: 修复删除图片后，最近删除视图部分图片显示为撕裂图的问题

### DIFF
--- a/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
+++ b/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
@@ -227,6 +227,7 @@ Rectangle {
 
         proxyModel.sourceModel: Album.ImageDataModel { id: dataModel; modelType: Album.Types.RecentlyDeleted}
 
+        visible: theView.count
         property int m_topMargin: 10
 
         // 监听缩略图列表选中状态，一旦改变，更新globalVar所有选中路径

--- a/src/src/thumbnailview/thumbnailmodel.cpp
+++ b/src/src/thumbnailview/thumbnailmodel.cpp
@@ -5,6 +5,7 @@
 #include "thumbnailmodel.h"
 #include "unionimage/unionimage.h"
 #include "imageengine/imagedataservice.h"
+#include "unionimage/baseutils.h"
 #include "imagedatamodel.h"
 
 #include <QDebug>
@@ -398,11 +399,21 @@ int ThumbnailModel::indexForFilePath(const QString &filePath)
     for (int row = 0; row < rowCount(); row++) {
         indexList.append(index(row, 0, QModelIndex()));
     }
-    for (auto index : indexList) {
-        if (filePath == data(index, Roles::FilePathRole).toString()) {
-            return index.row();
+    if (modelType() == Types::RecentlyDeleted) {
+        for (auto index : indexList) {
+            QString path = data(index, Roles::FilePathRole).toString();
+            if (filePath == Libutils::base::getDeleteFullPath(Libutils::base::hashByString(path), DBImgInfo::getFileNameFromFilePath(path))) {
+                return index.row();
+            }
+        }
+    } else {
+        for (auto index : indexList) {
+            if (filePath == data(index, Roles::FilePathRole).toString()) {
+                return index.row();
+            }
         }
     }
+
     return -1;
 }
 


### PR DESCRIPTION
    原因是最近删除视图缓存图片加载成功后，缩略图model类图片路径校验出错，解决方案是针对最近删除的图片刷新逻辑添加路径判断

Log: 修复删除图片后，最近删除视图部分图片显示为撕裂图的问题
Bug: https://pms.uniontech.com/bug-view-170385.html