### PR TITLE
chore: 【UI】侧边栏显示顺序调整，从上到下依次为照片库->相册->设备

### DIFF
--- a/src/album/albumview/leftlistview.cpp
+++ b/src/album/albumview/leftlistview.cpp
@@ -239,16 +239,18 @@ void LeftListView::initUI()
     m_pMountListWidget->setSpacing(0);
     m_pMountListWidget->setFrameShape(DListWidget::NoFrame);
 
+    // 侧边栏布局顺序，从上到下，依次为照片库->相册->设备
     pMainLayout->addWidget(photowidget);
     pMainLayout->addWidget(m_pPhotoLibListView);
+
+    lableCustomixeWidget->setLayout(pCustomizeLayout);
+    pMainLayout->addWidget(lableCustomixeWidget);
+    pMainLayout->addWidget(m_pCustomizeListView);
 
     m_pMountWidget->setLayout(pMountLayout);
     pMainLayout->addWidget(m_pMountWidget);
     pMainLayout->addWidget(m_pMountListWidget);
 
-    lableCustomixeWidget->setLayout(pCustomizeLayout);
-    pMainLayout->addWidget(lableCustomixeWidget);
-    pMainLayout->addWidget(m_pCustomizeListView);
     pMainLayout->addStretch();
     onUpdateLeftListview();
 }


### PR DESCRIPTION
  【UI】侧边栏显示顺序调整，从上到下依次为照片库->相册->设备

Log: 【UI】侧边栏显示顺序调整，从上到下依次为照片库->相册->设备
Bug: https://pms.uniontech.com/bug-view-194229.html