### PR TITLE
fix: Cached greeter background image too large

### DIFF
--- a/src/album/controller/wallpapersetter.cpp
+++ b/src/album/controller/wallpapersetter.cpp
@@ -56,7 +56,8 @@ bool WallpaperSetter::setBackground(const QString &pictureFilePath)
         return false;
     }
 
-    if (!tImg.save(tempWallPaperpath, "PNG", 100)) {
+    // 后端壁纸设置接口不接收超过32MB的图片：调整压缩格式从PNG到JPG，以降低缓存文件占用
+    if (!tImg.save(tempWallPaperpath, "JPG", 100)) {
         return false;
     }
     if (!tempInfo.exists()) {


### PR DESCRIPTION
设置锁屏背景的图片过大,后端DBus可能返回文件过大错误,
调整压缩格式PNG为JPG,同时过大的PNG/JPG图片也会被压缩.

Log: 修复设置大图片为壁纸无反应的问题
Bug: https://pms.uniontech.com/bug-view-247311.html
Influence: SetWallpaper