### PR TITLE
fix: Update image info after rename

### DIFF
--- a/src/qml/MainAlbumView.qml
+++ b/src/qml/MainAlbumView.qml
@@ -217,6 +217,7 @@ FadeInoutAnimation {
     }
 
     Connections {
+        target: FileControl
         // 关联外部通过 DBus 等方式触发调用相册
         function onOpenImageFile(fileName) {
             var paths = []
@@ -224,7 +225,11 @@ FadeInoutAnimation {
             openAndImportImages(paths)
         }
 
-        target: FileControl
+        // 应用内重命名后，更新数据库后，需要更新缩略图显示； 应用外无法实现
+        function onImageRenamed(oldPath, newPath) {
+            // console.log("MainAlbumView onImageRenamed oldPath:", oldPath, "newPath:", newPath)
+            albumControl.updateInfoPath(oldPath, newPath)
+        }
     }
 
     Connections {

--- a/src/qml/MenuItemStates.qml
+++ b/src/qml/MenuItemStates.qml
@@ -121,6 +121,10 @@ Item {
         if (selectedUrls.length > 0) {
             albumControl.removeFromAlbum(GStatus.currentCustomAlbumUId, selectedUrls)
             GStatus.sigFlushCustomAlbumView(GStatus.currentCustomAlbumUId)
+            if (GStatus.currentViewType === Album.Types.ViewCollecttion) {
+                // 合集视图下，刷新所有合集列表内容
+                GStatus.sigFlushAllCollectionView()
+            }
         }
     }
 

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -1844,6 +1844,21 @@ bool AlbumControl::insertImportIntoAlbum(int UID, const QStringList &paths)
     return DBManager::instance()->insertIntoAlbum(UID, localPaths, atype);
 }
 
+void AlbumControl::updateInfoPath(const QString &oldPath, const QString &newPath)
+{
+    auto oldLocalPath = url2localPath(oldPath);
+    auto newLocalPath = url2localPath(newPath);
+    bool ok = DBManager::instance()->updateImgPath(oldLocalPath, newLocalPath);
+
+    if (ok) {
+        // 通知前端刷新相关界面，包括自定义相册/我的收藏/合集-所有项目/已导入
+        sigRefreshCustomAlbum(-1);
+        sigRefreshAllCollection();
+        sigRefreshImportAlbum();
+        sigRefreshSearchView();
+    }
+}
+
 bool AlbumControl::renameAlbum(int UID, const QString &newName)
 {
     DBManager::instance()->renameAlbum(UID, newName);

--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -184,6 +184,8 @@ public:
     //添加某相册中的图片 0:我的收藏  1:截图录屏  2:相机 3:画板 4-~:其他自定义   paths:需要删除的图片地址
     Q_INVOKABLE bool insertImportIntoAlbum(int UID, const QStringList &paths);
 
+    Q_INVOKABLE void updateInfoPath(const QString &oldPath, const QString &newPath);
+
     //修改相册名称
     Q_INVOKABLE bool renameAlbum(int UID, const QString &newName);
 

--- a/src/src/dbmanager/dbmanager.h
+++ b/src/src/dbmanager/dbmanager.h
@@ -88,6 +88,7 @@ public:
     const DBImgInfoList     getInfosForKeyword(const QString &keywords) const;
     const DBImgInfoList     getTrashInfosForKeyword(const QString &keywords) const;
     const DBImgInfoList     getInfosForKeyword(int UID, const QString &keywords) const;
+    bool                    updateImgPath(const QString &oldPath, const QString &newPath);
 
     //CustomAutoImportPathTable
     //检查当前的自定义自动导入路径是否已经被监控，检查内容包括是否是子文件夹和是否是默认导入路径


### PR DESCRIPTION
Update the file path in database and notify refresh after rename; flush all collection view if delete from it.

Log: Update image info after rename.
Bug: https://pms.uniontech.com/bug-view-308075.html
     https://pms.uniontech.com/bug-view-300873.html