### PR TITLE
fix: 右键菜单栏黑框

### DIFF
--- a/src/album/albumview/leftlistview.cpp
+++ b/src/album/albumview/leftlistview.cpp
@@ -361,7 +361,9 @@ void LeftListView::showMenu(const QPoint &pos)
         m_pCustomizeListView->setCurrentIndex(m_pCustomizeListView->indexAt(pos));
         emit m_pCustomizeListView->pressed(m_pCustomizeListView->indexAt(pos));
     }
+#ifndef __loongarch64
     m_pMenu->setVisible(true);
+#endif
     foreach (QAction *action, m_MenuActionMap.values()) {
         action->setVisible(true);
         action->setEnabled(true);
@@ -399,6 +401,9 @@ void LeftListView::showMenu(const QPoint &pos)
     //菜单里面可能没有内容，强行显示出来会造成BUG
     if (needShowMenu) {
         m_pMenu->popup(QCursor::pos());
+#ifdef __loongarch64
+        m_pMenu->setVisible(true);
+#endif
     } else {
         m_pMenu->setVisible(false);
     }


### PR DESCRIPTION
右键左侧栏中自定义的相册，APP外区域出现黑灯瞎框

Log: 右键菜单栏APP外区域出现黑灯瞎框

Bug: https://pms.uniontech.com/bug-view-278331.html