### PR TITLE
fix: Resolve the issue of overlapping display of recently deleted tagcontent and recovery button

### DIFF
--- a/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
+++ b/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
@@ -127,8 +127,19 @@ BaseView {
                 topMargin: 10
                 left: parent.left
             }
+
+            width: restoreSelectedBtn.visible ? (restoreSelectedBtn.x - recentDelLabel.x) : (filterCombo.x - recentDelLabel.x)
             font: DTK.fontManager.t6
-            text: qsTr("The files will be permanently deleted after the days shown on them")
+            text: textMetics.elidedText
+
+            TextMetrics {
+                id: textMetics
+
+                elide: Text.ElideRight
+                elideWidth: recentDelTipLabel.width
+                font: recentDelTipLabel.font
+                text: qsTr("The files will be permanently deleted after the days shown on them")
+            }
         }
 
         //删除全部按钮


### PR DESCRIPTION

   Resolve the issue of overlapping display of recently deleted tag content and recovery button

Log: Resolve the issue of overlapping display of recently deleted tag content and recovery button
Bug: https://pms.uniontech.com/bug-view-269761.html