### PR TITLE
fix: prevent app freeze when using ctrl+A to select all in collection…

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -22,7 +22,7 @@ SwitchViewAnimation {
     property string numLabelText:""
     property string selectedText: getSelectedNum(selectedPaths)
     property alias count: theView.count
-    property var selectedPaths: []
+    property var selectedPaths: GStatus.selectedPaths
 
     function setDateRange(str) {
         dateRangeLabel.text = str
@@ -164,17 +164,6 @@ SwitchViewAnimation {
         visible: numLabelText !== ""
         property int m_topMargin: 10
 
-        // 监听缩略图列表选中状态，一旦改变，更新globalVar所有选中路径
-        Connections {
-            target: theView
-            function onSelectedChanged() {
-                selectedPaths = []
-                selectedPaths = theView.selectedUrls
-
-                if (parent.visible)
-                    GStatus.selectedPaths = selectedPaths
-            }
-        }
     }
 
     // 仅在自动导入相册无内容时，显示没有图片或视频时显示

--- a/src/src/thumbnailview/thumbnailmodel.h
+++ b/src/src/thumbnailview/thumbnailmodel.h
@@ -102,6 +102,7 @@ signals:
 
 private:
     void setStatus(Status status);
+    QVariantList selectUrlsVariantList();
 
 private:
     QByteArray m_sortRoleName;


### PR DESCRIPTION
… view

The application would freeze when selecting a large number of images. This occurred because each selection change triggered the QML code to update GStatus.selectedPaths through the selectedChanged signal handler, causing redundant array copying operations which became extremely expensive with large selections.

1. Remove redundant Connections listener in QML
2. Move selectedPaths update logic to C++ layer
3. Directly update GlobalStatus in ThumbnailModel selection methods
4. Add selectUrlsVariantList() method to reduce duplicate code

bug: https://pms.uniontech.com/bug-view-312883.html

## Summary by Sourcery

Optimize selection handling in collection view to prevent UI freezes with large selections by moving selected paths update logic to the C++ layer and removing redundant QML listeners.

Bug Fixes:
- Fix application freeze when selecting all items in large collections by optimizing selection update logic.

Enhancements:
- Move selection state update from QML to C++ layer to improve performance and reduce redundant operations.
- Add selectUrlsVariantList() method to centralize and optimize selected URL list generation.