### PR TITLE
fix: SMB display issue on immutable systems

### DIFF
--- a/src/src/utils/devicehelper.cpp
+++ b/src/src/utils/devicehelper.cpp
@@ -236,7 +236,7 @@ bool DeviceHelper::isSamba(const QUrl &url)
         return false;
 
     const QString &path = url.toLocalFile();
-    static const QString gvfsMatch { "(^/run/user/\\d+/gvfs/|^/root/.gvfs/|^/media/[\\s\\S]*/smbmounts)" };
+    static const QString gvfsMatch { "(^/run/user/\\d+/gvfs/|^/root/.gvfs/|^(/run)?/media/[\\s\\S]*/smbmounts)" };
     QRegularExpression re { gvfsMatch };
     QRegularExpressionMatch match { re.match(path) };
     return match.hasMatch();

--- a/src/src/utils/filetrashhelper.cpp
+++ b/src/src/utils/filetrashhelper.cpp
@@ -197,7 +197,7 @@ bool FileTrashHelper::isGvfsFile(const QUrl &url) const
         return false;
 
     const QString &path = url.toLocalFile();
-    static const QString gvfsMatch { "(^/run/user/\\d+/gvfs/|^/root/.gvfs/|^/media/[\\s\\S]*/smbmounts)" };
+    static const QString gvfsMatch { "(^/run/user/\\d+/gvfs/|^/root/.gvfs/|^(/run)?/media/[\\s\\S]*/smbmounts)" };
     QRegularExpression re { gvfsMatch };
     QRegularExpressionMatch match { re.match(path) };
     return match.hasMatch();


### PR DESCRIPTION
- Capture SMB paths with `/run` prefix on immutable systems

Log: Hide SMB folders on immutable systems
Bug: https://pms.uniontech.com/bug-view-299327.html