### PR TITLE
chroe: Update version to 6.0.24 and improve changelog

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.23.1
+  version: 6.0.24.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-album (6.0.24) unstable; urgency=medium
+
+  * fix: prevent app freeze when using ctrl+A to select all in collection view
+  * update version to 6.0.24
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Tue, 13 May 2025 14:18:32 +0800
+
 deepin-album (6.0.23) unstable; urgency=medium
 
   * Update translations.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.23.1
+  version: 6.0.24.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.23.1
+  version: 6.0.24.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
- Bump version from 6.0.23.1 to 6.0.24.1

## Summary by Sourcery

Bump deepin-album package version to 6.0.24.1 and refresh its changelog

Chores:
- Bump deepin-album version from 6.0.23.1 to 6.0.24.1 in ARM64, loong64, and main manifests
- Update Debian changelog entry for version 6.0.24.1