### PR TITLE
fix: 修复大图模式删除图片，没有删除确认弹窗的问题

### DIFF
--- a/src/album/mainwindow.h
+++ b/src/album/mainwindow.h
@@ -176,6 +176,7 @@ public slots:
     void onSigViewImage(const SignalManager::ViewInfo &info, OpenImgAdditionalOperation operation, bool isCustom, const QString &album, int UID);
     void onCollectButtonClicked();
     void updateCollectButton();
+    void onConfirmLibDel(const QString& path);
     void onLibDel(QString path);
     void deleteSaveImage();
     void onNewPathAction(); //响应新自定义路径创建


### PR DESCRIPTION
   添加删除确认信号的处理，来自看图的删除信号，弹出删除确认弹窗

Log: 修复大图模式删除图片，没有显示删除确认弹窗的问题
Bug: https://pms.uniontech.com/bug-view-157033.html