### PR TITLE
fix: Optimize MTP device handling

### DIFF
--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -536,8 +536,8 @@ TitleBar {
         ToolButton {
             id: titleRotateBtn
             visible: (titleImportBtn.visible ? false : true) && GStatus.currentViewType !== Album.Types.ViewDevice
-            enabled: FileControl.isRotatable(GStatus.selectedPaths)
-            ColorSelector.disabled: !FileControl.isRotatable(GStatus.selectedPaths)
+            enabled: visible && FileControl.isRotatable(GStatus.selectedPaths)
+            ColorSelector.disabled: visible && !FileControl.isRotatable(GStatus.selectedPaths)
             Layout.preferredWidth: iconSize
             Layout.preferredHeight: iconSize
             ToolTip.delay: 500
@@ -556,8 +556,8 @@ TitleBar {
         ToolButton {
             id: titleTrashBtn
             visible: (titleImportBtn.visible ? false : true) && GStatus.currentViewType !== Album.Types.ViewDevice
-            enabled: FileControl.isCanDelete(GStatus.selectedPaths)
-            ColorSelector.disabled: !FileControl.isCanDelete(GStatus.selectedPaths)
+            enabled: visible && FileControl.isCanDelete(GStatus.selectedPaths)
+            ColorSelector.disabled: visible && !FileControl.isCanDelete(GStatus.selectedPaths)
             Layout.preferredWidth: iconSize
             Layout.preferredHeight: iconSize
             ToolTip.delay: 500

--- a/src/qml/Control/DeviceLoadDialog.qml
+++ b/src/qml/Control/DeviceLoadDialog.qml
@@ -17,7 +17,26 @@ DialogWindow {
     width: 422
     property int lblHeight: 77
     property int btnWidth: 190
+    property bool loadFinished: true
     icon: "deepin-album"
+
+    function showWithNotify() {
+        // Not need wait load finished.
+        loadFinished = true;
+        deviceLoadDlg.show();
+    }
+
+    function loadStart() {
+        loadFinished = false;
+        deviceLoadDlg.show()
+    }
+
+    function loadFinish() {
+        loadFinished = true;
+        if (!timerDevLoad.running) {
+            deviceLoadDlg.visible = false;
+        }
+    }
 
     Item {
         Timer {
@@ -26,7 +45,7 @@ DialogWindow {
             running: deviceLoadDlg.visible
             repeat: false
             onTriggered: {
-                deviceLoadDlg.visible = false
+                deviceLoadDlg.visible = !loadFinished;
             }
         }
     }

--- a/src/qml/MenuItemStates.qml
+++ b/src/qml/MenuItemStates.qml
@@ -32,8 +32,16 @@ Item {
 
     property var selectedUrls: GStatus.selectedPaths
 
+    // block menu on `Device` view
+    property bool blockOnDevice: GStatus.currentViewType === Album.Types.ViewDevice
+
     //已选的图片状态检查
     function updateMenuItemStates() {
+        // Not need read image info on device
+        if (blockOnDevice) {
+            return
+        }
+
         haveImage = FileControl.haveImage(GStatus.selectedPaths)
         haveVideo = FileControl.haveVideo(GStatus.selectedPaths)
         canFullScreen = (GStatus.selectedPaths.length === 1 && FileControl.pathExists(GStatus.selectedPaths[0]))
@@ -54,6 +62,10 @@ Item {
 
     // 执行图片查看操作
     function executeViewImageCutSwitch(url, allUrls) {
+        if (blockOnDevice) {
+            return
+        }
+
         if (url !== undefined) {
             if (FileControl.isVideo(url)) {
                 albumControl.openDeepinMovie(url)
@@ -74,6 +86,10 @@ Item {
 
     // 执行全屏预览
     function executeFullScreen(url, allUrls) {
+        if (blockOnDevice) {
+            return
+        }
+
         if (window.visibility !== Window.FullScreen && selectedUrls.length > 0) {
             GControl.setImageFiles(allUrls, url)
             FileControl.resetImageFiles(allUrls);

--- a/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
@@ -203,6 +203,9 @@ SwitchViewAnimation {
 
     // 刷新选中项目标签内容
     function getSelectedText(paths) {
+        if (!visible)
+            return "";
+
         var selectedNumText = GStatus.getSelectedNumText(paths, numLabelText)
         if (visible)
             GStatus.statusBarNumText = selectedNumText

--- a/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
+++ b/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
@@ -108,6 +108,9 @@ BaseView {
 
     // 刷新选中项目标签内容
     function getSelectedText(paths) {
+        if (!visible)
+            return "";
+
         var selectedNumText = GStatus.getSelectedNumText(paths, numLabelText)
         if (visible)
             GStatus.statusBarNumText = selectedNumText

--- a/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
+++ b/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
@@ -88,7 +88,10 @@ BaseView {
 
     // 刷新选中项数标签
     function getSelectedText(paths) {
-        var selectedNumText = GStatus.getSelectedNumText(paths, numLabelText)
+        if (!visible)
+            return "";
+
+        var selectedNumText = GStatus.getSelectedNumText(paths, numLabelText, devicePath)
         if (visible)
             GStatus.statusBarNumText = selectedNumText
         return selectedNumText
@@ -102,7 +105,7 @@ BaseView {
     Connections {
         target: albumControl
         function onSigAddDevice() {
-            devloaddig.show()
+            devloaddig.showWithNotify()
         }
     }
 
@@ -116,9 +119,17 @@ BaseView {
             }
         }
 
+        // show loading dialog on first
+        function onDeviceAlbumInfoLoadStart(loadDevicePath) {
+            if (loadDevicePath === devicePath) {
+                devloaddig.loadStart()
+            }
+        }
+
         // device info load finished
         function onDeviceAlbumInfoCountChanged(loadDevicePath, picCount, videoCount) {
             if (loadDevicePath === devicePath) {
+                devloaddig.loadFinish()
                 setNumLabelText(picCount, videoCount)
             }
         }
@@ -220,7 +231,6 @@ BaseView {
         MouseArea {
             anchors.fill: parent
             onPressed: (mouse)=> {
-                theView.selectAll(false)
                 mouse.accepted = false
             }
         }

--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -174,6 +174,9 @@ BaseView {
 
     // 刷新选中项数标签
     function getSelectedText(paths) {
+        if (!visible)
+            return "";
+
         var selectedNumText = GStatus.getSelectedNumText(paths, numLabelText)
         if (visible)
             GStatus.statusBarNumText = selectedNumText

--- a/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
+++ b/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
@@ -73,6 +73,9 @@ BaseView {
 
     // 刷新选中项目标签内容
     function getSelectedText(paths) {
+        if (!visible)
+            return "";
+
         var selectedNumText = GStatus.getSelectedNumText(paths, numLabelText)
         if (visible)
             GStatus.statusBarNumText = selectedNumText

--- a/src/qml/ThumbnailImageView/SearchView.qml
+++ b/src/qml/ThumbnailImageView/SearchView.qml
@@ -76,6 +76,9 @@ BaseView {
 
     // 刷新选中项目标签内容
     function getSelectedText(paths) {
+        if (!visible)
+            return "";
+
         var selectedNumText = GStatus.getSelectedNumText(paths, numLabelText)
 
         if (visible)

--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -246,6 +246,7 @@ public:
     // Asynchronously load multimedia device data
     void loadDeviceAlbumInfoAsync(const QString &devicePath);
     DBImgInfoList getDeviceAlbumInfoList(const QString &devicePath, const int &filterType = 0, bool *loading = nullptr);
+    Q_SIGNAL void deviceAlbumInfoLoadStart(const QString &devicePath);
     Q_SIGNAL void deviceAlbumInfoLoadFinished(const QString &devicePath);
 
     Q_INVOKABLE void getDeviceAlbumInfoCountAsync(const QString &devicePath);
@@ -323,7 +324,7 @@ public:
     Q_INVOKABLE bool checkRepeatUrls(QStringList imported, QStringList urls, bool bNotify = true);
 
     //获得路径集合中视频/图片数量
-    Q_INVOKABLE QList<int> getPicVideoCountFromPaths(const QStringList &paths);
+    Q_INVOKABLE QList<int> getPicVideoCountFromPaths(const QStringList &paths, const QString &devicePath = {});
 public:
     QString getDeleteFullPath(const QString &hash, const QString &fileName);
 
@@ -461,7 +462,7 @@ private :
     struct DeviceInfo {
         int picCount{0};
         int videoCount{0};
-        QList<QPair<QString, ItemType>> fileList;
+        QMap<QString, ItemType> fileTypeMap;
     };
     using DeviceInfoPtr = QSharedPointer<DeviceInfo>;
     QMap<QString, DeviceInfoPtr> m_PhonePicFileMap;   // 外部设备及其全部图片路径

--- a/src/src/globalstatus.cpp
+++ b/src/src/globalstatus.cpp
@@ -793,9 +793,9 @@ void GlobalStatus::initConnect()
     });
 }
 
-QString GlobalStatus::getSelectedNumText(const QStringList &paths, const QString &text)
+QString GlobalStatus::getSelectedNumText(const QStringList &paths, const QString &text, const QString &devicePath)
 {
-    QList<int> ret = AlbumControl::instance()->getPicVideoCountFromPaths(paths);
+    QList<int> ret = AlbumControl::instance()->getPicVideoCountFromPaths(paths, devicePath);
 
     //QML的翻译不支持%n的特性，只能拆成这种代码
     int photoCount = ret[0];

--- a/src/src/globalstatus.h
+++ b/src/src/globalstatus.h
@@ -267,7 +267,7 @@ public:
     Q_SIGNAL void backingToMainAlbumViewChanged();
 
     // 根据选中内容获取状态栏文本内容
-    Q_INVOKABLE QString getSelectedNumText(const QStringList &paths, const QString &text);
+    Q_INVOKABLE QString getSelectedNumText(const QStringList &paths, const QString &text, const QString &devicePath = {});
 
     // Constant properties.
     int minHeight() const;


### PR DESCRIPTION
- Add loading dialog and align behavior with V20
- Disable image opening on mounted devices
- Reduce redundant file type checks with QMap cache
- Skip processing for invisible views

Log: Improved MTP device loading and browsing experience
Bug: https://pms.uniontech.com/bug-view-289223.html

## Summary by Sourcery

Optimize MTP device loading performance by improving device file type caching, adding loading state notifications, and reducing unnecessary image processing

New Features:
- Add loading state notifications for device album information
- Implement loading dialog control logic for device views

Bug Fixes:
- Prevent unnecessary image processing in device view
- Improve device file type counting accuracy

Enhancements:
- Replace QList with QMap for more efficient device file type caching
- Improve device loading performance by optimizing file type checking and processing