### PR TITLE
refactor: remove right menu separator height constant

### DIFF
--- a/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
+++ b/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
@@ -856,7 +856,7 @@ FocusScope {
 
         MenuSeparator {
             visible: thumnailListType !== Album.Types.ThumbnailTrash
-            height: visible ? GStatus.rightMenuSeparatorHeight : 0
+            height: visible ? undefined : 0
         }
 
         //添加到相册子菜单
@@ -955,7 +955,7 @@ FocusScope {
 
         MenuSeparator {
             visible: thumnailListType !== Album.Types.ThumbnailTrash
-            height: visible ? GStatus.rightMenuSeparatorHeight : 0
+            height: visible ? undefined : 0
         }
 
         //添加到我的收藏
@@ -980,7 +980,7 @@ FocusScope {
 
         MenuSeparator {
             visible: menuItemStates.canRotate
-            height: visible ? GStatus.rightMenuSeparatorHeight : 0
+            height: visible ? undefined : 0
         }
 
         //顺时针旋转

--- a/src/qml/PreviewImageViewer/ViewRightMenu.qml
+++ b/src/qml/PreviewImageViewer/ViewRightMenu.qml
@@ -209,7 +209,7 @@ Menu {
     MenuSeparator {
         visible: !menuItemStates.isInTrash && FileControl.isAlbum()
         // 不显示分割条时调整高度，防止菜单项间距不齐
-        height: visible ? firstSeparator.height : 0
+        height: visible ? undefined : 0
     }
 
     //添加到我的收藏
@@ -235,7 +235,7 @@ Menu {
     // 不允许无读写权限时上方选项已屏蔽，不展示此分割条
     MenuSeparator {
         // 不显示分割条时调整高度，防止菜单项间距不齐
-        height: visible ? firstSeparator.height : 0
+        height: visible ? undefined : 0
         visible: FileControl.isCanReadable(imageSource.toString()) || FileControl.isCanDelete(imageSource.toString())
     }
 
@@ -286,7 +286,7 @@ Menu {
     // 不允许无读写权限时上方选项已屏蔽，不展示此分割条
     MenuSeparator {
         // 不显示分割条时调整高度，防止菜单项间距不齐
-        height: visible ? firstSeparator.height : 0
+        height: visible ? undefined : 0
         visible: rotateClockItem.visible || rotateCounterClockItem.visible
     }
 

--- a/src/src/globalstatus.cpp
+++ b/src/src/globalstatus.cpp
@@ -21,7 +21,6 @@ static const double sc_AnimationDefaultDuration = 366;  // 默认动画时长
 static const int sc_PathViewItemCount = 3;              // 默认 PathView 在路径中的 Item 计数
 
 // 相册相关状态变量
-static const int sc_RightMenuSeparatorHeight = 12;   // 右键菜单分割层的高度
 static const int sc_NeedHideSideBarWidth = 783;      // 需要隐藏侧边栏的时，主界面宽度
 static const int sc_SideBarWidth = 200;              // 侧边栏宽度
 static const int sc_StatusBarHeight = 30;            // 状态栏高度
@@ -366,11 +365,6 @@ void GlobalStatus::setFileControl(FileControl *fc)
         qWarning() << "Failed to get sidebar animation setting, using default: false";
         m_bEnableSidebarAnimation = false;
     }
-}
-
-int GlobalStatus::rightMenuSeparatorHeight() const
-{
-    return sc_RightMenuSeparatorHeight;
 }
 
 int GlobalStatus::sideBarWidth() const

--- a/src/src/globalstatus.h
+++ b/src/src/globalstatus.h
@@ -27,7 +27,6 @@ class GlobalStatus : public QObject
     Q_PROPERTY(double animationDefaultDuration READ animationDefaultDuration CONSTANT)
     Q_PROPERTY(int pathViewItemCount READ pathViewItemCount CONSTANT)
 
-    Q_PROPERTY(int rightMenuSeparatorHeight READ rightMenuSeparatorHeight CONSTANT)
     Q_PROPERTY(int needHideSideBarWidth READ needHideSideBarWidth CONSTANT)
     Q_PROPERTY(int sideBarWidth READ sideBarWidth CONSTANT)
     Q_PROPERTY(int statusBarHeight READ statusBarHeight CONSTANT)
@@ -283,8 +282,6 @@ public:
 
     double animationDefaultDuration() const;
     int pathViewItemCount() const;
-
-    int rightMenuSeparatorHeight() const;
 
     int needHideSideBarWidth() const;
     int sideBarWidth() const;


### PR DESCRIPTION
1. Removed sc_RightMenuSeparatorHeight constant from globalstatus.cpp
2. Removed rightMenuSeparatorHeight() method and its Q_PROPERTY from
globalstatus.h
3. Changed all menu separator height properties from using
GStatus.rightMenuSeparatorHeight to undefined when visible
4. This change simplifies the code by letting QML handle default
separator heights automatically
5. The explicit height setting was unnecessary as Qt/QML provides proper
default styling

refactor: 移除右键菜单分隔条高度常量

1. 从 globalstatus.cpp 中移除 sc_RightMenuSeparatorHeight 常量
2. 从 globalstatus.h 中移除 rightMenuSeparatorHeight() 方法及其
Q_PROPERTY
3. 将所有菜单分隔条的 height 属性从使用 GStatus.rightMenuSeparatorHeight
改为 visible 时设为 undefined
4. 此更改通过让 QML 自动处理默认分隔条高度来简化代码
5. 显式设置高度是不必要的，因为 Qt/QML 提供了适当的默认样式

pms: BUG-317691

## Summary by Sourcery

Refactor right-click menu separators to rely on QML’s default heights by removing the explicit height constant and property and setting separator heights to undefined when visible.

Enhancements:
- Remove sc_RightMenuSeparatorHeight constant and rightMenuSeparatorHeight Q_PROPERTY from GlobalStatus
- Update all QML MenuSeparator height bindings to use undefined when visible instead of the removed property