### PR TITLE
fix: Solve the problem of image classification search results not being able to play slides

### DIFF
--- a/src/album/searchview/searchview.cpp
+++ b/src/album/searchview/searchview.cpp
@@ -248,6 +248,8 @@ void SearchView::onSlideShowBtnClicked()
             || COMMON_STR_TIMELINE == m_albumName
             || COMMON_STR_RECENT_IMPORTED == m_albumName) {
         imagelist = DBManager::instance()->getInfosForKeyword(m_keywords);
+    } else if (COMMON_STR_CLASSDETAIL == m_albumName) {
+        imagelist = DBManager::instance()->getInfosForClassAndKeyword(m_className, m_keywords);
     } else if (COMMON_STR_TRASH == m_albumName) {
         imagelist = DBManager::instance()->getTrashInfosForKeyword(m_keywords);
     } else {


### PR DESCRIPTION
   Solve the problem of image classification search results not being able to play slides

Log: Solve the problem of image classification search results not being able to play slides
Bug: https://pms.uniontech.com/bug-view-232541.html