### PR TITLE
chore: 相册强依赖image-editor 1.0.29以上版本

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: deepin-album
 Section: utils
 Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
-Build-Depends: debhelper (>= 11), cmake, qtbase5-dev, pkg-config, libexif-dev, libqt5svg5-dev, libqt5x11extras5-dev, qttools5-dev-tools, qttools5-dev, libxcb-util0-dev, libstartup-notification0-dev, libraw-dev, libfreeimage-dev, libqt5opengl5-dev, qtbase5-private-dev, qtmultimedia5-dev, x11proto-xext-dev, libmtdev-dev, libegl1-mesa-dev, libudev-dev, libfontconfig1-dev, libfreetype6-dev, libglib2.0-dev, libxrender-dev, libdtkwidget-dev, libimageeditor-dev  (>= 1.0.22), libdtkwidget5-bin, libdtkcore5-bin, libgio-qt-dev, libudisks2-qt5-dev, deepin-gettext-tools, libtiff-dev
+Build-Depends: debhelper (>= 11), cmake, qtbase5-dev, pkg-config, libexif-dev, libqt5svg5-dev, libqt5x11extras5-dev, qttools5-dev-tools, qttools5-dev, libxcb-util0-dev, libstartup-notification0-dev, libraw-dev, libfreeimage-dev, libqt5opengl5-dev, qtbase5-private-dev, qtmultimedia5-dev, x11proto-xext-dev, libmtdev-dev, libegl1-mesa-dev, libudev-dev, libfontconfig1-dev, libfreetype6-dev, libglib2.0-dev, libxrender-dev, libdtkwidget-dev, libimageeditor-dev  (>= 1.0.29), libdtkwidget5-bin, libdtkcore5-bin, libgio-qt-dev, libudisks2-qt5-dev, deepin-gettext-tools, libtiff-dev
 Standards-Version: 4.1.3
 Homepage: <insert the upstream URL, if relevant>
 
 Package: deepin-album
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libimageeditor (>= 1.0.22)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libimageeditor (>= 1.0.29)
 Description: Album for UOS
   Album is a fashion photo manager for viewing and organizing pictures.
 Recommends: uos-reporter,  deepin-event-log


### PR DESCRIPTION
   因image-editor添加删除确认提示功能，相册需强依赖image-editor 1.0.29以上版本

Log: 相册强依赖image-editor1.0.29以上版本
Bug: https://pms.uniontech.com/bug-view-197551.html