### PR TITLE
fix: Adapt to compact mode.

### DIFF
--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -2144,10 +2144,10 @@ void MainWindow::wheelEvent(QWheelEvent *event)
 void MainWindow::setTitleBarHideden(bool hide)
 {
     if (hide) {
-        titlebar()->setFixedHeight(0);
+        titlebar()->setVisible(false);
         setTitlebarShadowEnabled(false);
     } else {
-        titlebar()->setFixedHeight(50);
+        titlebar()->setVisible(true);
         setTitlebarShadowEnabled(true);
     }
 }


### PR DESCRIPTION
适配紧凑模式，使用setVisible()替换setFixedHeight(),
避免DTK更新标题栏高度时出现多个标题栏。

Log: Adapt to compact mode.
Influence: CompactMode