### PR TITLE
fix: AboutDialog's titlebar tearing shadow

### DIFF
--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -109,10 +109,8 @@ TitleBar {
         HelpAction { }
         AboutAction {
             aboutDialog: AboutDialog {
-                maximumWidth: 360
-                maximumHeight: 362
-                minimumWidth: 360
-                minimumHeight: 362
+                width: 360
+                height: 362
                 productName: qsTr("Album")
                 productIcon: "deepin-album"
                 version: qsTr("Version:") + Qt.application.version


### PR DESCRIPTION
  It is a bug for `dtkdeclarative`, but we can avoid it.

Issue: https://github.com/linuxdeepin/developer-center/issues/4222