### PR TITLE
chore: Bump version to 6.0.23

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.22.1
+  version: 6.0.23.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.23) unstable; urgency=medium
+
+  * Update translations.
+
+ -- renbin <renbin@uniontech.com>  Thu, 17 Apr 2025 09:37:03 +0800
+
 deepin-album (6.0.22) unstable; urgency=medium
 
   * chore: update translations.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.22.1
+  version: 6.0.23.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.22.1
+  version: 6.0.23.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
Bump version to 6.0.23

Log: Bump version to 6.0.23

## Summary by Sourcery

Chores:
- Bump application version number in linglong configuration files for arm64, loong64, and main configuration