### PR TITLE
perf: 相册启动时间优化，并解决部分bug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,8 @@
 
 #include "config.h"
 
+#include <DLog>
+
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QScopedPointer>
@@ -59,6 +61,9 @@ int main(int argc, char *argv[])
     app->setProductIcon(QIcon::fromTheme("deepin-album"));
     //app->setApplicationDescription(QObject::tr("Main", "Album is a fashion manager for viewing and organizing photos and videos."));
     app->setWindowIcon(QIcon::fromTheme("deepin-album"));
+
+    DLogManager::registerConsoleAppender();
+    DLogManager::registerFileAppender();
 
     QQmlApplicationEngine engine;
 

--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -237,8 +237,8 @@ TitleBar {
                     text: qsTr("Y")
                     checked: true
                     onClicked: {
-                        collectionBtnClicked(1)
-                        collectionCombo.setCurrentIndex(0)
+                        collectionBtnClicked(0)
+                        collectionCombo.setCurrentIndex()
                     }
                 }
                 ToolButton {

--- a/src/qml/Control/ListView/ThumbnailListView2.qml
+++ b/src/qml/Control/ListView/ThumbnailListView2.qml
@@ -50,7 +50,7 @@ FocusScope {
 
     //缩略图动态变化
     property real realCellWidth:  {
-        var rowSizeHint = (width - GStatus.thumbnailListRightMargin) / GStatus.cellBaseWidth
+        var rowSizeHint = parseInt((width - GStatus.thumbnailListRightMargin) / GStatus.cellBaseWidth)
         return (width - GStatus.thumbnailListRightMargin) / rowSizeHint
     }
 

--- a/src/qml/MainAlbumView.qml
+++ b/src/qml/MainAlbumView.qml
@@ -140,6 +140,7 @@ Item {
         Component.onCompleted: {
             var oldSliderValue = Number(fileControl.getConfigValue("", "album-zoomratio", 4))
             setSliderWidgetValue(oldSliderValue)
+            GStatus.thumbnailSizeLevel = oldSliderValue
         }
     }
 

--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -27,7 +27,8 @@ Item {
 
     // 筛选类型改变处理事件
     onFilterTypeChanged: {
-        flushAllCollectionView()
+        if (visible)
+            flushAllCollectionView()
     }
 
     // 清空已选内容

--- a/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
@@ -21,10 +21,18 @@ BaseView {
 
     function setIndex(index) {
 
-        currentViewIndex = index
+        if (currentViewIndex === index)
+            return
 
-        if (currentViewIndex === 2)
+        currentViewIndex = index
+        if (currentViewIndex === 0)
+            yearCollection.flushModel()
+        else if (currentViewIndex === 1)
+            monthCollection.flushModel()
+        else if (currentViewIndex === 2) {
+            dayCollection.flushModel()
             flushDayViewStatusText()
+        }
     }
 
     onVisibleChanged: {

--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -31,6 +31,8 @@ Item {
     }
 
     function flushModel() {
+        if (!visible)
+            return
         //0.清理
         theModel.clear()
 

--- a/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
@@ -19,6 +19,8 @@ Item {
     signal yearClicked(string year)
 
     function flushModel() {
+        if (!visible)
+            return
         //0.清理
         theModel.clear()
 

--- a/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
+++ b/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
@@ -34,7 +34,8 @@ BaseView {
 
     // 筛选类型改变处理事件
     onFilterTypeChanged: {
-        flushCustomAlbumView(GStatus.currentCustomAlbumUId)
+        if (visible)
+            flushCustomAlbumView(GStatus.currentCustomAlbumUId)
     }
 
     // 我的收藏和相册视图之间切换，需要重载数据

--- a/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
+++ b/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
@@ -25,9 +25,7 @@ BaseView {
     property alias selectedPaths: theView.selectedPaths
 
     onVisibleChanged: {
-        if (visible) {
-            flushDeviceAlbumView()
-        }
+        flushDeviceAlbumView()
     }
 
     // 筛选类型改变处理事件
@@ -37,12 +35,14 @@ BaseView {
 
     // 设备之间切换，需要重载数据
     onDevicePathChanged: {
-        if (visible)
-            flushDeviceAlbumView()
+        flushDeviceAlbumView()
     }
 
     // 刷新设备视图内容
     function flushDeviceAlbumView() {
+        if (!visible)
+            return
+
         dataModel.devicePath = devicePath
         theView.proxyModel.refresh(filterType)
         GStatus.selectedPaths = theView.selectedUrls

--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -36,7 +36,8 @@ BaseView {
 
     // 筛选类型改变处理事件
     onFilterTypeChanged: {
-        flushHaveImportedView()
+        if (visible)
+            flushHaveImportedView()
     }
 
     // 刷新已导入视图内容

--- a/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
+++ b/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
@@ -21,9 +21,7 @@ BaseView {
     property int totalCount: 0
 
     onVisibleChanged: {
-        if (visible) {
-            flushRecentDelView()
-        }
+        flushRecentDelView()
     }
 
     // 筛选类型改变处理事件
@@ -33,6 +31,9 @@ BaseView {
 
     // 刷新最近删除视图内容
     function flushRecentDelView() {
+        if (!visible)
+            return
+
         theView.proxyModel.refresh(filterType)
         GStatus.selectedPaths = theView.selectedUrls
         getNumLabelText()

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -51,7 +51,6 @@ ApplicationWindow {
         setY(screen.height / 2 - height / 2);
 
         // 合集-所有项视图延迟刷新，解决其加载时会闪烁显示一张缩略图的问题
-        GStatus.currentViewType = Album.Types.ViewCustomAlbum
         GStatus.currentViewType = Album.Types.ViewCollecttion
 
         GStatus.loading = false

--- a/src/src/globalstatus.h
+++ b/src/src/globalstatus.h
@@ -281,11 +281,11 @@ private:
 
     bool m_bRefreshFavoriteIconFlag = false;    // 刷新收藏图标标记，翻转一次，前端图标就刷新一次
     bool m_bRefreshRangeBtnState = false;       // 刷新显示比例图标激活状态标记，翻转一次，前端图标就刷新一次
-    Types::ThumbnailViewType m_currentViewType = Types::ViewCollecttion; // 当前显示的视图类型
+    Types::ThumbnailViewType m_currentViewType = Types::ViewImport; // 当前显示的视图类型
     int m_currentCustomAlbumUId = -1;           // 当前自定义相册所在UId，-1：照片库(非我的收藏) 0:我的收藏 1:截图录屏 2:相机 3:画板 其他:自定义相册
     int m_stackControlCurrent = 0;              // 0:相册界面 1:看图界面 2:幻灯片
     int m_stackControlLastCurrent = -1;         // 记录上一次显示的主界面索引 0:相册界面 1:看图界面 2:幻灯片
-    int m_thumbnailSizeLevel = 0;               // 缩略图缩放等级
+    int m_thumbnailSizeLevel = -1;              // 缩略图缩放等级
     qreal m_cellBaseWidth;                      // 缩略图网格大小
     QString m_statusBarNumText = "";            // 状态栏显示的总数文本内容
     QString m_searchEditText = "";              // 搜索框文本内容

--- a/src/src/imageengine/imagedataservice.cpp
+++ b/src/src/imageengine/imagedataservice.cpp
@@ -35,7 +35,7 @@
 
 const QString SETTINGS_GROUP = "Thumbnail";
 const QString SETTINGS_DISPLAY_MODE = "ThumbnailMode";
-const int THUMBNAIL_MAX_SIZE = 200;
+const int THUMBNAIL_MAX_SIZE = 180;
 
 ImageDataService *ImageDataService::s_ImageDataService = nullptr;
 

--- a/src/src/thumbnailload.cpp
+++ b/src/src/thumbnailload.cpp
@@ -12,6 +12,7 @@
 const QString SETTINGS_GROUP = "Thumbnail";
 const QString SETTINGS_DISPLAY_MODE = "ThumbnailMode";
 const int LINE_SPACE = 2;
+const int THUMBNAIL_MAX_SIZE = 180;
 
 ThumbnailLoad::ThumbnailLoad()
     : QQuickImageProvider(QQuickImageProvider::Image)
@@ -567,20 +568,20 @@ QImage ImagePublisher::clipToRect(const QImage &src)
 
     if (!tImg.isNull() && 0 != tImg.height() && 0 != tImg.width() && (tImg.height() / tImg.width()) < 10 && (tImg.width() / tImg.height()) < 10) {
         bool cache_exist = false;
-        if (tImg.height() != 200 && tImg.width() != 200) {
+        if (tImg.height() != THUMBNAIL_MAX_SIZE && tImg.width() != THUMBNAIL_MAX_SIZE) {
             if (tImg.height() >= tImg.width()) {
                 cache_exist = true;
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToWidth(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             } else if (tImg.height() <= tImg.width()) {
                 cache_exist = true;
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToHeight(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             }
         }
         if (!cache_exist) {
             if ((static_cast<float>(tImg.height()) / (static_cast<float>(tImg.width()))) > 3) {
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToWidth(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             } else {
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToHeight(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             }
         }
     }
@@ -613,9 +614,9 @@ QImage ImagePublisher::addPadAndScaled(const QImage &src)
     auto result = src.convertToFormat(QImage::Format_RGBA8888);
 
     if (result.height() > result.width()) {
-        result = result.scaledToHeight(200, Qt::SmoothTransformation);
+        result = result.scaledToHeight(THUMBNAIL_MAX_SIZE, Qt::SmoothTransformation);
     } else {
-        result = result.scaledToWidth(200, Qt::SmoothTransformation);
+        result = result.scaledToWidth(THUMBNAIL_MAX_SIZE, Qt::SmoothTransformation);
     }
 
     return result;
@@ -985,20 +986,20 @@ QImage AsyncImageResponse::clipToRect(const QImage &src)
 
     if (!tImg.isNull() && 0 != tImg.height() && 0 != tImg.width() && (tImg.height() / tImg.width()) < 10 && (tImg.width() / tImg.height()) < 10) {
         bool cache_exist = false;
-        if (tImg.height() != 200 && tImg.width() != 200) {
+        if (tImg.height() != THUMBNAIL_MAX_SIZE && tImg.width() != THUMBNAIL_MAX_SIZE) {
             if (tImg.height() >= tImg.width()) {
                 cache_exist = true;
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToWidth(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             } else if (tImg.height() <= tImg.width()) {
                 cache_exist = true;
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToHeight(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             }
         }
         if (!cache_exist) {
             if ((static_cast<float>(tImg.height()) / (static_cast<float>(tImg.width()))) > 3) {
-                tImg = tImg.scaledToWidth(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToWidth(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             } else {
-                tImg = tImg.scaledToHeight(200,  Qt::FastTransformation);
+                tImg = tImg.scaledToHeight(THUMBNAIL_MAX_SIZE,  Qt::FastTransformation);
             }
         }
     }
@@ -1031,9 +1032,9 @@ QImage AsyncImageResponse::addPadAndScaled(const QImage &src)
     auto result = src.convertToFormat(QImage::Format_RGBA8888);
 
     if (result.height() > result.width()) {
-        result = result.scaledToHeight(200, Qt::SmoothTransformation);
+        result = result.scaledToHeight(THUMBNAIL_MAX_SIZE, Qt::SmoothTransformation);
     } else {
-        result = result.scaledToWidth(200, Qt::SmoothTransformation);
+        result = result.scaledToWidth(THUMBNAIL_MAX_SIZE, Qt::SmoothTransformation);
     }
 
     return result;

--- a/src/src/thumbnailview/imagedatamodel.cpp
+++ b/src/src/thumbnailview/imagedatamodel.cpp
@@ -74,7 +74,7 @@ QVariant ImageDataModel::data(const QModelIndex &index, int role) const
 
     case Roles::ItemTypeRole: {
         if (info.itemType == ItemTypePic) {
-            return "pciture";
+            return "picture";
         } else if (info.itemType == ItemTypeVideo) {
             return "video";
         } else {


### PR DESCRIPTION
  1.未显示的视图，不加载其内容
  2.解决重启后，缩略图大小显示不对的问题
  3.解决界面宽度调整后，略图列表右侧有较大留白区域的问题
  4.使用Dtk日志接口输出日志信息
  5.修复相册启动时，侧边栏图标严重闪烁的问题(启动时不加载年/月视图)
  6.调整缩略图缓存尺寸为180*180

Log: 相册启动时间优化，并解决部分bug