### PR TITLE
chore: Bump version to 6.0.22

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.21.1
+  version: 6.0.22.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-album (6.0.22) unstable; urgency=medium
+
+  * chore: update translations.
+  * fix: Optimize MTP device handling(Bug: 289223)
+
+ -- renbin <renbin@uniontech.com>  Thu, 10 Apr 2025 19:29:17 +0800
+
 deepin-album (6.0.21) unstable; urgency=medium
 
   * chore: update desktop file

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.21.1
+  version: 6.0.22.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.21.1
+  version: 6.0.22.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
Bump version to 6.0.22

Log: Bump version to 6.0.22

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, loong64, and main package configurations