### PR TITLE
fix: image viewer contain videos

### DIFF
--- a/src/qml/Control/ListView/ThumbnailListViewTools.js
+++ b/src/qml/Control/ListView/ThumbnailListViewTools.js
@@ -8,8 +8,8 @@ function executeViewImageCutSwitch() {
         var indexes = thumbnailModel.selectedIndexes
         if (indexes.length > 0) {
             var url = thumbnailModel.data(indexes[0], "url").toString()
-            var allUrls = thumbnailModel.allUrls()
-            menuItemStates.executeViewImageCutSwitch(url, allUrls)
+            var allPicUrls = thumbnailModel.allPictureUrls()
+            menuItemStates.executeViewImageCutSwitch(url, allPicUrls)
         }
     }
 }
@@ -20,12 +20,13 @@ function executeViewImage(x, y, w, h) {
         var indexes = thumbnailModel.selectedIndexes
         if (indexes.length > 0) {
             var url = thumbnailModel.data(indexes[0], "url").toString()
-            var allUrls = thumbnailModel.allUrls()
             if (FileControl.isVideo(url)) {
+                var allUrls = thumbnailModel.allUrls()
                 menuItemStates.executeViewImageCutSwitch(url, allUrls)
             } else {
+                var allPicUrls = thumbnailModel.allPictureUrls()
                 GStatus.enteringImageViewer = true
-                menuItemStates.executeViewImageCutSwitch(url, allUrls)
+                menuItemStates.executeViewImageCutSwitch(url, allPicUrls)
                 GStatus.sigMoveCenter(x, y, w, h)
                 GStatus.sigShowToolBar()
             }
@@ -47,7 +48,7 @@ function executeDelete() {
 // 执行全屏预览
 function executeFullScreen() {
     if (window.visibility !== Window.FullScreen && selectedUrls.length > 0) {
-        var allUrls = thumbnailModel.allUrls()
+        var allUrls = thumbnailModel.allPictureUrls()
         var indexes = thumbnailModel.selectedIndexes
         if (indexes.length > 0) {
             menuItemStates.executeFullScreen(allUrls[indexes[0]], allUrls)
@@ -63,7 +64,7 @@ function executePrint() {
 // 执行幻灯片放映
 function excuteSlideShow() {
     if (selectedUrls.length > 0) {
-        var allUrls = thumbnailModel.allUrls()
+        var allUrls = thumbnailModel.allPictureUrls()
         menuItemStates.excuteSlideShow(allUrls)
         //stackControl.startMainSliderShow(allUrls, allUrls.indexOf(selectedUrls[0]))
     }

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -2108,8 +2108,14 @@ void AlbumControl::openDeepinMovie(const QString &path)
         const int osMajor = DSysInfo::majorVersion().toInt();
         if (osMajor >= kMinimalOsVersion) {
             qInfo() << "trying start detached ll-cli run deepin-movie";
-            arguments << "run" << "org.deepin.movie" << "--" << "deepin-movie" << path;
-            trylinglongSucc = process->startDetached("ll-cli", arguments);
+            // check if current installed org.deepin.movie
+            process->start("ll-cli", {"list"});
+            process->waitForFinished();
+            QByteArray output = process->readAllStandardOutput();
+            if (output.contains("org.deepin.movie")) {
+                arguments << "run" << "org.deepin.movie" << "--" << "deepin-movie" << path;
+                trylinglongSucc = process->startDetached("ll-cli", arguments);
+            }
         }
 
         if (!trylinglongSucc) {

--- a/src/src/thumbnailview/imagedatamodel.cpp
+++ b/src/src/thumbnailview/imagedatamodel.cpp
@@ -81,6 +81,10 @@ QVariant ImageDataModel::data(const QModelIndex &index, int role) const
             return "other";
         }
     }
+
+    case Roles::ItemTypeFlagRole: {
+        return info.itemType;
+    }
     }
 
     return {};

--- a/src/src/thumbnailview/roles.h
+++ b/src/src/thumbnailview/roles.h
@@ -14,9 +14,22 @@ class Roles : public QObject
 public:
     using QObject::QObject;
     ~Roles() = default;
-    enum RoleNames { BlankRole = Qt::UserRole + 1, DBImgInfoRole, Thumbnail, ReloadThumbnail, ItemTypeRole, SelectedRole, SourceIndex
-    , ModelTypeRole, FileNameRole, UrlRole, FilePathRole, PathHashRole, RemainDaysRole
-                   };
+    enum RoleNames {
+        BlankRole = Qt::UserRole + 1,
+        DBImgInfoRole,
+        Thumbnail,
+        ReloadThumbnail,
+        ItemTypeRole,
+        SelectedRole,
+        SourceIndex,
+        ModelTypeRole,
+        FileNameRole,
+        UrlRole,
+        FilePathRole,
+        PathHashRole,
+        RemainDaysRole,
+        ItemTypeFlagRole,
+    };
 };
 
 #endif

--- a/src/src/thumbnailview/thumbnailmodel.cpp
+++ b/src/src/thumbnailview/thumbnailmodel.cpp
@@ -329,6 +329,19 @@ QJsonArray ThumbnailModel::allUrls()
     return arr;
 }
 
+QStringList ThumbnailModel::allPictureUrls()
+{
+    QStringList pictureUrls;
+    for (int row = 0; row < rowCount(); row++) {
+        QModelIndex idx = index(row, 0);
+        if (ItemTypePic == idx.data(Roles::ItemTypeFlagRole).toInt()) {
+            pictureUrls.append(idx.data(Roles::UrlRole).toString());
+        }
+    }
+
+    return pictureUrls;
+}
+
 QJsonArray ThumbnailModel::allPaths()
 {
     QJsonArray arr;

--- a/src/src/thumbnailview/thumbnailmodel.h
+++ b/src/src/thumbnailview/thumbnailmodel.h
@@ -70,6 +70,7 @@ public:
     Q_INVOKABLE int proxyIndex(const int &indexValue);
     Q_INVOKABLE int sourceIndex(const int &indexValue);
     Q_INVOKABLE QJsonArray allUrls();
+    Q_INVOKABLE QStringList allPictureUrls();
     Q_INVOKABLE QJsonArray allPaths();
     Q_INVOKABLE QJsonArray selectedUrls();
     Q_INVOKABLE QJsonArray selectedPaths();


### PR DESCRIPTION
[fix: check deepin-movie installed in linglong](https://github.com/linuxdeepin/deepin-album/commit/92f72a2eaf5fdc468296e34f502cb393c2f9d99a) 

As title, we need check deepin-movie installed in
linglong before execute it.

Log: check deepin-movie installed before execute.

[fix: image viewer contain videos](https://github.com/linuxdeepin/deepin-album/commit/4c2b5fc4d5caf75bb5e6ade4e12d0cabf2eb1ef0) 

Image viewer not need show videos.

Log: image viewer remove videos.
Bug: https://pms.uniontech.com/bug-view-295427.html