### PR TITLE
fix: 修复U盘格式化过程中，无法关闭相册应用的问题

### DIFF
--- a/src/album/dbmanager/DBandImgOperate.cpp
+++ b/src/album/dbmanager/DBandImgOperate.cpp
@@ -178,6 +178,11 @@ void DBandImgOperate::rotateImageFile(int angel, const QStringList &paths)
     }
 }
 
+bool DBandImgOperate::isRotating()
+{
+    return m_rotateIsRunning;
+}
+
 void DBandImgOperate::waitRotateStop()
 {
     while (m_rotateIsRunning);

--- a/src/album/dbmanager/DBandImgOperate.h
+++ b/src/album/dbmanager/DBandImgOperate.h
@@ -33,6 +33,7 @@ public:
     explicit DBandImgOperate(QObject *parent = nullptr);
     ~DBandImgOperate();
 
+    bool isRotating();
     void waitRotateStop();
     void stopRotate();
 public slots:

--- a/src/album/imageengine/imageengineapi.cpp
+++ b/src/album/imageengine/imageengineapi.cpp
@@ -157,6 +157,11 @@ void ImageEngineApi::loadFirstPageThumbnails(int num)
     emit sigLoadFirstPageThumbnailsToView();
 }
 
+bool ImageEngineApi::isRotating()
+{
+    return m_worker->isRotating();
+}
+
 void ImageEngineApi::stopRotate()
 {
     m_worker->stopRotate();

--- a/src/album/imageengine/imageengineapi.h
+++ b/src/album/imageengine/imageengineapi.h
@@ -97,6 +97,7 @@ public:
     int m_FirstPageScreen = 0;
     QStringList m_imgLoaded;//已经加载过的图片，防止多次加载
     bool m_firstPageIsLoaded = false;
+    bool isRotating();
     void stopRotate();
     void waitRotateStop();
 private:

--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -1664,17 +1664,27 @@ void MainWindow::waitImportantProcessBeforeExit()
     canExit = false;
 
     auto watcher = QtConcurrent::run([&canExit]() {
-        //1.1停止
-        ImageEngineApi::instance()->stopRotate();
-        ImageDataService::instance()->stopFlushThumbnail();
+        if (ImageEngineApi::instance()->isRotating()) {
+            //1.1停止
+            ImageEngineApi::instance()->stopRotate();
 
-        //1.2等待
-        ImageEngineApi::instance()->waitRotateStop();
-        ImageDataService::instance()->waitFlushThumbnailFinish();
+            //1.2等待
+            ImageEngineApi::instance()->waitRotateStop();
 
-        //1.3强制文件写入
-        std::system("sync");
+            //1.3强制文件写入
+            std::system("sync");
+        }
 
+        if (ImageDataService::instance()->readerIsRunning()) {
+            //1.1停止
+            ImageDataService::instance()->stopFlushThumbnail();
+
+            //1.2等待
+            ImageDataService::instance()->waitFlushThumbnailFinish();
+
+            //1.3强制文件写入
+            std::system("sync");
+        }
         canExit = true;
     });
 


### PR DESCRIPTION
  U盘格式化时，调用sync命令同样会被阻塞，调整sync命令调用时机，仅在旋转和读图时才执行sync命令阻塞相册关闭

Log: 修复U盘格式化过程中，无法关闭相册应用的问题

Bug: https://pms.uniontech.com/bug-view-164375.html