### PR TITLE
fix: 修复相册视图-侧边栏空白区域，可移动相册主界面的问题

### DIFF
--- a/src/album/albumview/leftlistview.cpp
+++ b/src/album/albumview/leftlistview.cpp
@@ -199,7 +199,7 @@ void LeftListView::initUI()
 
         AlbumLeftTabItem *pAlbumLeftTabItem = new AlbumLeftTabItem(albumName.second, albumName.first, "AutoImport");
         pAlbumLeftTabItem->setFixedWidth(LEFT_VIEW_LISTITEM_WIDTH_160 /*+ 8*/);
-        pAlbumLeftTabItem->setFixedHeight(LEFT_VIEW_LISTITEM_HEIGHT_40); 
+        pAlbumLeftTabItem->setFixedHeight(LEFT_VIEW_LISTITEM_HEIGHT_40);
         m_pCustomizeListView->setItemWidget(pListWidgetItem, pAlbumLeftTabItem);
     }
 
@@ -770,4 +770,10 @@ void LeftListView::mousePressEvent(QMouseEvent *e)
 {
     m_pCustomizeListView->SaveRename(e->pos());
     DWidget::mousePressEvent(e);
+}
+
+void LeftListView::mouseMoveEvent(QMouseEvent *e)
+{
+    DWidget::mousePressEvent(e);
+    e->accept();
 }

--- a/src/album/albumview/leftlistview.h
+++ b/src/album/albumview/leftlistview.h
@@ -47,6 +47,7 @@ private:
     QString getNewAlbumName();
     void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
     void mousePressEvent(QMouseEvent *e) override;
+    void mouseMoveEvent(QMouseEvent *e) override;
 signals:
     void itemClicked();
     //幻灯片播放


### PR DESCRIPTION
   应用的鼠标移动事件需要被接受，平台插件(dde-qt5platform-plugins)才不会移动窗口

Log: 修复相册视图-侧边栏空白区域，可移动相册主界面的问题
Bug: https://pms.uniontech.com/bug-view-194203.html