### PR TITLE
chore: Bump version to 5.10.23

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-album (5.10.23) unstable; urgency=medium
+
+  * feat: Set greeter background when setting wallpaper(Bug: 32367)(Influence: SetWallpaper)
+  * fix: Cached greeter background image too large(Bug: 247311)(Influence: SetWallpaper)
+  * fix: Filter image format not support wallpaper(Bug: 247311)(Influence: SetWallpaper)
+
+ -- renbin <renbin@uniontech.com>  Wed, 27 Mar 2024 15:33:48 +0800
+
 deepin-album (5.10.22) unstable; urgency=medium
 
   * fix: Improve the function of batch exporting images(Bug: 237179)


### PR DESCRIPTION
Bump version to 5.10.23
PR:
* https://github.com/linuxdeepin/deepin-album/pull/205
* https://github.com/linuxdeepin/deepin-album/pull/206
* https://github.com/linuxdeepin/deepin-album/pull/207

Bump version to 5.10.23