### PR TITLE
fix: 修复右上角菜单-新建相册无反应的问题

### DIFF
--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -25,6 +25,7 @@ TitleBar {
 
     signal collectionBtnClicked(int nIndex)
     signal showHideSideBar(bool bShow)
+    signal showNewAlbumDialog()
 
     property int minSearchEditWidth : 100 //搜索框最小尺寸
     property int normalSearchEditWidth : 240 //搜索框最大尺寸
@@ -92,13 +93,7 @@ TitleBar {
             id: equalizerControl
             text: qsTr("New album")
             onTriggered: {
-                var x = parent.mapToGlobal(0, 0).x + parent.width / 2 - 190
-                var y = parent.mapToGlobal(0, 0).y + parent.height / 2 - 89
-                newAlbum.setX(x)
-                newAlbum.setY(y)
-                newAlbum.setNormalEdit()
-                newAlbum.show()
-
+                showNewAlbumDialog()
             }
         }
         MenuItem {

--- a/src/qml/MainAlbumView.qml
+++ b/src/qml/MainAlbumView.qml
@@ -72,6 +72,19 @@ Rectangle {
         }
     }
 
+    Connections {
+        target: titleAlubmRect
+        onShowNewAlbumDialog: {
+            var x = parent.mapToGlobal(0, 0).x + parent.width / 2 - 190
+            var y = parent.mapToGlobal(0, 0).y + parent.height / 2 - 89
+            newAlbum.setX(x)
+            newAlbum.setY(y)
+            newAlbum.setNormalEdit()
+            newAlbum.isChangeView = true
+            newAlbum.show()
+        }
+    }
+
     //左右按钮隐藏动画
     NumberAnimation {
         id :hideSliderAnimation


### PR DESCRIPTION
   原因是标题栏布局实现调整，导致标题栏内无法访问到新建相册对话框对象，解决方案是发送信号到主界面，通知显示新建相册对话框

Log: 修复右上角菜单-新建相册无反应的问题
Bug: https://pms.uniontech.com/bug-view-192979.html