### PR TITLE
fix: Resolve the issue of entering slide mode after viewing images and exiting without a title bar

### DIFF
--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -2375,9 +2375,7 @@ void MainWindow::onAddImageBtnClicked(bool checked)
 
 void MainWindow::onHideFromFullScreen()
 {
-    if (VIEW_IMAGE != m_backIndex_fromFullScreen) {
-        setTitleBarHideden(false);
-    }
+    setTitleBarHideden(false);
 
     m_pCenterWidget->setCurrentIndex(m_backIndex);
 }


### PR DESCRIPTION
  Resolve the issue of entering slide mode after viewing images and exiting without a title bar

Log: Resolve the issue of entering slide mode after viewing images and exiting without a title bar
Bug: https://pms.uniontech.com/bug-view-232641.html