### PR TITLE
chore: Update version to 5.10.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-album (5.10.19) unstable; urgency=medium
+
+  * fix: Adapt to compact mode.(Influence: CompactMode)
+  * fix: Adapt comapct mode with click image.(Influence: CompactMode)
+  * fix: Title bar disappear when open without args.(Influence: TitleBar)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Wed, 31 May 2023 13:37:52 +0800
+
 deepin-album (5.10.18) unstable; urgency=medium
 
   * Update version to 5.10.18 community


### PR DESCRIPTION
Update version to 5.10.19
适配紧凑模式，相关PR：
* https://github.com/linuxdeepin/deepin-album/pull/164
* https://github.com/linuxdeepin/deepin-album/pull/165
* https://github.com/linuxdeepin/deepin-album/pull/166

Log: Update version to 5.10.19