### PR TITLE
fix: 修复导入链接图片后，相册二次启动失败的问题

### DIFF
--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -62,7 +62,7 @@ public:
     Q_INVOKABLE QVariantList getAlbumAllInfos(const int &filterType = 0);
 
     //导入图片，导入图片接口
-    Q_INVOKABLE bool importAllImagesAndVideos(const QStringList &paths, const int UID = -1);
+    Q_INVOKABLE bool importAllImagesAndVideos(const QStringList &paths, const int UID = -1, const bool notifyUI = true);
 
     //导入图片，导入图片接口urls
     Q_INVOKABLE bool importAllImagesAndVideosUrl(const QList <QUrl> &paths, const int UID, bool checkRepeat = true);

--- a/src/src/imageengine/imageenginethread.cpp
+++ b/src/src/imageengine/imageenginethread.cpp
@@ -73,6 +73,11 @@ void ImportImagesThread::setData(const QList<QUrl> &paths, const int UID, const 
     m_type = DataType_Url;
 }
 
+void ImportImagesThread::setNotifyUI(bool bValue)
+{
+    m_notifyUI = bValue;
+}
+
 bool ImportImagesThread::ifCanStopThread(void *imgobject)
 {
     Q_UNUSED(imgobject);
@@ -184,6 +189,7 @@ void ImportImagesThread::runDetail()
 
     QThread::msleep(100);
     //发送导入完成信号
-    emit sigImportFinished();
+    if (m_notifyUI)
+        emit sigImportFinished();
 }
 

--- a/src/src/imageengine/imageenginethread.h
+++ b/src/src/imageengine/imageenginethread.h
@@ -49,6 +49,7 @@ public:
     ~ImportImagesThread() override;
     void setData(const QStringList &paths, const int UID);
     void setData(const QList<QUrl> &paths, const int UID, const bool checkRepeat);
+    void setNotifyUI(bool bValue);
 
 protected:
     bool ifCanStopThread(void *imgobject) override;
@@ -76,6 +77,7 @@ private:
     QStringList m_filePaths;//所有的本地文件路径
     int m_UID = -1;
     DataType m_type = DataType_NULL;
+    bool m_notifyUI = true;
     bool m_checkRepeat = true;
 };
 


### PR DESCRIPTION
  1.优化单例类AlbumControl构建流程，其构造函数的调用链中不能迭代调用AlbumControl::instance()
  2.优化链接图片处理流程

Log: 修复导入链接图片后，相册二次启动失败的问题
Bug: https://pms.uniontech.com/bug-view-218077.html