### PR TITLE
fix: Resolve the issue of being able to close alt+F4 when importing progress bars

### DIFF
--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -66,6 +66,19 @@ const int ALBUMBTN_NORMAL_WIDTH = 90;
 
 }//namespace
 
+void DDialogEx::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Escape)
+        return;
+
+    DDialog::keyPressEvent(event);
+}
+
+void DDialogEx::closeEvent(QCloseEvent *event)
+{
+    event->ignore();
+}
+
 using namespace utils::common;
 MainWindow::MainWindow()
     : m_iCurrentView(VIEW_ALLPIC)
@@ -269,10 +282,9 @@ void MainWindow::initUI()
 //初始化等待窗口
 void MainWindow::initWaitDialog()
 {
-    m_waitdailog = new DDialog(this);
-
-    m_waitdailog->setCloseButtonVisible(false);
-    m_waitdailog->setWindowModality(Qt::WindowModal);
+    m_waitdailog = new DDialogEx(this);
+    m_waitdailog->setWindowFlag(Qt::WindowCloseButtonHint, false);
+    m_waitdailog->setModal(true);
     m_waitdailog->setFixedSize(QSize(480, 93));
 
     m_waitlabel = new DLabel(m_waitdailog);
@@ -2283,7 +2295,7 @@ void MainWindow::onCloseWaitDialog()
 {
     m_progressType = Progress_Unknown;
     m_countLabel->setText("");
-    m_waitdailog->close();
+    m_waitdailog->hide();
 }
 
 void MainWindow::onImagesRemoved()

--- a/src/album/mainwindow.h
+++ b/src/album/mainwindow.h
@@ -47,6 +47,19 @@ extern bool bfirstandviewimage;
 
 class QShortcut;
 
+class DDialogEx : public DDialog
+{
+    Q_OBJECT
+
+public:
+    explicit DDialogEx(QWidget *parent = nullptr): DDialog (parent) {};
+    ~DDialogEx() {};
+
+protected:
+    void keyPressEvent(QKeyEvent *event) override;
+    void closeEvent(QCloseEvent *event) override;
+};
+
 class MainWindow : public DMainWindow, public ImageEngineImportObject
 {
     Q_OBJECT
@@ -236,7 +249,7 @@ private:
     FlatButton *m_pTimeBtn = nullptr;
     FlatButton *m_pAlbumBtn = nullptr;
 
-    DDialog  *m_waitdailog = nullptr;
+    DDialogEx  *m_waitdailog = nullptr;
     DProgressBar *m_importBar = nullptr;
     DLabel *m_waitlabel = nullptr;
     DLabel *m_countLabel = nullptr;


### PR DESCRIPTION
   Resolve the issue of being able to close alt+F4 when importing progress bars

Log: Resolve the issue of being able to close alt+F4 when importing progress bars
Bug: https://pms.uniontech.com/bug-view-232643.html