### PR TITLE
fix: 相册挂载外设时，启动时间优化

### DIFF
--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -246,7 +246,7 @@ public:
     Q_INVOKABLE QString getDeviceName(const QString &devicePath);
 
     //获取设备的图片
-    Q_INVOKABLE QStringList getDevicePicPaths(const QString &path);
+    Q_INVOKABLE QStringList getDevicePicPaths(const QString &strPath);
 
     //获得device路径
     Q_INVOKABLE QVariantMap getDeviceAlbumInfos(const QString &devicePath, const int &filterType = 0);


### PR DESCRIPTION
  将扫描设备路径流程放置到点击设备时执行，节省相册启动时间

Log: 相册挂载外设时，启动时间优化
Bug: https://pms.uniontech.com/bug-view-185733.html