### PR TITLE
fix: Fix cannot delete damaged thumbnails issue

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 

--- a/src/qml/ThumbnailImageView/ThumbnailImage.qml
+++ b/src/qml/ThumbnailImageView/ThumbnailImage.qml
@@ -99,7 +99,7 @@ Item {
     }
 
     Shortcut {
-        enabled: visible && menuItemStates.canDelete && GStatus.currentViewType !== Album.Types.ViewDevice
+        enabled: visible && GStatus.currentViewType !== Album.Types.ViewDevice
         autoRepeat: false
         sequence : "Delete"
         onActivated : {          
@@ -107,7 +107,12 @@ Item {
                 deleteDialog.setDisplay(menuItemStates.isInTrash ? Album.Types.TrashSel : Album.Types.TrashNormal, GStatus.selectedPaths.length)
                 deleteDialog.show()
             } else {
-                deleteDialog.deleteDirectly()
+                if (menuItemStates.canDelete) {
+                    deleteDialog.deleteDirectly()
+                } else {
+                    // 源文件已不存在，从相册移除裂图
+                    menuItemStates.executeRemoveFromAlbum()
+                }
             }
         }
     }

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -1810,6 +1810,9 @@ void AlbumControl::removeFromAlbum(int UID, const QStringList &paths)
     DBManager::instance()->removeCustomAlbumIdByPaths(UID, localPaths);
 
     DBManager::instance()->removeFromAlbum(UID, localPaths, atype);
+
+    // 删除信息使更新显示时不显示该图片
+    DBManager::instance()->removeImgInfos(localPaths);
 }
 
 bool AlbumControl::insertIntoAlbum(int UID, const QStringList &paths)


### PR DESCRIPTION
First it does not action delete shortcut, and then without remove info from db if remove from album that cause the damaged thumbnails still show even refresh.

Log: Fix cannot delete damaged thumbnails issue.
Bug: https://pms.uniontech.com/bug-view-289217.html