### PR TITLE
fix: 修复侧边栏导航项和标题栏按钮缺少hover样式的问题

### DIFF
--- a/src/album/albumview/leftlistview.cpp
+++ b/src/album/albumview/leftlistview.cpp
@@ -113,7 +113,6 @@ void LeftListView::initUI()
     m_pPhotoLibListView = new LeftListWidget();
     m_pPhotoLibListView->setFocusPolicy(Qt::NoFocus);
     DStyledItemDelegate *itemDelegate0 = new DStyledItemDelegate(m_pPhotoLibListView);
-    itemDelegate0->setBackgroundType(DStyledItemDelegate::NoBackground);
     m_pPhotoLibListView->setItemDelegate(itemDelegate0);
 
     m_pPhotoLibListView->setFixedWidth(LEFT_VIEW_WIDTH_180);
@@ -184,7 +183,6 @@ void LeftListView::initUI()
     m_pCustomizeListView = new LeftListWidget();
     m_pCustomizeListView->setFocusPolicy(Qt::NoFocus);
     DStyledItemDelegate *itemDelegate1 = new DStyledItemDelegate(m_pCustomizeListView);
-    itemDelegate1->setBackgroundType(DStyledItemDelegate::NoBackground);
     m_pCustomizeListView->setItemDelegate(itemDelegate1);
     m_pCustomizeListView->setSpacing(0);
     m_pCustomizeListView->setFrameShape(DListWidget::NoFrame);
@@ -236,7 +234,6 @@ void LeftListView::initUI()
     m_pMountListWidget->setFocusPolicy(Qt::NoFocus);
     m_pMountListWidget->setVisible(false);
     DStyledItemDelegate *itemDelegate2 = new DStyledItemDelegate(m_pMountListWidget);
-    itemDelegate2->setBackgroundType(DStyledItemDelegate::NoBackground);
     m_pMountListWidget->setItemDelegate(itemDelegate2);
 
     m_pMountListWidget->setSpacing(0);

--- a/src/album/albumview/leftlistwidget.cpp
+++ b/src/album/albumview/leftlistwidget.cpp
@@ -61,8 +61,19 @@ void LeftListWidget::dragEnterEvent(QDragEnterEvent *event)
     }
 }
 
+void LeftListWidget::paintEvent(QPaintEvent *event)
+{
+    // 让背景色适合主题颜色
+    DPalette pa;
+    pa = DApplicationHelper::instance()->palette(this);
+    pa.setBrush(DPalette::ItemBackground, pa.brush(DPalette::Base));
+    DApplicationHelper::instance()->setPalette(this, pa);
+
+    DListWidget::paintEvent(event);
+}
+
 void LeftListWidget::mousePressEvent(QMouseEvent *e)
