### PR TITLE
perf: 内存优化

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -88,7 +88,7 @@ Item {
                 Rectangle {
                     anchors.centerIn: parent
                     width: image.width
-                    height: image.width
+                    height: image.height
                     color:"black"
                     radius: 18
                 }

--- a/src/src/imageengine/imagedataservice.cpp
+++ b/src/src/imageengine/imagedataservice.cpp
@@ -35,6 +35,7 @@
 
 const QString SETTINGS_GROUP = "Thumbnail";
 const QString SETTINGS_DISPLAY_MODE = "ThumbnailMode";
+const int THUMBNAIL_MAX_SIZE = 200;
 
 ImageDataService *ImageDataService::s_ImageDataService = nullptr;
 
@@ -388,20 +389,20 @@ QImage ReadThumbnailManager::clipToRect(const QImage &src)
 
     if (!tImg.isNull() && 0 != tImg.height() && 0 != tImg.width() && (tImg.height() / tImg.width()) < 10 && (tImg.width() / tImg.height()) < 10) {
         bool cache_exist = false;
-        if (tImg.height() != 200 && tImg.width() != 200) {
+        if (tImg.height() != THUMBNAIL_MAX_SIZE && tImg.width() != THUMBNAIL_MAX_SIZE) {
             if (tImg.height() >= tImg.width()) {
                 cache_exist = true;
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToWidth(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             } else if (tImg.height() <= tImg.width()) {
                 cache_exist = true;
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToHeight(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             }
         }
         if (!cache_exist) {
             if ((static_cast<float>(tImg.height()) / (static_cast<float>(tImg.width()))) > 3) {
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToWidth(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             } else {
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToHeight(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             }
         }
     }
@@ -433,9 +434,9 @@ QImage ReadThumbnailManager::addPadAndScaled(const QImage &src)
     auto result = src.convertToFormat(QImage::Format_RGBA8888);
 
     if (result.height() > result.width()) {
-        result = result.scaledToHeight(200, Qt::SmoothTransformation);
+        result = result.scaledToHeight(THUMBNAIL_MAX_SIZE, Qt::SmoothTransformation);
     } else {
-        result = result.scaledToWidth(200, Qt::SmoothTransformation);
+        result = result.scaledToWidth(THUMBNAIL_MAX_SIZE, Qt::SmoothTransformation);
     }
 
     return result;

--- a/src/src/thumbnailload.cpp
+++ b/src/src/thumbnailload.cpp
@@ -702,7 +702,7 @@ QImage CollectionPublisher::createYearImage(const QString &year)
     QImage image;
     QString error;
     LibUnionImage_NameSpace::loadStaticImageFromFile(picPath, image, error);
-    image.scaled(outputWidth, outputHeight, Qt::KeepAspectRatioByExpanding);
+    image = image.scaled(outputWidth, outputHeight, Qt::KeepAspectRatioByExpanding);
 
     return image;
 }
@@ -720,7 +720,7 @@ QImage CollectionPublisher::createMonthImage(const QString &year, const QString 
         QImage image;
         QString error;
         LibUnionImage_NameSpace::loadStaticImageFromFile(path, image, error);
-        image.scaled(outputWidth, outputHeight, Qt::KeepAspectRatioByExpanding);
+        image = image.scaled(outputWidth, outputHeight, Qt::KeepAspectRatioByExpanding);
         return image;
     });
 

--- a/src/src/thumbnailload.h
+++ b/src/src/thumbnailload.h
@@ -150,8 +150,8 @@ protected:
 
 private:
     //图片输出尺寸（黄金矩形）
-    static constexpr int outputWidth  = 500;
-    static constexpr int outputHeight = 309;
+    static constexpr int outputWidth  = 1000;
+    static constexpr int outputHeight = 618;
 
     //图片裁剪策略
     QImage createYearImage(const QString &year); //生成年视图


### PR DESCRIPTION
   限制年/月视图Image控件请求的图片最大不超过1000*618，以避免年/视图图片因缓存原始尺寸图片而占用过大内存

Log: 内存优化