### PR TITLE
perf: 优化缩略图列表代理控件加载速度

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,6 +93,8 @@ int main(int argc, char *argv[])
 
     engine.rootContext()->setContextProperty("imageDataService", ImageDataService::instance());
 
+    QImageItem::initDamage();
+
     GlobalStatus status;
     engine.rootContext()->setContextProperty("GStatus", &status);
 

--- a/src/qml/Control/ListView/ThumbnailListDelegate.qml
+++ b/src/qml/Control/ListView/ThumbnailListDelegate.qml
@@ -18,24 +18,23 @@ import "../"
 import "../../"
 
 Item {
+    id: main
     //注意：在model里面加进去的变量，这边可以直接进行使用，只是部分位置不好拿到，需要使用变量
     property string m_index
     property string m_url
     property string m_displayFlushHelper
     property var m_favoriteBtn: itemFavoriteBtn
     property string remainDays
-
-    //选中后显示的阴影框
-    Rectangle {
-        id: selectShader
-        anchors.centerIn: parent
-        width: parent.width
-        height: parent.height
-        radius: 10
-        color: "#AAAAAA"
-        visible: theView.ism.indexOf(parent.m_index) !== -1 || GStatus.selectedPaths.indexOf(m_url) !== -1
-        opacity: 0.4
-    }
+    property bool bShowDamageIcon: image.bLoadError
+    property bool bSelected: theView.ism.indexOf(parent.m_index) !== -1 || GStatus.selectedPaths.indexOf(m_url) !== -1
+    property bool bHovered: false //属性：是否hover
+    property bool bFavorited: albumControl.photoHaveFavorited(model.url, GStatus.bRefreshFavoriteIconFlag)
+    property bool bShowRemainDays: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted
+    property bool bShowVideoLabel: fileControl.isVideo(m_url)
+    property Item selectArea: null
+    property Item favoriteBtn: null
+    property Item remainDaysLbl: null
+    property Item videoLabel: null
 
     //缩略图本体
     Image {
@@ -66,8 +65,7 @@ Item {
         anchors.centerIn: parent
 
         // 判断是否加载错误图片状态组件
-        //active: image.status === Image.Error
-        active: image.bLoadError
+        active: bShowDamageIcon
         sourceComponent: ActionButton {
             anchors.centerIn: parent
             ColorSelector.hovered: false
@@ -183,87 +181,265 @@ Item {
         }
     }
 
-    //选中后显示的图标
-    DciIcon {
-        name: "select_active_1"
-        visible: selectShader.visible
-        anchors {
-            top: image.top
-            right: image.right
-            topMargin: 5
-            rightMargin : 5
+    onBSelectedChanged: {
+        if (bSelected) {
+            if (selectArea == null)
+                selectArea = selectedComponent.createObject(main)
+        } else {
+            selectArea.destroy()
+            selectArea = null
+        }
+
+        if (bSelected) {
+            if (favoriteBtn == null) {
+                favoriteBtn = favoriteComponent.createObject(main)
+            }
+        } else {
+            if (favoriteBtn && !bFavorited) {
+                favoriteBtn.destroy()
+                favoriteBtn = null
+            }
         }
     }
 
-    DciIcon {
-        name: "Inner_shadow"
-        visible: selectShader.visible
-        anchors {
-            top: image.top
-            right: image.right
-            topMargin: 5
-            rightMargin : 5
+    onBFavoritedChanged: {
+        if (bFavorited) {
+            if (favoriteBtn == null) {
+                favoriteBtn = favoriteComponent.createObject(main)
+            }
+        } else {
+            if (favoriteBtn && !bHovered && !bSelected) {
+                favoriteBtn.destroy()
+                favoriteBtn = null
+            }
         }
     }
 
-    DciIcon {
-        name: "shadow"
-        visible: selectShader.visible
-        anchors {
-            top: image.top
-            right: image.right
-            topMargin: 5
-            rightMargin : 5
+    onBShowRemainDaysChanged: {
+        if (bShowRemainDays) {
+            if (remainDaysLbl == null) {
+                remainDaysLbl = remainDaysComponent.createObject(main)
+            }
+        } else {
+            remainDaysLbl.destroy()
+            remainDaysLbl = null
         }
     }
 
-    DciIcon {
-        name: "yes"
-        visible: selectShader.visible
-        anchors {
-            top: image.top
-            right: image.right
-            topMargin: 5
-            rightMargin : 5
+    onBShowVideoLabelChanged: {
+        if (bShowVideoLabel) {
+            if (videoLabel == null) {
+                videoLabel = videoTimeComponent.createObject(main)
+            }
+        } else {
+            videoLabel.destroy()
+            videoLabel = null
         }
     }
 
-    //剩余天数标签
-    VideoLabel {
-        id: labelRemainDays
-        visible: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted
-        anchors {
-            bottom: image.bottom
-            left: image.left
-            leftMargin : 5
-            bottomMargin : 5
+    // 选中框组件
+    Component {
+        id: selectedComponent
+        Item {
+            anchors.fill: parent
+
+            // 计算图片区域的位置
+            Rectangle {
+                id: imageArea
+                anchors.centerIn: parent
+                width: parent.width - 14
+                height: parent.height - 14
+                visible: false
+            }
+
+            //选中后显示的阴影框
+            Rectangle {
+                id: selectShader
+                anchors.centerIn: parent
+                width: parent.width
+                height: parent.height
+                radius: 10
+                color: "#AAAAAA"
+                visible: true
+                opacity: 0.4
+            }
+
+            //选中后显示的图标
+            DciIcon {
+                name: "select_active_1"
+                visible: selectShader.visible
+                anchors {
+                    top: imageArea.top
+                    right: imageArea.right
+                    topMargin: 5
+                    rightMargin : 5
+                }
+            }
+
+            DciIcon {
+                name: "Inner_shadow"
+                visible: selectShader.visible
+                anchors {
+                    top: imageArea.top
+                    right: imageArea.right
+                    topMargin: 5
+                    rightMargin : 5
+                }
+            }
+
+            DciIcon {
+                name: "shadow"
+                visible: selectShader.visible
+                anchors {
+                    top: imageArea.top
+                    right: imageArea.right
+                    topMargin: 5
+                    rightMargin : 5
+                }
+            }
+
+            DciIcon {
+                name: "yes"
+                visible: selectShader.visible
+                anchors {
+                    top: imageArea.top
+                    right: imageArea.right
+                    topMargin: 5
+                    rightMargin : 5
+                }
+            }
         }
-        opacity: 0.7
-        displayStr: remainDays > 1 ? (remainDays + qsTr("days")) : (remainDays + qsTr("day"))
-        height: 22
-        width: 44
     }
 
-    //视频时长标签
-    VideoLabel {
-        id: videoLabel
-        visible: fileControl.isVideo(m_url)
-        anchors {
-            bottom: image.bottom
-            right: image.right
-            rightMargin : 5
-            bottomMargin : 5
-        }
-        opacity: 0.7
-        displayStr: fileControl.isVideo(m_url) ? albumControl.getVideoTime(m_url) : "00:00"
-        height: 22
-        width: displayStr.length === 5 ? 44 : 64
+    // 收藏图标组件
+    Component {
+        id: favoriteComponent
+        Item {
+            anchors.fill: parent
 
-        Connections {
-            target: albumControl
-            onSigRefreashVideoTime: {
-                if (url === m_url) {
-                    videoLabel.displayStr = videoTimeStr
+            // 计算图片区域的位置
+            Rectangle {
+                id: imageArea
+                anchors.fill: parent
+                width: parent.width - 14
+                height: parent.height - 14
+                visible: false
+            }
+
+            //收藏图标
+            ActionButton {
+                id: itemFavoriteBtn
+                anchors {
+                    bottom: imageArea.bottom
+                    left: imageArea.left
+                    leftMargin : (imageArea.width - image.paintedWidth) / 2 + 5
+                    bottomMargin : (imageArea.height - image.paintedHeight) / 2 + 5
+                }
+
+                hoverEnabled: false  //设置为false，可以解决鼠标移动到图标附近时，图标闪烁问题
+
+                icon {
+                    name: bFavorited ? "collected" : "collection2"
+                }
+
+                MouseArea {
+                    id:mouseAreaFavoriteBtn
+                    anchors.fill: itemFavoriteBtn
+                    propagateComposedEvents: true
+
+                    onClicked: {
+                        var paths = []
+                        paths.push(m_url)
+
+                        if (bFavorited) {
+                            //取消收藏
+                            albumControl.removeFromAlbum(0, paths)
+                        } else {
+                            //收藏
+                            albumControl.insertIntoAlbum(0, paths)
+                        }
+
+                        GStatus.bRefreshFavoriteIconFlag = !GStatus.bRefreshFavoriteIconFlag
+                        // 若当前视图为我的收藏，需要实时刷新我的收藏列表内容
+                        if (GStatus.currentViewType === Album.Types.ViewFavorite && GStatus.currentCustomAlbumUId === 0) {
+                            GStatus.sigFlushCustomAlbumView(GStatus.currentCustomAlbumUId)
+                        }
+
+                        mouse.accepted = true
+                    }
+                }
+            }
+        }
+    }
+
+    //剩余天数标签组件
+    Component {
+        id: remainDaysComponent
+        Item {
+            anchors.fill: parent
+
+            // 计算图片区域的位置
+            Rectangle {
+                id: imageArea
+                anchors.centerIn: parent
+                width: parent.width - 14
+                height: parent.height - 14
+                visible: false
+            }
+
+            VideoLabel {
+                id: labelRemainDays
+                visible: true
+                anchors {
+                    bottom: imageArea.bottom
+                    left: imageArea.left
+                    leftMargin : 5
+                    bottomMargin : 5
+                }
+                opacity: 0.7
+                displayStr: remainDays > 1 ? (remainDays + qsTr("days")) : (remainDays + qsTr("day"))
+                height: 22
+                width: 44
+            }
+        }
+    }
+
+    // 视频时长组件
+    Component {
+        id: videoTimeComponent
+        Item {
+            anchors.fill: parent
+
+            // 计算图片区域的位置
+            Rectangle {
+                id: imageArea
+                anchors.centerIn: parent
+                width: parent.width - 14
+                height: parent.height - 14
+                visible: false
+            }
+
+            VideoLabel {
+                id: videoLabel
+                visible: bShowVideoLabel
+                anchors {
+                    bottom: imageArea.bottom
+                    right: imageArea.right
+                    rightMargin : 5
+                    bottomMargin : 5
+                }
+                opacity: 0.7
+                displayStr: fileControl.isVideo(m_url) ? albumControl.getVideoTime(m_url) : "00:00"
+                height: 22
+                width: displayStr.length === 5 ? 44 : 64
+
+                Connections {
+                    target: albumControl
+                    onSigRefreashVideoTime: {
+                        if (url === m_url) {
+                            videoLabel.displayStr = videoTimeStr
+                        }
+                    }
                 }
             }
         }

--- a/src/qml/Control/ListView/ThumbnailListDelegate2.qml
+++ b/src/qml/Control/ListView/ThumbnailListDelegate2.qml
@@ -19,6 +19,7 @@ import "../../"
 import "./"
 
 Item {
+    id: main
     //注意：在model里面加进去的变量，这边可以直接进行使用，只是部分位置不好拿到，需要使用变量
     property string m_index
     property string m_displayFlushHelper
@@ -26,50 +27,20 @@ Item {
 
     property int index: model.index
     property bool blank: model.blank
+    property bool bShowDamageIcon: image.null
     property bool bSelected: model.selected !== undefined ? model.selected : false
     property bool bHovered: false //属性：是否hover
     property bool bFavorited: albumControl.photoHaveFavorited(model.url, GStatus.bRefreshFavoriteIconFlag)
-    property Item imageItem: image
+    property bool bShowRemainDays: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted && !model.blank
+    property bool bShowVideoLabel: fileControl.isVideo(model.url) && !model.blank
+    property Item imageItem: null
+    property Item damageIcon: null
+    property Item selectArea: null
     property Item favoriteBtn: null
+    property Item remainDaysLbl: null
+    property Item videoLabel: null
 
-    onBSelectedChanged: {
-        if (bSelected && model.modelType !== Album.Types.Device) {
-            if (favoriteBtn == null) {
-                favoriteBtn = favoriteComponent.createObject(buttons)
-            }
-        } else {
-            if (favoriteBtn && !bFavorited) {
-                favoriteBtn.destroy()
-                favoriteBtn = null
-            }
-        }
-    }
-
-    onBFavoritedChanged: {
-        if (bFavorited) {
-            if (favoriteBtn == null) {
-                favoriteBtn = favoriteComponent.createObject(buttons)
-            }
-        } else {
-            if (favoriteBtn && !bHovered && !bSelected) {
-                favoriteBtn.destroy()
-                favoriteBtn = null
-            }
-        }
-    }
-
-    //选中后显示的阴影框
-    Rectangle {
-        id: selectShader
-        anchors.centerIn: parent
-        width: parent.width
-        height: parent.height
-        radius: 10
-        color: "#AAAAAA"
-        visible: bSelected
-        opacity: 0.4
-    }
-
+    // 缩略图本体
     Album.QImageItem {
         id: image
         anchors.centerIn: parent
@@ -82,22 +53,6 @@ Item {
         }
         fillMode: Album.QImageItem.PreserveAspectFit
         visible: false
-    }
-
-    Loader {
-        id: damageIconLoader
-        anchors.centerIn: parent
-
-        active: image.null
-        sourceComponent: ActionButton {
-            anchors.centerIn: parent
-            ColorSelector.hovered: false
-            icon {
-                name: "photo_breach"
-                width: image.width
-                height: image.height
-            }
-        }
     }
 
     // 图片保存完成，缩略图区域重新加载当前图片
@@ -157,6 +112,7 @@ Item {
         visible: true
     }
 
+
     MouseArea {
         id:mouseAreaTopParentRect
         anchors.fill: parent
@@ -173,8 +129,8 @@ Item {
                 return;
 
             bHovered = true
-            if (favoriteBtn == null && model.modelType !== Album.Types.Device)
-                favoriteBtn = favoriteComponent.createObject(buttons)
+            if (favoriteBtn == null && model.modelType !== Album.Types.Device && model.modelType !== Album.Types.RecentlyDeleted)
+                favoriteBtn = favoriteComponent.createObject(main)
         }
 
         onExited: {
@@ -186,141 +142,266 @@ Item {
         }
     }
 
+    onBSelectedChanged: {
+        if (bSelected) {
+            if (selectArea == null)
+                selectArea = selectedComponent.createObject(main)
+        } else {
+            selectArea.destroy()
+            selectArea = null
+        }
+
+        if (bSelected && model.modelType !== Album.Types.Device && model.modelType !== Album.Types.RecentlyDeleted) {
+            if (favoriteBtn == null) {
+                favoriteBtn = favoriteComponent.createObject(main)
+            }
+        } else {
+            if (favoriteBtn && !bFavorited) {
+                favoriteBtn.destroy()
+                favoriteBtn = null
+            }
+        }
+    }
+
+    onBFavoritedChanged: {
+        if (bFavorited) {
+            if (favoriteBtn == null) {
+                favoriteBtn = favoriteComponent.createObject(main)
+            }
+        } else {
+            if (favoriteBtn && !bHovered && !bSelected) {
+                favoriteBtn.destroy()
+                favoriteBtn = null
+            }
+        }
+    }
+
+    onBShowRemainDaysChanged: {
+        if (bShowRemainDays) {
+            if (remainDaysLbl == null) {
+                remainDaysLbl = remainDaysComponent.createObject(main)
+            }
+        } else {
+            remainDaysLbl.destroy()
+            remainDaysLbl = null
+        }
+    }
+
+    onBShowVideoLabelChanged: {
+        if (bShowVideoLabel) {
+            if (videoLabel == null) {
+                videoLabel = videoTimeComponent.createObject(main)
+            }
+        } else {
+            videoLabel.destroy()
+            videoLabel = null
+        }
+    }
+
+    // 选中框组件
+    Component {
+        id: selectedComponent
+        Item {
+            anchors.fill: parent
+
+            // 计算图片区域的位置
+            Rectangle {
+                id: imageArea
+                anchors.centerIn: parent
+                width: parent.width - 14
+                height: parent.height - 14
+                visible: false
+            }
+
+            //选中后显示的阴影框
+            Rectangle {
+                id: selectShader
+                anchors.centerIn: parent
+                width: parent.width
+                height: parent.height
+                radius: 10
+                color: "#AAAAAA"
+                visible: true
+                opacity: 0.4
+            }
+
+            //选中后显示的图标
+            DciIcon {
+                name: "select_active_1"
+                visible: selectShader.visible
+                anchors {
+                    top: imageArea.top
+                    right: imageArea.right
+                    topMargin: 5
+                    rightMargin : 5
+                }
+            }
+
+            DciIcon {
+                name: "Inner_shadow"
+                visible: selectShader.visible
+                anchors {
+                    top: imageArea.top
+                    right: imageArea.right
+                    topMargin: 5
+                    rightMargin : 5
+                }
+            }
+
+            DciIcon {
+                name: "shadow"
+                visible: selectShader.visible
+                anchors {
+                    top: imageArea.top
+                    right: imageArea.right
+                    topMargin: 5
+                    rightMargin : 5
+                }
+            }
+
+            DciIcon {
+                name: "yes"
+                visible: selectShader.visible
+                anchors {
+                    top: imageArea.top
+                    right: imageArea.right
+                    topMargin: 5
+                    rightMargin : 5
+                }
+            }
+        }
+    }
+
+    // 收藏图标组件
     Component {
         id: favoriteComponent
-        //收藏图标
-        ActionButton {
-            id: itemFavoriteBtn
-            hoverEnabled: false  //设置为false，可以解决鼠标移动到图标附近时，图标闪烁问题
+        Item {
+            anchors.fill: parent
 
-            icon {
-                name: bFavorited ? "collected" : "collection2"
+            // 计算图片区域的位置
+            Rectangle {
+                id: imageArea
+                anchors.fill: parent
+                width: parent.width - 14
+                height: parent.height - 14
+                visible: false
             }
 
-            MouseArea {
-                id:mouseAreaFavoriteBtn
-                anchors.fill: itemFavoriteBtn
-                propagateComposedEvents: true
-
-                onClicked: {
-                    var paths = []
-                    paths.push(modelData.url)
-
-                    if (bFavorited) {
-                        //取消收藏
-                        albumControl.removeFromAlbum(0, paths)
-                    } else {
-                        //收藏
-                        albumControl.insertIntoAlbum(0, paths)
-                    }
-
-                    GStatus.bRefreshFavoriteIconFlag = !GStatus.bRefreshFavoriteIconFlag
-                    // 若当前视图为我的收藏，需要实时刷新我的收藏列表内容
-                    if (GStatus.currentViewType === Album.Types.ViewFavorite && GStatus.currentCustomAlbumUId === 0) {
-                        GStatus.sigFlushCustomAlbumView(GStatus.currentCustomAlbumUId)
-                    }
-
-                    mouse.accepted = true
+            //收藏图标
+            ActionButton {
+                id: itemFavoriteBtn
+                anchors {
+                    bottom: imageArea.bottom
+                    left: imageArea.left
+                    leftMargin : (imageArea.width - image.paintedWidth) / 2 + 5
+                    bottomMargin : (imageArea.height - image.paintedHeight) / 2 + 5
                 }
 
+                hoverEnabled: false  //设置为false，可以解决鼠标移动到图标附近时，图标闪烁问题
+
+                icon {
+                    name: bFavorited ? "collected" : "collection2"
+                }
+
+                MouseArea {
+                    id:mouseAreaFavoriteBtn
+                    anchors.fill: itemFavoriteBtn
+                    propagateComposedEvents: true
+
+                    onClicked: {
+                        var paths = []
+                        paths.push(modelData.url)
+
+                        if (bFavorited) {
+                            //取消收藏
+                            albumControl.removeFromAlbum(0, paths)
+                        } else {
+                            //收藏
+                            albumControl.insertIntoAlbum(0, paths)
+                        }
+
+                        GStatus.bRefreshFavoriteIconFlag = !GStatus.bRefreshFavoriteIconFlag
+                        // 若当前视图为我的收藏，需要实时刷新我的收藏列表内容
+                        if (GStatus.currentViewType === Album.Types.ViewFavorite && GStatus.currentCustomAlbumUId === 0) {
+                            GStatus.sigFlushCustomAlbumView(GStatus.currentCustomAlbumUId)
+                        }
+
+                        mouse.accepted = true
+                    }
+
+                }
             }
         }
     }
 
-    Column {
-        id: buttons
+    //剩余天数标签组件
+    Component {
+        id: remainDaysComponent
+        Item {
+            anchors.fill: parent
 
-        visible: true
+            // 计算图片区域的位置
+            Rectangle {
+                id: imageArea
+                anchors.centerIn: parent
+                width: parent.width - 14
+                height: parent.height - 14
+                visible: false
+            }
 
-        anchors {
-            bottom: image.bottom
-            left: image.left
-            leftMargin : (image.width - image.paintedWidth) / 2 + 5
-            bottomMargin : (image.height - image.paintedHeight) / 2 + 5
+            VideoLabel {
+                id: labelRemainDays
+                visible: true
+                anchors {
+                    bottom: imageArea.bottom
+                    left: imageArea.left
+                    leftMargin : 5
+                    bottomMargin : 5
+                }
+                opacity: 0.7
+                displayStr: model.remainDays > 1 ? (model.remainDays + qsTr("days")) : (model.remainDays + qsTr("day"))
+                height: 22
+                width: 44
+            }
         }
     }
 
-    //选中后显示的图标
-    DciIcon {
-        name: "select_active_1"
-        visible: selectShader.visible
-        anchors {
-            top: image.top
-            right: image.right
-            topMargin: 5
-            rightMargin : 5
-        }
-    }
+    // 视频时长组件
+    Component {
+        id: videoTimeComponent
+        Item {
+            anchors.fill: parent
 
-    DciIcon {
-        name: "Inner_shadow"
-        visible: selectShader.visible
-        anchors {
-            top: image.top
-            right: image.right
-            topMargin: 5
-            rightMargin : 5
-        }
-    }
+            // 计算图片区域的位置
+            Rectangle {
+                id: imageArea
+                anchors.centerIn: parent
+                width: parent.width - 14
+                height: parent.height - 14
+                visible: false
+            }
 
-    DciIcon {
-        name: "shadow"
-        visible: selectShader.visible
-        anchors {
-            top: image.top
-            right: image.right
-            topMargin: 5
-            rightMargin : 5
-        }
-    }
+            VideoLabel {
+                id: videoLabel
+                visible: bShowVideoLabel
+                anchors {
+                    bottom: imageArea.bottom
+                    right: imageArea.right
+                    rightMargin : 5
+                    bottomMargin : 5
+                }
+                opacity: 0.7
+                displayStr: fileControl.isVideo(model.url) ? albumControl.getVideoTime(model.url) : "00:00"
+                height: 22
+                width: displayStr.length === 5 ? 44 : 64
 
-    DciIcon {
-        name: "yes"
-        visible: selectShader.visible
-        anchors {
-            top: image.top
-            right: image.right
-            topMargin: 5
-            rightMargin : 5
-        }
-    }
-
-    //剩余天数标签
-    VideoLabel {
-        id: labelRemainDays
-        visible: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted && !model.blank
-        anchors {
-            bottom: image.bottom
-            left: image.left
-            leftMargin : 5
-            bottomMargin : 5
-        }
-        opacity: 0.7
-        displayStr: model.remainDays > 1 ? (model.remainDays + qsTr("days")) : (model.remainDays + qsTr("day"))
-        height: 22
-        width: 44
-    }
-
-    //视频时长标签
-    VideoLabel {
-        id: videoLabel
-        visible: fileControl.isVideo(model.url) && !model.blank
-        anchors {
-            bottom: image.bottom
-            right: image.right
-            rightMargin : 5
-            bottomMargin : 5
-        }
-        opacity: 0.7
-        displayStr: fileControl.isVideo(model.url) ? albumControl.getVideoTime(model.url) : "00:00"
-        height: 22
-        width: displayStr.length === 5 ? 44 : 64
-
-        Connections {
-            target: albumControl
-            onSigRefreashVideoTime: {
-                if (url === model.url) {
-                    videoLabel.displayStr = videoTimeStr
+                Connections {
+                    target: albumControl
+                    onSigRefreashVideoTime: {
+                        if (url === model.url) {
+                            videoLabel.displayStr = videoTimeStr
+                        }
+                    }
                 }
             }
         }

--- a/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
@@ -603,7 +603,6 @@ Item {
     }
 
     Component.onCompleted: {
-        flushModel()
         GStatus.sigFlushAllCollectionView.connect(flushModel)
     }
 }

--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -185,7 +185,6 @@ Item {
     }
 
     Component.onCompleted: {
-        flushModel()
         GStatus.sigFlushAllCollectionView.connect(flushModel)
     }
 }

--- a/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
@@ -159,7 +159,6 @@ Item {
     }
 
     Component.onCompleted: {
-        flushModel()
         GStatus.sigFlushAllCollectionView.connect(flushModel)
     }
 }

--- a/src/src/thumbnailview/qimageitem.h
+++ b/src/src/thumbnailview/qimageitem.h
@@ -39,6 +39,7 @@ public:
     explicit QImageItem(QQuickItem *parent = nullptr);
     ~QImageItem() override;
 
+    static void initDamage();
     void setImage(const QImage &image);
     QImage image() const;
     void resetImage();
@@ -75,6 +76,8 @@ protected:
     void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
 #endif
 
+private:
+    static QImage s_damage;
 private:
     QImage m_image;
     bool m_smooth;


### PR DESCRIPTION
  1.使用Component动态加载选中框、剩余天数、视频时长等控件
  2.QImageItem为空时，默认显示撕裂图，节省C++/model类型的缩略图列表创建撕裂图的时间开销（约500ms）
  3.Dci图标撕裂图显示异常问题解决，并实现在C++中加载撕裂图

Log: 优化缩略图列表代理控件加载速度