### PR TITLE
fix: 修复相册视图-导航栏，相册名称没有tooltips提示文案的问题

### DIFF
--- a/src/album/widgets/albumlefttabitem.cpp
+++ b/src/album/widgets/albumlefttabitem.cpp
@@ -193,6 +193,7 @@ void AlbumLeftTabItem::initUI()
     } else {
         DFontSizeManager::instance()->bind(m_nameLabel, DFontSizeManager::T6, Qt::ElideRight);
         m_nameLabel->Settext(elideFont.elidedText(m_albumNameStr, Qt::ElideRight, m_nameLabel->width()));
+        m_nameLabel->setToolTip(m_albumNameStr);
         AC_SET_OBJECT_NAME(m_nameLabel, m_albumNameStr);
         AC_SET_ACCESSIBLE_NAME(m_nameLabel, m_albumNameStr);
     }
@@ -238,6 +239,7 @@ void AlbumLeftTabItem::onCheckNameValid()
         QFontMetrics elideFont(m_nameLabel->font());
         //m_nameLabel->Settext(elideFont.elidedText(newNameStr, Qt::ElideRight, 85));
         m_nameLabel->Settext(elideFont.elidedText(newNameStr, Qt::ElideRight, m_nameLabel->width()));
+        m_nameLabel->setToolTip(newNameStr);
         m_nameLabel->oldstr = newNameStr;
         QFont ft;
         ft.setPixelSize(14);
@@ -254,6 +256,7 @@ void AlbumLeftTabItem::onCheckNameValid()
         QFontMetrics elideFont(m_nameLabel->font());
         //m_nameLabel->Settext(elideFont.elidedText(newNameStr, Qt::ElideRight, 85));
         m_nameLabel->Settext(elideFont.elidedText(newNameStr, Qt::ElideRight, m_nameLabel->width()));
+        m_nameLabel->setToolTip(newNameStr);
         m_nameLabel->oldstr = newNameStr;
         QFont ft;
         ft.setPixelSize(14);


### PR DESCRIPTION
   补齐tooltips文案显示逻辑

Log: 修复相册视图-导航栏，相册名称没有tooltips提示文案的问题
Bug: https://pms.uniontech.com/bug-view-194271.html