### PR TITLE
fix: Delay phenomenon when deleting a large number of files, and ctrl…

### DIFF
--- a/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
+++ b/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
@@ -256,14 +256,15 @@ BaseView {
         visible: theView.count
         property int m_topMargin: 10
 
+        // 此处更新全局选中的已经由c++端实现，为了避免qml数组拷贝触发频繁的属性函数调用， 注释掉下面的内容
         // 监听缩略图列表选中状态，一旦改变，更新globalVar所有选中路径
-        Connections {
-            target: theView
-            function onSelectedChanged() {
-                if (parent.visible)
-                    GStatus.selectedPaths = theView.selectedUrls
-            }
-        }
+        // Connections {
+        //     target: theView
+        //     function onSelectedChanged() {
+        //         if (parent.visible)
+        //             GStatus.selectedPaths = theView.selectedUrls
+        //     }
+        // }
     }
 
     // 若没有数据，显示无图片视图


### PR DESCRIPTION
…+A to select all in the recently deleted view causes album to freeze

- Removed selected signal connections in the recently deleted view QML to avoid frequent array copy work triggered by the QML engine.
- Previous improvements can be referenced at:
  1. ce844dbf12496eb8061fb3ec3ed91742561a8fd7
  2. c37786ae36229ec37d9353176ac17daea27caf8d 
The above two commits have already modified all the previous operations. This fix addresses the missed signal connection in the recently deleted view.

bug: https://pms.uniontech.com/bug-view-316707.html

## Summary by Sourcery

Disable redundant selection change handling in the recently deleted view to prevent album freezes and delays when bulk deleting files or using Ctrl+A.

Bug Fixes:
- Remove onSelectedChanged Connections block in RecentlyDeletedView.qml to avoid frequent array copying and prevent UI freezes.

Enhancements:
- Improve performance in the recently deleted view by eliminating unnecessary signal connections.