### PR TITLE
chore: 【UI】相册标题栏扁平按钮悬浮色调整，保持与侧边栏悬浮色一致

### DIFF
--- a/src/album/widgets/flatbutton.cpp
+++ b/src/album/widgets/flatbutton.cpp
@@ -4,9 +4,26 @@
 
 #include "flatbutton.h"
 
+#include <DPalette>
+#include <DApplicationHelper>
+
+DGUI_USE_NAMESPACE
+
 FlatButton::FlatButton(QWidget *parent) : DPushButton(parent)
 {
     setFlat(true);
+
+    // 修改按钮背景色，以便hover状态颜色与侧边栏悬浮色一致。
+    DPalette pa;
+    pa = DApplicationHelper::instance()->palette(this);
+    QColor clr = QColor(255, 255, 255, 255);
+    pa.setColor(QPalette::Light, clr);
+    pa.setColor(QPalette::Midlight, clr);
+    pa.setColor(QPalette::Dark, clr);
+    pa.setColor(QPalette::Mid, clr);
+    pa.setColor(QPalette::Shadow, clr);
+    this->setPalette(pa);
+
 }
 
 bool FlatButton::event(QEvent *event)


### PR DESCRIPTION
  【UI】相册标题栏扁平按钮悬浮色调整，保持与侧边栏悬浮色一致

Log: 【UI】相册标题栏扁平按钮悬浮色调整，保持与侧边栏悬浮色一致
Bug: https://pms.uniontech.com/bug-view-194199.html