### PR TITLE
chore: Update version to 6.0.26

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.25.1
+  version: 6.0.26.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.26) unstable; urgency=medium
+
+  * Update version to 6.0.26 
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 22 May 2025 16:10:43 +0800
+
 deepin-album (6.0.25) unstable; urgency=medium
 
   * Update version to 6.0.25 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.25.1
+  version: 6.0.26.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.25.1
+  version: 6.0.26.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
- Bump version from 6.0.25 to 6.0.26.

log: Update version to 6.0.26

## Summary by Sourcery

Bump the deepin-album package version from 6.0.25.1 to 6.0.26.1 across all manifests

Chores:
- Update version in arm64, loong64, and default YAML manifests
- Refresh Debian changelog to reflect the new version