### PR TITLE
fix: 修复高分屏图标显示过大的问题

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,7 @@ int main(int argc, char *argv[])
     app->loadTranslator();
     app->setApplicationLicense("GPLV3");
     app->setApplicationVersion(DApplication::buildVersion(VERSION));
+    app->setAttribute(Qt::AA_UseHighDpiPixmaps);
     app->setOrganizationName("deepin");
     app->setApplicationName("deepin-album");
     app->setApplicationDisplayName(QObject::tr("Album"));


### PR DESCRIPTION
   相册应用使用Qt::AA_UseHighDpiPixmaps属性

Log: 修复高分屏图标显示过大的问题
Issue: https://github.com/linuxdeepin/developer-center/issues/4884