### PR TITLE
fix: [UI] Add hover status display to the sidebar sub item

### DIFF
--- a/src/qml/PreviewImageViewer/ToolBarThumbnailListView.qml
+++ b/src/qml/PreviewImageViewer/ToolBarThumbnailListView.qml
@@ -267,7 +267,7 @@ Item {
             icon.width:36
             icon.height:36
 
-            anchors.left: fitWindowButton.right
+            anchors.left: rotateButton.right
             anchors.leftMargin: 10
             anchors.top: parent.top
             anchors.topMargin: (parent.height - height) / 2

--- a/src/qml/SideBar/SideBarItemDelegate.qml
+++ b/src/qml/SideBar/SideBarItemDelegate.qml
@@ -7,7 +7,7 @@ import QtQuick.Layouts 1.11
 import QtQuick.Controls 2.4
 import QtQml.Models 2.11
 import org.deepin.dtk 1.0
-
+import org.deepin.dtk.style 1.0 as DS
 
 ItemDelegate {
     id: item
@@ -26,6 +26,15 @@ ItemDelegate {
                 control.itemRightClicked(model.uuid, model.displayName)
             }
         }
+    }
+
+    RoundRectangle {
+        visible: hovered
+        anchors.fill: parent
+        color: DTK.themeType === ApplicationHelper.LightType ? Qt.rgba(0,0,0,0.1)
+                                                             : Qt.rgba(1,1,1,0.1)
+        radius: DS.Style.control.radius
+        corners: item.corners
     }
 
     DciIcon {

--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -78,8 +78,8 @@ SwitchViewAnimation {
         height: parent.height + GStatus.statusBarHeight - GStatus.collectionTopMargin
         anchors {
             top: parent.top
-            topMargin: GStatus.collectionTopMargin
             horizontalCenter: parent.horizontalCenter
+            bottomMargin: GStatus.collectionTopMargin
         }
     }
 

--- a/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
@@ -52,8 +52,8 @@ SwitchViewAnimation {
         height: parent.height + GStatus.statusBarHeight - GStatus.collectionTopMargin
         anchors {
             top: parent.top
-            topMargin: GStatus.collectionTopMargin
             horizontalCenter: parent.horizontalCenter
+            bottomMargin: GStatus.collectionTopMargin
         }
     }
 


### PR DESCRIPTION
   1.Add hover status display to the sidebar sub item
   2.Large image preview shows rotation button
   3.Adjust the bottom margin of the year/month view to 25px, top marigin to 0px

Log: [UI] Add hover status display to the sidebar sub item
Bug: https://pms.uniontech.com/bug-view-268929.html, https://pms.uniontech.com/bug-view-268925.html