### PR TITLE
fix: Hide search box on photo classification cover page

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -1041,6 +1041,7 @@ void AlbumView::updateRightView()
     } else if (COMMON_STR_CLASS == m_currentType) {
         m_bHasClassified = false;
         updateRightClassView();
+        emit sigSearchEditIsDisplay(false);
     } else if (COMMON_STR_CLASSDETAIL == m_currentType) {
         if (!m_currentClassName.isEmpty())
             updateRightClassViewDetail(m_currentClassName);

--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -2197,7 +2197,9 @@ void MainWindow::onButtonClicked(int id)
         }
         albumBtnClicked();
         // 如果是最近删除或者移动设备,则搜索框不显示
-        if (2 == m_pAlbumview->m_pRightStackWidget->currentIndex() || 6 == m_pAlbumview->m_pRightStackWidget->currentIndex()) {
+        if (2 == m_pAlbumview->m_pRightStackWidget->currentIndex()
+                || 6 == m_pAlbumview->m_pRightStackWidget->currentIndex()
+                || (3 == m_pAlbumview->m_pRightStackWidget->currentIndex() && m_pAlbumview->m_currentType == COMMON_STR_CLASS)) {
             m_pSearchEdit->setVisible(false);
         } else {
 #ifdef tablet_PC


### PR DESCRIPTION
  Hide search box on photo classification cover page

Log: Hide search box on photo classification cover page
Bug: https://pms.uniontech.com/bug-view-232637.html