### PR TITLE
fix: [review] When the sidebar content is fully displayed, only the vertical scroll wheel is used

### DIFF
--- a/src/qml/Control/ListView/ThumbnailListDelegate.qml
+++ b/src/qml/Control/ListView/ThumbnailListDelegate.qml
@@ -104,30 +104,27 @@ Item {
         visible: false
     }
 
+    DropShadow {
+        anchors.fill: opacityMask
+
+        horizontalOffset: -0.5
+        verticalOffset: 1.3
+
+        radius: 1.0
+        samples: radius * 2 + 1
+        spread: 0.01
+
+        smooth: true
+        opacity: 0.1
+
+        source: opacityMask
+    }
+
     OpacityMask{
         id: opacityMask
         anchors.fill: maskRec
         source: image
-        maskSource: mask
-    }
-
-    FastBlur {
-        anchors.top: opacityMask.top; anchors.topMargin: 6
-        anchors.left: opacityMask.left; anchors.leftMargin: 1
-        width: opacityMask.width - 2; height: opacityMask.height - 6
-        source: opacityMask
-        radius: 10
-        transparentBorder: true
-    }
-
-    //遮罩执行
-    OpacityMask {
-        id: mask
-        anchors.fill: maskRec
-        source: image
         maskSource: maskRec
-        antialiasing: true
-        smooth: true
     }
 
     //border and shadow

--- a/src/qml/SideBar/Sidebar.qml
+++ b/src/qml/SideBar/Sidebar.qml
@@ -16,7 +16,7 @@ import "../"
 ScrollView {
     id: sidebarScrollView
     clip: true
-    wheelEnabled: false
+    wheelEnabled: column.height > sidebarScrollView.height
     signal sideBarListChanged(string type, string displayName)
     property int currentImportCustomIndex: 0 //自动导入相册当前索引值
     property int currentCustomIndex: 0 //自定义相册当前索引值

--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -47,7 +47,7 @@ BaseView {
 
     // 筛选类型改变处理事件
     onFilterTypeChanged: {
-        if (visible)
+        if (visible && !GStatus.loading)
             flushHaveImportedView()
     }
 


### PR DESCRIPTION

   1.When the sidebar content is fully displayed, only the vertical scroll wheel is used;
   2.Adjust Image show style.

Log: When the sidebar content is fully displayed, only the vertical scroll wheel is used