-{ 
+{
     QModelIndex index = indexAt(e->pos());
     if (!index.isValid()) {
         emit sigMousePressIsNoValid();

--- a/src/album/albumview/leftlistwidget.h
+++ b/src/album/albumview/leftlistwidget.h
@@ -31,6 +31,9 @@ protected:
 
     void dragEnterEvent(QDragEnterEvent *event) override;
 
+    /**@brief:事件重写*/
+    void paintEvent(QPaintEvent *event) override;
+
 signals:
     void signalDropEvent(QModelIndex index);
     void sigMousePressIsNoValid();

--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -310,14 +310,11 @@ void MainWindow::initTitleBar()
     btnGroup->setExclusive(true);
     QHBoxLayout *pTitleBtnLayout = new QHBoxLayout();
 
-    m_pAllPicBtn = new DPushButton();
+    m_pAllPicBtn = new FlatButton();
     m_pAllPicBtn->setFocusPolicy(Qt::TabFocus);
     AC_SET_OBJECT_NAME(m_pAllPicBtn, Main_All_Picture_Button);
     AC_SET_ACCESSIBLE_NAME(m_pAllPicBtn, Main_All_Picture_Button);
 
-//    m_pAllPicBtn = new DSuggestButton();
-    m_pAllPicBtn->setFlat(true);
-//    m_pAllPicBtn->setFixedSize(80, 36);
     m_pAllPicBtn->setMaximumSize(110, 36);
     m_pAllPicBtn->setCheckable(true);
     m_pAllPicBtn->setChecked(true);
@@ -326,13 +323,11 @@ void MainWindow::initTitleBar()
     DFontSizeManager::instance()->bind(m_pAllPicBtn, DFontSizeManager::T6);
     pTitleBtnLayout->addWidget(m_pAllPicBtn);
 
-    m_pTimeBtn = new DPushButton();
+    m_pTimeBtn = new FlatButton();
     m_pTimeBtn->setFocusPolicy(Qt::TabFocus);
     AC_SET_OBJECT_NAME(m_pTimeBtn, Main_Time_Line_Button);
     AC_SET_ACCESSIBLE_NAME(m_pTimeBtn, Main_Time_Line_Button);
-//    m_pTimeBtn = new DSuggestButton();
-    m_pTimeBtn->setFlat(true);
-//    m_pTimeBtn->setFixedSize(60, 36);
+
     m_pTimeBtn->setMaximumSize(110, 36);
     m_pTimeBtn->setCheckable(true);
     m_pTimeBtn->setText(tr("Timelines"));
@@ -341,13 +336,11 @@ void MainWindow::initTitleBar()
     pTitleBtnLayout->addSpacing(-6);
     pTitleBtnLayout->addWidget(m_pTimeBtn);
 
-    m_pAlbumBtn = new DPushButton();
+    m_pAlbumBtn = new FlatButton();
     m_pAlbumBtn->setFocusPolicy(Qt::TabFocus);
     AC_SET_OBJECT_NAME(m_pAlbumBtn, Main_Album_Button);
     AC_SET_ACCESSIBLE_NAME(m_pAlbumBtn, Main_Album_Button);
-//    m_pAlbumBtn = new DSuggestButton();
-    m_pAlbumBtn->setFlat(true);
-//    m_pAlbumBtn->setFixedSize(60, 36);
+
     m_pAlbumBtn->setMaximumSize(90, 36);
     m_pAlbumBtn->setCheckable(true);
     m_pAlbumBtn->setText(tr("Albums"));

--- a/src/album/mainwindow.h
+++ b/src/album/mainwindow.h
@@ -12,6 +12,7 @@
 #include "searchview/searchview.h"
 #include "controller/exporter.h"
 #include "widgets/dialogs/imginfodialog.h"
+#include "widgets/flatbutton.h"
 #include "fileinotifygroup.h"
 
 #include <QListWidget>
@@ -221,9 +222,9 @@ private:
     int m_pSliderPos = 2;       //滑动条步进
 
     QButtonGroup *btnGroup = nullptr;
-    DPushButton *m_pAllPicBtn = nullptr;
-    DPushButton *m_pTimeBtn = nullptr;
-    DPushButton *m_pAlbumBtn = nullptr;
+    FlatButton *m_pAllPicBtn = nullptr;
+    FlatButton *m_pTimeBtn = nullptr;
+    FlatButton *m_pAlbumBtn = nullptr;
 
     DDialog  *m_waitdailog = nullptr;
     DProgressBar *m_importBar = nullptr;

--- a/src/album/widgets/flatbutton.cpp
+++ b/src/album/widgets/flatbutton.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "flatbutton.h"
+
+FlatButton::FlatButton(QWidget *parent) : DPushButton(parent)
+{
+    setFlat(true);
+}
+
+bool FlatButton::event(QEvent *event)
+{
+    if (event->type() == QEvent::HoverEnter) {
+        setFlat(false);
+    }
+
+    if (event->type() == QEvent::HoverLeave) {
+        setFlat(true);
+    }
+
+    return QPushButton::event(event);
+}

--- a/src/album/widgets/flatbutton.h
+++ b/src/album/widgets/flatbutton.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FLATBUTTON_H
+#define FLATBUTTON_H
+
+#include <DPushButton>
+#include <QEvent>
+
+DWIDGET_USE_NAMESPACE
+
+class FlatButton : public DPushButton
+{
+    Q_OBJECT
+public:
+
+    /**
+     * @description: FlatButton 构造函数
+    */
+    explicit FlatButton(QWidget *parent = nullptr);
+
+protected:
+    bool event(QEvent * event) override;
+
+};
+
+#endif // FLATBUTTON_H


### PR DESCRIPTION
   1.添加FlatButton，支持Flat类型按钮可显示hover样式
   2.列表控件代理背景类型不能被设置为NoBackground类型，否则会丢失hover样式，修改为重写ListWidget的paint事件，在paint事件中定义子项背景色，以保证颜色与主题背景色一致

Log: 修复侧边栏导航项和标题栏按钮缺少hover样式的问题
Bug: https://pms.uniontech.com/bug-view-194199.html