### PR TITLE
fix: 修复低版本相册点击大图-删除按钮无效的问题

### DIFF
--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -539,9 +539,6 @@ void MainWindow::initCentralWidget()
     connect(m_collect, &DIconButton::clicked, this, &MainWindow::onCollectButtonClicked);
 
     //处理看图-删除按钮
-#ifdef DELETE_CONFIRM
-    connect(ImageEngine::instance(), &ImageEngine::sigConfirmDel, this, &MainWindow::onConfirmLibDel, Qt::DirectConnection);
-#endif
     connect(ImageEngine::instance(), &ImageEngine::sigDel, this, &MainWindow::onLibDel, Qt::DirectConnection);
     //获取所有自定义相册
     connect(ImageEngine::instance(), &ImageEngine::sigGetAlbumName, this, &MainWindow::onSendAlbumName);
@@ -1397,9 +1394,11 @@ void MainWindow::updateCollectButton()
     }
 }
 
-void MainWindow::onConfirmLibDel(const QString &path)
+void MainWindow::onLibDel(QString path)
 {
+// image-editor 1.0.30以后高版本，添加删除确认逻辑处理
 #ifdef DELETE_CONFIRM
+    bool bConfirmDelete = false;
     int count = 0;
     QFileInfo infox(path);
     if (infox.isSymLink()) {
@@ -1416,14 +1415,13 @@ void MainWindow::onConfirmLibDel(const QString &path)
     if (dialog->exec() > 0) {
         // 通知看图，删除图片
         ImageEngine::instance()->sigDeleteImage();
-        // 相册，同步数据库
-        onLibDel(path);
+        bConfirmDelete = true;
     }
-#endif
-}
 
-void MainWindow::onLibDel(QString path)
-{
+    if (!bConfirmDelete)
+        return;
+#endif
+
     if (m_imageViewer == nullptr) {
         return;
     }

--- a/src/album/mainwindow.h
+++ b/src/album/mainwindow.h
@@ -177,7 +177,6 @@ public slots:
     void onSigViewImage(const SignalManager::ViewInfo &info, OpenImgAdditionalOperation operation, bool isCustom, const QString &album, int UID);
     void onCollectButtonClicked();
     void updateCollectButton();
-    void onConfirmLibDel(const QString& path);
     void onLibDel(QString path);
     void deleteSaveImage();
     void onNewPathAction(); //响应新自定义路径创建


### PR DESCRIPTION
   相册-大图删除按钮逻辑整理：
    a.老版本，直接删除图片，保持和看图逻辑一致
    b.新版本，弹出删除确认弹窗

   image-editor相关pr:
   https://github.com/linuxdeepin/image-editor/pull/77

Log: 修复低版本相册点击大图-删除按钮无效的问题