### PR TITLE
fix: Filter image format not support wallpaper 

### DIFF
--- a/src/album/controller/wallpapersetter.cpp
+++ b/src/album/controller/wallpapersetter.cpp
@@ -45,7 +45,7 @@ bool WallpaperSetter::setBackground(const QString &pictureFilePath)
     QString errMsg;
     QFileInfo info(pictureFilePath);
     QString tempWallPaperpath;
-    tempWallPaperpath = WALLPAPER_PATH + info.baseName() + ".png";
+    tempWallPaperpath = WALLPAPER_PATH + info.baseName() + ".jpg";
     QFileInfo tempInfo(tempWallPaperpath);
     if (!UnionImage_NameSpace::loadStaticImageFromFile(pictureFilePath, tImg, errMsg)) {
         return false;
@@ -57,7 +57,7 @@ bool WallpaperSetter::setBackground(const QString &pictureFilePath)
     }
 
     // 后端壁纸设置接口不接收超过32MB的图片：调整压缩格式从PNG到JPG，以降低缓存文件占用
-    if (!tImg.save(tempWallPaperpath, "JPG", 100)) {
+    if (!tImg.save(tempWallPaperpath, "JPG")) {
         return false;
     }
     if (!tempInfo.exists()) {

--- a/src/album/thumbnail/thumbnaillistview.cpp
+++ b/src/album/thumbnail/thumbnaillistview.cpp
@@ -859,7 +859,7 @@ void ThumbnailListView::updateMenuContents()
 
     if ((1 == paths.length() || QFileInfo(paths[0]).suffix().contains("gif"))) {
         DBImgInfo data = selectedIndexes().at(0).data(Qt::DisplayRole).value<DBImgInfo>();
-        if (data.itemType == ItemTypePic && QFileInfo(paths[0]).isReadable()) {
+        if (data.itemType == ItemTypePic && QFileInfo(paths[0]).isReadable() && utils::base::isSupportWallpaper(paths[0])) {
             m_MenuActionMap.value(tr("Set as wallpaper"))->setVisible(true);
         } else {
             m_MenuActionMap.value(tr("Set as wallpaper"))->setVisible(false);

--- a/src/album/utils/baseutils.cpp
+++ b/src/album/utils/baseutils.cpp
@@ -672,6 +672,20 @@ bool isSupportClassify(const QString &path)
     return bRet;
 }
 
+/**
+   @return 图片 \a path 是否支持设置为壁纸，同步看图代码
+ */
+bool isSupportWallpaper(const QString &path)
+{
+    QMimeDatabase db;
+    QMimeType mt = db.mimeTypeForFile(path, QMimeDatabase::MatchDefault);
+    return mt.name().startsWith("image")
+           && !mt.name().endsWith("svg+xml")
+           && !mt.name().endsWith("raf")
+           && !mt.name().endsWith("crw")
+           && !mt.name().endsWith("x-portable-anymap");
+}
+
 }  // namespace base
 
 }  // namespace utils

--- a/src/album/utils/baseutils.h
+++ b/src/album/utils/baseutils.h
@@ -269,6 +269,8 @@ QImage cheatScaled(const QImage &srcImg, int size, int side);
 QImage getThumbnailFromImage(const QImage &srcImg, int size);
 //判断图片路径是否支持图片分类
 bool isSupportClassify(const QString &path);
+//判断图片是否支持设置壁纸
+bool isSupportWallpaper(const QString &path);
 }  // namespace base
 
 }  // namespace utils


### PR DESCRIPTION
缓存图片后缀和格式保持相同, 提高压缩率
部分图片格式不支持，新增格式判断函数和看图一致

Log: 过滤不支持设置为壁纸的图片格式
Bug: https://pms.uniontech.com/bug-view-247311.html
Influence: SetWallpaper