### PR TITLE
fix: Resolve the issue of not hiding image operation buttons after deleting all images

### DIFF
--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -29,8 +29,8 @@ TitleBar {
     background: Rectangle {
         anchors.left: parent.left
         anchors.top: parent.top
-        anchors.leftMargin: GStatus.sideBarIsVisible ? 200 : 0
-        width: parent.width - (GStatus.sideBarIsVisible ? 200 : 0)
+        anchors.leftMargin: title.width > GStatus.needHideSideBarWidth ? 200 : 0
+        width: parent.width - (title.width > GStatus.needHideSideBarWidth ? 200 : 0)
         height: parent.height
 
         color: DTK.themeType === ApplicationHelper.LightType ? "#FDFDFD"
@@ -206,7 +206,7 @@ TitleBar {
         // 比例+年月日按钮组/下拉框
         RowLayout {
             spacing: 5
-
+            Layout.alignment: Qt.AlignLeft
             // 比例按钮
             ToolButton {
                 id: range1Button
@@ -415,7 +415,7 @@ TitleBar {
         RowLayout {
             spacing: iconSpacing
             Layout.alignment: Qt.AlignRight
-            Layout.minimumWidth: iconSize * 3 + iconSpacing * (3 - 1)
+            //Layout.minimumWidth: iconSize * 3 + iconSpacing * (3 - 1)
             ToolButton {
                 visible: GStatus.selectedPaths.length === 0 || GStatus.currentViewType === Album.Types.ViewDevice || GStatus.currentViewType === Album.Types.ViewRecentlyDeleted
                 id: titleImportBtn
@@ -521,7 +521,6 @@ TitleBar {
             rightLayout.anchors.leftMargin = title.width <= GStatus.needHideSideBarWidth ? layoutLeftMargin_AlignLeft : layoutLeftMargin_AlignRight
         }
     }
-
 
     Connections {
         target: GStatus

--- a/src/qml/Control/ListView/ThumbnailListViewTools.js
+++ b/src/qml/Control/ListView/ThumbnailListViewTools.js
@@ -25,6 +25,7 @@ function executeViewImage() {
 function executeDelete() {
     if ( thumnailListType !== Album.Types.ThumbnailTrash ){
         albumControl.insertTrash(GStatus.selectedPaths)
+        thumbnailModel.clearSelection()
     } else {
         albumControl.deleteImgFromTrash(selectedPaths)
         selectAll(false)

--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -113,7 +113,7 @@ BaseView {
                 topMargin: 10
                 left: parent.left
             }
-            visible: bShowImportTips
+            visible: false
             font: DTK.fontManager.t6
             text: qsTr("0 item")
         }


### PR DESCRIPTION
   1.Resolve the issue of not hiding image operation buttons after deleting all images
   2.fix titlebar left area has shadow‘s problem

Log: Resolve the issue of not hiding image operation buttons after deleting all images
Bug: https://pms.uniontech.com/bug-view-168547.html