### PR TITLE
chore(version): bump version to 6.0.29

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.28.1
+  version: 6.0.29.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.29) unstable; urgency=medium
+
+  * chore: Update translations (#343)
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Mon, 23 Jun 2025 12:58:38 +0800
+
 deepin-album (6.0.28) unstable; urgency=medium
 
   * chore: Update deepin-manual resources

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.28.1
+  version: 6.0.29.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.28.1
+  version: 6.0.29.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
## Summary by Sourcery

Bump deepin-album version to 6.0.29.1 across package manifests and update the Debian changelog.

Chores:
- Update version to 6.0.29.1 in arm64/linglong.yaml, linglong.yaml, and loong64/linglong.yaml.
- Update Debian changelog for version 6.0.29.1.