### PR TITLE
fix: Resolve the issue of invalid delete key on photo classification detail page

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -1577,10 +1577,10 @@ void AlbumView::onKeyDelete()
                 ImageEngineApi::instance()->moveImagesToTrash(paths, true);
             }
         }
-    } else if (COMMON_STR_CLASS == m_currentType) {
-        paths = m_classThumbnailList->selectedPaths();
+    } else if (COMMON_STR_CLASSDETAIL == m_currentType) {
+        paths = m_classDetailThumbnailList->selectedPaths();
         if (!paths.isEmpty()) {
-            m_classThumbnailList->clearSelection();
+            m_classDetailThumbnailList->clearSelection();
             bMoveToTrash = true;
         }
     } else if (COMMON_STR_FAVORITES == m_currentType) {


### PR DESCRIPTION
   Resolve the issue of invalid delete key on photo classification detail page

Log: Resolve the issue of invalid delete key on photo classification detail page
Bug: https://pms.uniontech.com/bug-view-232631.html