### PR TITLE
fix: 修复相册名称为单字符时，相册名会与顶部控件区域重叠的问题

### DIFF
--- a/src/album/widgets/batchoperatewidget.cpp
+++ b/src/album/widgets/batchoperatewidget.cpp
@@ -232,12 +232,7 @@ void BatchOperateWidget::sltSelectionChanged(const QItemSelection &selected, con
 {
     Q_UNUSED(selected)
     Q_UNUSED(deselected)
-    if (m_thumbnailListView->getAppointTypeSelectItemCount(ItemTypeNull) == 0) {
-        if (AlbumViewTrashType == m_operateType)
-            batchSelectChanged(true, false);
-        refreshBtnEnabled(true);
-        return;
-    }
+
     batchSelectChanged(true, false);
     refreshBtnEnabled();
     m_thumbnailListView->setFocus();


### PR DESCRIPTION
   1.调整自定义相册顶部控件显示布局和计算方式
   2.调整我的收藏顶部控件显示布局和计算方式

Log: 修复相册名称为单字符时，相册名会与顶部控件区域重叠的问题

Bug: https://pms.uniontech.com/bug-view-138675.html