### PR TITLE
fix: 修复相册窗口处于未激活状态下，相册导航栏图标未置灰的问题

### DIFF
--- a/src/album/widgets/albumlefttabitem.cpp
+++ b/src/album/widgets/albumlefttabitem.cpp
@@ -130,7 +130,7 @@ void AlbumLeftTabItem::initUI()
     m_nameLabel->setFont(ft);
 //    DPalette pa = DApplicationHelper::instance()->palette(m_nameLabel);
 //    pa.setBrush(DPalette::Text, pa.color(DPalette::ToolTipText));
-    m_nameLabel->setForegroundRole(DPalette::TextTitle);
+    m_nameLabel->setForegroundRole(QPalette::WindowText);
 //    m_nameLabel->setPalette(pa);
     // 设置标签不显示多文本
     m_nameLabel->setTextFormat(Qt::PlainText);
@@ -165,7 +165,7 @@ void AlbumLeftTabItem::initUI()
         const int width = 24;
         pixmapMount = utils::base::renderSVG(":/resources/images/sidebar/normal/icon_exit_normal.svg", QSize(width, width));
         m_unMountBtn->setPixmap(pixmapMount);
-        pHBoxLayout->addWidget(m_unMountBtn); 
+        pHBoxLayout->addWidget(m_unMountBtn);
 
         //调整m_nameLabel、m_pLineEdit宽度
         QRect rect = m_nameLabel->geometry();
@@ -371,7 +371,7 @@ void AlbumLeftTabItem::oriAlbumStatus()
     }
 
     pImageLabel->setPixmap(pixmap);
-    m_nameLabel->setForegroundRole(DPalette::TextTitle);
+    m_nameLabel->setForegroundRole(QPalette::WindowText);
 }
 
 void AlbumLeftTabItem::newAlbumStatus()
@@ -425,4 +425,10 @@ void AlbumLeftTabItem::newAlbumStatus()
 void AlbumLeftTabItem::mouseReleaseEvent(QMouseEvent *e)
 {
     Q_UNUSED(e)
+}
+
+void AlbumLeftTabItem::paintEvent(QPaintEvent *e)
+{
+    pImageLabel->setEnabled(this->isActiveWindow());
+    QWidget::paintEvent(e);
 }

--- a/src/album/widgets/albumlefttabitem.h
+++ b/src/album/widgets/albumlefttabitem.h
@@ -30,6 +30,9 @@ public:
 
     void mouseReleaseEvent(QMouseEvent *e) override;
 
+protected:
+    void paintEvent(QPaintEvent *e) override;
+
 private:
     void initConnections();
     void initUI();


### PR DESCRIPTION
  1.添加paintEvent事件处理，在窗口未激活时，设置图标为置灰状态
  2.调整文本颜色UI效果

Log: 修复相册窗口处于未激活状态下，相册导航栏图标未置灰的问题
Bug: https://pms.uniontech.com/bug-view-156983.html