### PR TITLE
fix: Fix translation errors

### DIFF
--- a/src/translations/deepin-album.ts
+++ b/src/translations/deepin-album.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en">
+<TS version="2.1" language="en_US">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -192,7 +192,7 @@
         <location filename="../src/albumControl.cpp" line="2173"/>
         <location filename="../src/albumControl.cpp" line="2177"/>
         <source>%1Year%2Month%3Day</source>
-        <translation type="unfinished"></translation>
+        <translation>%1Year%2Month%3Day</translation>
     </message>
     <message>
         <location filename="../src/albumControl.cpp" line="2227"/>
@@ -389,42 +389,42 @@
     <message>
         <location filename="../src/globalstatus.cpp" line="863"/>
         <source>1 item selected (1 photo)</source>
-        <translation type="unfinished">1 item selected (1 photo)</translation>
+        <translation>1 item selected (1 photo)</translation>
     </message>
     <message>
         <location filename="../src/globalstatus.cpp" line="865"/>
         <source>1 item selected (1 video)</source>
-        <translation type="unfinished">1 item selected (1 video)</translation>
+        <translation>1 item selected (1 video)</translation>
     </message>
     <message>
         <location filename="../src/globalstatus.cpp" line="867"/>
         <source>%1 items selected (%1 photos)</source>
-        <translation type="unfinished">%1 items selected (%1 photos)</translation>
+        <translation>%1 items selected (%1 photos)</translation>
     </message>
     <message>
         <location filename="../src/globalstatus.cpp" line="869"/>
         <source>%1 items selected (%1 videos)</source>
-        <translation type="unfinished">%1 items selected (%1 videos)</translation>
+        <translation>%1 items selected (%1 videos)</translation>
     </message>
     <message>
         <location filename="../src/globalstatus.cpp" line="871"/>
         <source>%1 item selected (1 photo, 1 video)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 item selected (1 photo, 1 video)</translation>
     </message>
     <message>
         <location filename="../src/globalstatus.cpp" line="873"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
-        <translation type="unfinished">%1 items selected (1 photo, %2 videos)</translation>
+        <translation>%1 items selected (1 photo, %2 videos)</translation>
     </message>
     <message>
         <location filename="../src/globalstatus.cpp" line="875"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
-        <translation type="unfinished">%1 items selected (%2 photos, 1 video)</translation>
+        <translation>%1 items selected (%2 photos, 1 video)</translation>
     </message>
     <message>
         <location filename="../src/globalstatus.cpp" line="877"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
-        <translation type="unfinished">%1 items selected (%2 photos, %3 videos)</translation>
+        <translation>%1 items selected (%2 photos, %3 videos)</translation>
     </message>
 </context>
 <context>
@@ -433,40 +433,40 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="211"/>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="430"/>
         <source>Import</source>
-        <translation type="unfinished">Import</translation>
+        <translation>Import</translation>
     </message>
     <message>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="341"/>
         <source>1 photo</source>
-        <translation type="unfinished">1 photo</translation>
+        <translation>1 photo</translation>
     </message>
     <message>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="343"/>
         <source>1 video</source>
-        <translation type="unfinished">1 video</translation>
+        <translation>1 video</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform>%n photos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform>%n videos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform>%n items</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -475,7 +475,7 @@
     <message>
         <location filename="../src/widgets/widgtes/noresultwidget.cpp" line="39"/>
         <source>No results</source>
-        <translation type="unfinished">No results</translation>
+        <translation>No results</translation>
     </message>
 </context>
 <context>
@@ -517,19 +517,19 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="361"/>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="368"/>
         <source>All</source>
-        <translation type="unfinished">All</translation>
+        <translation>All</translation>
     </message>
     <message>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="412"/>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="376"/>
         <source>Photos</source>
-        <translation type="unfinished">Photos</translation>
+        <translation>Photos</translation>
     </message>
     <message>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="419"/>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="383"/>
         <source>Videos</source>
-        <translation type="unfinished">Videos</translation>
+        <translation>Videos</translation>
     </message>
     <message>
         <location filename="../src/albumControl.cpp" line="1355"/>
@@ -539,22 +539,22 @@
     <message>
         <location filename="../src/unionimage/unionimage_global.h" line="269"/>
         <source>day</source>
-        <translation type="unfinished">day</translation>
+        <translation>day</translation>
     </message>
     <message>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
         <source>Imported on</source>
-        <translation type="unfinished">Imported on</translation>
+        <translation>Imported on</translation>
     </message>
     <message>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
         <source> %1-%2-%3 %4</source>
-        <translation type="unfinished"></translation>
+        <translation>%1-%2-%3 %4</translation>
     </message>
     <message>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
         <source>Imported on </source>
-        <translation type="unfinished"></translation>
+        <translation>Imported on </translation>
     </message>
     <message>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="440"/>
@@ -566,14 +566,14 @@
         <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="164"/>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="236"/>
         <source>Select</source>
-        <translation type="unfinished"></translation>
+        <translation>Select</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
         <source>Unselect</source>
-        <translation type="unfinished"></translation>
+        <translation>Unselect</translation>
     </message>
 </context>
 <context>
@@ -613,7 +613,7 @@
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaildelegate.cpp" line="207"/>
         <source>days</source>
-        <translation type="unfinished">days</translation>
+        <translation>days</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="723"/>
@@ -626,7 +626,7 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="950"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="979"/>
         <source>Photo info</source>
-        <translation type="unfinished">Photo info</translation>
+        <translation>Photo info</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="724"/>
@@ -639,7 +639,7 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="951"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="980"/>
         <source>Video info</source>
-        <translation type="unfinished">Video info</translation>
+        <translation>Video info</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="746"/>
@@ -647,7 +647,7 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="931"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="957"/>
         <source>View</source>
-        <translation type="unfinished">View</translation>
+        <translation>View</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="747"/>
@@ -656,7 +656,7 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="877"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="958"/>
         <source>Fullscreen</source>
-        <translation type="unfinished">Fullscreen</translation>
+        <translation>Fullscreen</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="748"/>
@@ -665,7 +665,7 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="897"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="960"/>
         <source>Slide show</source>
-        <translation type="unfinished">Slide show</translation>
+        <translation>Slide show</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="749"/>
@@ -675,20 +675,20 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="889"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="962"/>
         <source>Export</source>
-        <translation type="unfinished">Export</translation>
+        <translation>Export</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="759"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="963"/>
         <source>Copy</source>
-        <translation type="unfinished">Copy</translation>
+        <translation>Copy</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="767"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="844"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="966"/>
         <source>Remove from album</source>
-        <translation type="unfinished">Remove from album</translation>
+        <translation>Remove from album</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="769"/>
@@ -696,7 +696,7 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="887"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="959"/>
         <source>Print</source>
-        <translation type="unfinished">Print</translation>
+        <translation>Print</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="779"/>
@@ -706,7 +706,7 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="906"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="973"/>
         <source>Rotate clockwise</source>
-        <translation type="unfinished">Rotate clockwise</translation>
+        <translation>Rotate clockwise</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="780"/>
@@ -716,14 +716,14 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="907"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="974"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished">Rotate counterclockwise</translation>
+        <translation>Rotate counterclockwise</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="781"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="881"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="978"/>
         <source>Display in file manager</source>
-        <translation type="unfinished">Display in file manager</translation>
+        <translation>Display in file manager</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="784"/>
@@ -735,22 +735,22 @@
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="919"/>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="977"/>
         <source>Set as wallpaper</source>
-        <translation type="unfinished">Set as wallpaper</translation>
+        <translation>Set as wallpaper</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="949"/>
         <source>Restore</source>
-        <translation type="unfinished">Restore</translation>
+        <translation>Restore</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="986"/>
         <source>Add to album</source>
-        <translation type="unfinished">Add to album</translation>
+        <translation>Add to album</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="990"/>
         <source>New album</source>
-        <translation type="unfinished">New album</translation>
+        <translation>New album</translation>
     </message>
 </context>
 <context>
@@ -758,35 +758,35 @@
     <message>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="304"/>
         <source>1 photo</source>
-        <translation type="unfinished">1 photo</translation>
+        <translation>1 photo</translation>
     </message>
     <message>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="306"/>
         <source>1 video</source>
-        <translation type="unfinished">1 video</translation>
+        <translation>1 video</translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform>%n photos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform>%n videos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform>%n items</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_az.ts
+++ b/src/translations/deepin-album_az.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="az">
+<TS version="2.1" language="az_AZ">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotolar&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n şəkillər&lt;/numerusform&gt;
+            <numerusform>%n şəkil</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videolar&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videolar&lt;/numerusform&gt;
+            <numerusform>%n şəkil</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elementlər&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementlər&lt;/numerusform&gt;
+            <numerusform>%n element</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n şəkil&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n şəkil&lt;/numerusform&gt;
+            <numerusform>%n şəkil</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n şəkil&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n şəkil&lt;/numerusform&gt;
+            <numerusform>%n şəkil</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n element&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n element&lt;/numerusform&gt;
+            <numerusform>%n element</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_ca.ts
+++ b/src/translations/deepin-album_ca.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ca">
+<TS version="2.1" language="ca_ES">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotografia&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografies&lt;/numerusform&gt;
+            <numerusform>%n fotografia</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n vídeo&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n vídeos&lt;/numerusform&gt;
+            <numerusform>%n vídeo</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n element&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elements&lt;/numerusform&gt;
+            <numerusform>%n element</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotografia&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografies&lt;/numerusform&gt;
+            <numerusform>%n fotografia</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n vídeo&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n vídeos&lt;/numerusform&gt;
+            <numerusform>%n vídeo</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n element&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elements&lt;/numerusform&gt;
+            <numerusform>%n element</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_cs.ts
+++ b/src/translations/deepin-album_cs.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="cs">
+<TS version="2.1" language="cs_CZ">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotka&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotky&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotek&lt;/numerusform&gt;
+            <numerusform>%n fotka</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n položka&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položky&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položek&lt;/numerusform&gt;
+            <numerusform>%n položka</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotka&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotky&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotek&lt;/numerusform&gt;
+            <numerusform>%n fotka</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n položka&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položky&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položek&lt;/numerusform&gt;
+            <numerusform>%n položka</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_de.ts
+++ b/src/translations/deepin-album_de.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="de">
+<TS version="2.1" language="de_DE">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n Fotos&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Fotos&lt;/numerusform&gt;
+            <numerusform>%n Fotos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n Videos&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Videos&lt;/numerusform&gt;
+            <numerusform>%n Videos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n Objekte&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Objekte&lt;/numerusform&gt;
+            <numerusform>%n Objekte</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n Fotos&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Fotos&lt;/numerusform&gt;
+            <numerusform>%n Fotos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n Videos&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Videos&lt;/numerusform&gt;
+            <numerusform>%n Videos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n Objekte&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Objekte&lt;/numerusform&gt;
+            <numerusform>%n Objekte</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_es.ts
+++ b/src/translations/deepin-album_es.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="es">
+<TS version="2.1" language="es_ES">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotos&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videos&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elemento&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementos&lt;/numerusform&gt;
+            <numerusform>%n elemento</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotos&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videos&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elemento&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementos&lt;/numerusform&gt;
+            <numerusform>%n elemento</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_fi.ts
+++ b/src/translations/deepin-album_fi.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fi">
+<TS version="2.1" language="fi_FI">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n kuvaa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n kuvaa&lt;/numerusform&gt;
+            <numerusform>%n kuvaa</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videota&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videota&lt;/numerusform&gt;
+            <numerusform>%n videota</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n kohdetta&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n kohdetta&lt;/numerusform&gt;
+            <numerusform>%n kohdetta</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n kuvaa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n kuvaa&lt;/numerusform&gt;
+            <numerusform>%n kuvaa</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videota&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videota&lt;/numerusform&gt;
+            <numerusform>%n videota</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n kohdetta&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n kohdetta&lt;/numerusform&gt;
+            <numerusform>%n kohdetta</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_hu.ts
+++ b/src/translations/deepin-album_hu.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="hu">
+<TS version="2.1" language="hu_HU">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,21 +449,21 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n kép(ek)&lt;/numerusform&gt;
+            <numerusform>%n kép(ek)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videó(k)&lt;/numerusform&gt;
+            <numerusform>%n videó(k)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elem(ek)&lt;/numerusform&gt;
+            <numerusform>%n elem(ek)</numerusform>
         </translation>
     </message>
 </context>
@@ -766,21 +766,21 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n kép(ek)&lt;/numerusform&gt;
+            <numerusform>%n kép(ek)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videó(k)&lt;/numerusform&gt;
+            <numerusform>%n videó(k)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elem(ek)&lt;/numerusform&gt;
+            <numerusform>%n elem(ek)</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_it.ts
+++ b/src/translations/deepin-album_it.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="it">
+<TS version="2.1" language="it_IT">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n immagini&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n immagini&lt;/numerusform&gt;
+            <numerusform>%n immagini</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elementi&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementi&lt;/numerusform&gt;
+            <numerusform>%n elementi</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n immagini&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n immagini&lt;/numerusform&gt;
+            <numerusform>%n immagini</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elementi&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementi&lt;/numerusform&gt;
+            <numerusform>%n elementi</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_ja.ts
+++ b/src/translations/deepin-album_ja.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja">
+<TS version="2.1" language="ja_JP">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -448,22 +448,22 @@
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -765,22 +765,22 @@
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform>%n 個の画像</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform>%n 個の動画</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
-        <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+        <translation>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_nl.ts
+++ b/src/translations/deepin-album_nl.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="nl">
+<TS version="2.1" language="nl_NL">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n foto's&lt;/numerusform&gt;
+            <numerusform>%n photos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video's&lt;/numerusform&gt;
+            <numerusform>%n videos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n item&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n items&lt;/numerusform&gt;
+            <numerusform>%n items</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n foto's&lt;/numerusform&gt;
+            <numerusform>%n photos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video's&lt;/numerusform&gt;
+            <numerusform>%n videos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n item&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n items&lt;/numerusform&gt;
+            <numerusform>%n items</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_pl.ts
+++ b/src/translations/deepin-album_pl.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="pl">
+<TS version="2.1" language="pl_PL">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n zdjęcie&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n zdjęcia&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n zdjęć&lt;/numerusform&gt;
+            <numerusform>%n zdjęcie</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n film&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n filmy&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n filmów&lt;/numerusform&gt;
+            <numerusform>%n film</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n przedmiot&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n przedmioty&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n przedmiotów&lt;/numerusform&gt;
+            <numerusform>%n przedmiot</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n zdjęcie&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n zdjęcia&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n zdjęć&lt;/numerusform&gt;
+            <numerusform>%n zdjęcie</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n film&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n filmy&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n filmów&lt;/numerusform&gt;
+            <numerusform>%n film</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n przedmiot&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n przedmioty&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n przedmiotów&lt;/numerusform&gt;
+            <numerusform>%n przedmiot</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_pt_BR.ts
+++ b/src/translations/deepin-album_pt_BR.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotos&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n vídeo&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n vídeos&lt;/numerusform&gt;
+            <numerusform>%n videos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n item&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n itens&lt;/numerusform&gt;
+            <numerusform>%n items</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotos&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n vídeo&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n vídeos&lt;/numerusform&gt;
+            <numerusform>%n videos</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n item&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n itens&lt;/numerusform&gt;
+            <numerusform>%n items</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_ru.ts
+++ b/src/translations/deepin-album_ru.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ru">
+<TS version="2.1" language="ru_RU">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
+            <numerusform>%n фотоs</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
+            <numerusform>%n видео</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n элемент&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n элементов&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n элементов&lt;/numerusform&gt;
+            <numerusform>%n элемент</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
+            <numerusform>%n фотоs</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
+            <numerusform>%n видео</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n элемент&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n элементов&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n элементов&lt;/numerusform&gt;
+            <numerusform>%n элемент</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_sk.ts
+++ b/src/translations/deepin-album_sk.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sk">
+<TS version="2.1" language="sk_SK">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
+            <numerusform>%n fotografií</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
+            <numerusform>%n videí</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
+            <numerusform>%n položiek</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
+            <numerusform>%n fotografií</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
+            <numerusform>%n videí</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
+            <numerusform>%n položiek</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_sl.ts
+++ b/src/translations/deepin-album_sl.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sl">
+<TS version="2.1" language="sl_SI">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,30 +449,30 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n slika&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n sliki&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n slike&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n slik&lt;/numerusform&gt;
+            <numerusform>%n slika</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videi&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videev&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%1 predmet&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmeta&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmeti&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmetov&lt;/numerusform&gt;
+            <numerusform>%1 predmet</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -775,30 +775,30 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n slika&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n sliki&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n slike&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n slik&lt;/numerusform&gt;
+            <numerusform>%n slika</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videi&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videev&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%1 predmet&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmeta&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmeti&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmetov&lt;/numerusform&gt;
+            <numerusform>%1 predmet</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_sq.ts
+++ b/src/translations/deepin-album_sq.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sq">
+<TS version="2.1" language="sq_AL">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n objekt&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n objekte&lt;/numerusform&gt;
+            <numerusform>%n objekt</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n objekt&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n objekte&lt;/numerusform&gt;
+            <numerusform>%n objekt</numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_tr.ts
+++ b/src/translations/deepin-album_tr.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="tr">
+<TS version="2.1" language="tr_TR">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,21 +449,21 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotoğraf&lt;/numerusform&gt;
+            <numerusform>%n fotoğraf</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n öğe&lt;/numerusform&gt;
+            <numerusform>%n öğe</numerusform>
         </translation>
     </message>
 </context>
@@ -766,21 +766,21 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotoğraf&lt;/numerusform&gt;
+            <numerusform>%n fotoğraf</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n öğe&lt;/numerusform&gt;
+            <numerusform>%n öğe</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_uk.ts
+++ b/src/translations/deepin-album_uk.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="uk">
+<TS version="2.1" language="uk_UA">
 <context>
     <name>AlbumControl</name>
     <message>
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n фотографія&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 фотографії&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фотографій&lt;/numerusform&gt;
+            <numerusform>%n фотографія</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
+            <numerusform>%n відео</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n запис&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n записи&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n записів&lt;/numerusform&gt;
+            <numerusform>%n запис</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n фотографія&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 фотографії&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 фотографій&lt;/numerusform&gt;
+            <numerusform>%n фотографія</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
+            <numerusform>%n відео</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n запис&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n записи&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n записів&lt;/numerusform&gt;
+            <numerusform>%n запис</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_zh_CN.ts
+++ b/src/translations/deepin-album_zh_CN.ts
@@ -463,7 +463,7 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            <numerusform>共%n项</numerusform>
+            <numerusform>共1个项</numerusform>
         </translation>
     </message>
 </context>
@@ -780,7 +780,7 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            <numerusform>共%n项</numerusform>
+            <numerusform>共1个项</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_zh_HK.ts
+++ b/src/translations/deepin-album_zh_HK.ts
@@ -1,781 +1,782 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="zh_HK" version="2.1">
-    <context>
-        <name>AlbumControl</name>
-        <message>
-            <location filename="../src/albumControl.cpp" line="278"/>
-            <source>All photos and videos</source>
-            <translation>所有照片和影片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="306"/>
-            <source>Disk is busy, cannot eject now</source>
-            <translation>磁盤文件被佔用，無法彈出</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="307"/>
-            <source>OK</source>
-            <translation>確定</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="928"/>
-            <source>Fullscreen</source>
-            <translation>全螢幕</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="931"/>
-            <source>Exit fullscreen/slideshow</source>
-            <translation>退出全螢幕/幻燈片放映</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="937"/>
-            <source>Help</source>
-            <translation>幫助</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="940"/>
-            <source>Display shortcuts</source>
-            <translation>顯示快捷鍵</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="943"/>
-            <source>Display in file manager</source>
-            <translation>在文件管理器中顯示</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="946"/>
-            <source>Slide show</source>
-            <translation>幻燈片放映</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="949"/>
-            <source>View</source>
-            <translation>查看</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="952"/>
-            <source>Export photos</source>
-            <translation>導出照片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="955"/>
-            <source>Import photos/videos</source>
-            <translation>導入照片和影片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="958"/>
-            <source>Select all</source>
-            <translation>全選</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="961"/>
-            <source>Copy</source>
-            <translation>複製</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="964"/>
-            <source>Delete</source>
-            <translation>刪除</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="967"/>
-            <source>Photo/Video info</source>
-            <translation>照片/影片訊息</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="970"/>
-            <source>Set as wallpaper</source>
-            <translation>設為壁紙</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="973"/>
-            <source>Rotate clockwise</source>
-            <translation>順時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="976"/>
-            <source>Rotate counterclockwise</source>
-            <translation>逆時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="982"/>
-            <source>Zoom in</source>
-            <translation>放大照片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="985"/>
-            <source>Zoom out</source>
-            <translation>縮小照片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="988"/>
-            <source>Previous</source>
-            <translation>上一張</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="991"/>
-            <source>Next</source>
-            <translation>下一張</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="994"/>
-            <source>Favorite</source>
-            <translation>收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="997"/>
-            <source>Unfavorite</source>
-            <translation>取消收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1000"/>
-            <source>New album</source>
-            <translation>新建相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1003"/>
-            <source>Rename album</source>
-            <translation>重命名相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1006"/>
-            <source>Page up</source>
-            <translation>向上滾動一屏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1009"/>
-            <source>Page down</source>
-            <translation>向下滾動一屏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1051"/>
-            <source>Photos</source>
-            <translation>照片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1054"/>
-            <source>Albums</source>
-            <translation>相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1057"/>
-            <source>Settings</source>
-            <translation>設置</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1629"/>
-            <source>Favorites</source>
-            <translation>我的收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1631"/>
-            <source>Screen Capture</source>
-            <translation>截圖錄屏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1633"/>
-            <source>Camera</source>
-            <translation>相機</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1635"/>
-            <source>Draw</source>
-            <translation>畫板</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1728"/>
-            <source>Unnamed</source>
-            <translation>未命名相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="2173"/>
-            <location filename="../src/albumControl.cpp" line="2177"/>
-            <source>%1Year%2Month%3Day</source>
-            <translation>%1年%2月%3日</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="2227"/>
-            <source>Channel</source>
-            <translation>聲道</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="2448"/>
-            <source>Pictures</source>
-            <translation>圖片</translation>
-        </message>
-    </context>
-    <context>
-        <name>DBManager</name>
-        <message>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="480"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="522"/>
-            <source>Screen Capture</source>
-            <translation>截圖錄屏</translation>
-        </message>
-        <message>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="481"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="498"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="527"/>
-            <source>Camera</source>
-            <translation>相機</translation>
-        </message>
-        <message>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="532"/>
-            <source>Draw</source>
-            <translation>畫板</translation>
-        </message>
-        <message>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2021"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2041"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2045"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2047"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2053"/>
-            <source>(copy)</source>
-            <translation>(副本)</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinStorage</name>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1116"/>
-            <source>%1 Drive</source>
-            <translation>%1驅動器</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1120"/>
-            <source>Blank %1 Disc</source>
-            <translation>空白%1光盤</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1124"/>
-            <source>%1 Encrypted</source>
-            <translation>%1已加密</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1127"/>
-            <source>%1 Volume</source>
-            <translation>%1卷</translation>
-        </message>
-    </context>
-    <context>
-        <name>FileControl</name>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="838"/>
-            <source>Fullscreen</source>
-            <translation>全螢幕</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="842"/>
-            <source>Exit fullscreen</source>
-            <translation>退出全螢幕</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="846"/>
-            <source>Extract text</source>
-            <translation>識別文字</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="850"/>
-            <source>Slide show</source>
-            <translation>幻燈片放映</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="854"/>
-            <source>Rename</source>
-            <translation>重命名</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="858"/>
-            <location filename="../src/filecontrol.cpp" line="950"/>
-            <source>Copy</source>
-            <translation>複製</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="862"/>
-            <source>Delete</source>
-            <translation>刪除</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="866"/>
-            <source>Rotate clockwise</source>
-            <translation>順時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="870"/>
-            <source>Rotate counterclockwise</source>
-            <translation>逆時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="874"/>
-            <source>Set as wallpaper</source>
-            <translation>設為壁紙</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="878"/>
-            <source>Display in file manager</source>
-            <translation>在文件管理器中顯示</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="882"/>
-            <source>Image info</source>
-            <translation>圖片訊息</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="886"/>
-            <source>Previous</source>
-            <translation>上一張</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="890"/>
-            <source>Next</source>
-            <translation>下一張</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="894"/>
-            <source>Zoom in</source>
-            <translation>放大照片</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="898"/>
-            <source>Zoom out</source>
-            <translation>縮小照片</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="902"/>
-            <source>Open</source>
-            <translation>打開</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="906"/>
-            <source>Print</source>
-            <translation>打印</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="930"/>
-            <source>Image Viewing</source>
-            <translation>查看圖片</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="934"/>
-            <source>Help</source>
-            <translation>幫助</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="938"/>
-            <source>Display shortcuts</source>
-            <translation>顯示快捷鍵</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="946"/>
-            <source>Settings</source>
-            <translation>設置</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="954"/>
-            <source>Select all</source>
-            <translation>全選</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="962"/>
-            <source>Live Text</source>
-            <translation>實況文本</translation>
-        </message>
-    </context>
-    <context>
-        <name>GlobalStatus</name>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="863"/>
-            <source>1 item selected (1 photo)</source>
-            <translation>已選擇1項（1張照片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="865"/>
-            <source>1 item selected (1 video)</source>
-            <translation>已選擇1項（1個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="867"/>
-            <source>%1 items selected (%1 photos)</source>
-            <translation>已選擇%1項（%1張照片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="869"/>
-            <source>%1 items selected (%1 videos)</source>
-            <translation>已選擇%1項（%1個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="871"/>
-            <source>%1 item selected (1 photo, 1 video)</source>
-            <translation>已選擇%1項（1張照片，1個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="873"/>
-            <source>%1 items selected (1 photo, %2 videos)</source>
-            <translation>已選擇%1項（1張照片，%2個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="875"/>
-            <source>%1 items selected (%2 photos, 1 video)</source>
-            <translation>已選擇%1項（%2張照片，1個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="877"/>
-            <source>%1 items selected (%2 photos, %3 videos)</source>
-            <translation>已選擇%1項（%2張照片，%3個影片）</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImportTimeLineView</name>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="211"/>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="430"/>
-            <source>Import</source>
-            <translation>已導入</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="341"/>
-            <source>1 photo</source>
-            <translation>共1張照片</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="343"/>
-            <source>1 video</source>
-            <translation>共1個影片</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
-            <source>%n photos</source>
-            <translation><numerusform>共%n張照片</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
-            <source>%n videos</source>
-            <translation><numerusform>共%n個影片</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
-            <source>%n items</source>
-            <translation><numerusform>共%n項</numerusform>
-            </translation>
-        </message>
-    </context>
-    <context>
-        <name>NoResultWidget</name>
-        <message>
-            <location filename="../src/widgets/widgtes/noresultwidget.cpp" line="39"/>
-            <source>No results</source>
-            <translation>無結果</translation>
-        </message>
-    </context>
-    <context>
-        <name>PathManager</name>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1098"/>
-            <source>System Disk</source>
-            <translation>系統盤</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <location filename="../src/albumControl.cpp" line="635"/>
-            <location filename="../src/albumControl.cpp" line="684"/>
-            <source>%1/%2/%3 %4:%5</source>
-            <translation>%1/%2/%3 %4:%5</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="666"/>
-            <source>%1</source>
-            <translation>%1</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="672"/>
-            <source>%1/%2</source>
-            <translation>%1/%2</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="678"/>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="289"/>
-            <source>%1/%2/%3</source>
-            <translation>%1年%2月%3日</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="397"/>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="404"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="361"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="368"/>
-            <source>All</source>
-            <translation>所有項目</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="412"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="376"/>
-            <source>Photos</source>
-            <translation>照片</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="419"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="383"/>
-            <source>Videos</source>
-            <translation>影片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1355"/>
-            <source>Trash</source>
-            <translation>最近刪除</translation>
-        </message>
-        <message>
-            <location filename="../src/unionimage/unionimage_global.h" line="269"/>
-            <source>day</source>
-            <translation>天</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
-            <source>Imported on</source>
-            <translation>導入於</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
-            <source>%1-%2-%3 %4</source>
-            <translation>%1年%2月%3日 %4</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
-            <source>Imported on</source>
-            <translation>導入於</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="440"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2106"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
-            <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="48"/>
-            <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="164"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="236"/>
-            <source>Select</source>
-            <translation>選擇</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
-            <source>Unselect</source>
-            <translation>取消選擇</translation>
-        </message>
-    </context>
-    <context>
-        <name>ThumbnailListView</name>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="762"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="764"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="804"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="807"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="809"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="819"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="948"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="965"/>
-            <source>Delete</source>
-            <translation>刪除</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="772"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="776"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="828"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="836"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="838"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="969"/>
-            <source>Favorite</source>
-            <translation>收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="773"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="775"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="830"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="835"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="839"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="970"/>
-            <source>Unfavorite</source>
-            <translation>取消收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaildelegate.cpp" line="207"/>
-            <source>days</source>
-            <translation>天</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="723"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="726"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="730"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="782"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="868"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="876"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="882"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="950"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="979"/>
-            <source>Photo info</source>
-            <translation>照片訊息</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="724"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="727"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="731"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="783"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="869"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="872"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="883"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="951"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="980"/>
-            <source>Video info</source>
-            <translation>影片訊息</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="746"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="798"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="931"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="957"/>
-            <source>View</source>
-            <translation>查看</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="747"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="799"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="870"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="877"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="958"/>
-            <source>Fullscreen</source>
-            <translation>全螢幕</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="748"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="874"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="888"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="897"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="960"/>
-            <source>Slide show</source>
-            <translation>幻燈片放映</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="749"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="754"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="817"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="875"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="889"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="962"/>
-            <source>Export</source>
-            <translation>導出</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="759"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="963"/>
-            <source>Copy</source>
-            <translation>複製</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="767"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="844"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="966"/>
-            <source>Remove from album</source>
-            <translation>從相冊中移除</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="769"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="873"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="887"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="959"/>
-            <source>Print</source>
-            <translation>打印</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="779"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="859"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="862"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="903"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="906"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="973"/>
-            <source>Rotate clockwise</source>
-            <translation>順時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="780"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="860"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="863"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="904"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="907"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="974"/>
-            <source>Rotate counterclockwise</source>
-            <translation>逆時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="781"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="881"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="978"/>
-            <source>Display in file manager</source>
-            <translation>在文件管理器中顯示</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="784"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="790"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="791"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="878"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="914"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="916"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="919"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="977"/>
-            <source>Set as wallpaper</source>
-            <translation>設為壁紙</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="949"/>
-            <source>Restore</source>
-            <translation>恢復</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="986"/>
-            <source>Add to album</source>
-            <translation>添加到相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="990"/>
-            <source>New album</source>
-            <translation>新建相冊</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimeLineView</name>
-        <message>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="304"/>
-            <source>1 photo</source>
-            <translation>共1张照片</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="306"/>
-            <source>1 video</source>
-            <translation>共1個影片</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
-            <source>%n photos</source>
-            <translation><numerusform>共%n張照片</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
-            <source>%n videos</source>
-            <translation><numerusform>共%n個影片</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
-            <source>%n items</source>
-            <translation><numerusform>共%n項</numerusform>
-            </translation>
-        </message>
-    </context>
+<TS version="2.1" language="zh_HK">
+<context>
+    <name>AlbumControl</name>
+    <message>
+        <location filename="../src/albumControl.cpp" line="278"/>
+        <source>All photos and videos</source>
+        <translation>所有照片和影片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="306"/>
+        <source>Disk is busy, cannot eject now</source>
+        <translation>磁盤文件被佔用，無法彈出</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="307"/>
+        <source>OK</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="928"/>
+        <source>Fullscreen</source>
+        <translation>全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="931"/>
+        <source>Exit fullscreen/slideshow</source>
+        <translation>退出全螢幕/幻燈片放映</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="937"/>
+        <source>Help</source>
+        <translation>幫助</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="940"/>
+        <source>Display shortcuts</source>
+        <translation>顯示快捷鍵</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="943"/>
+        <source>Display in file manager</source>
+        <translation>在文件管理器中顯示</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="946"/>
+        <source>Slide show</source>
+        <translation>幻燈片放映</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="949"/>
+        <source>View</source>
+        <translation>查看</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="952"/>
+        <source>Export photos</source>
+        <translation>導出照片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="955"/>
+        <source>Import photos/videos</source>
+        <translation>導入照片和影片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="958"/>
+        <source>Select all</source>
+        <translation>全選</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="961"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="964"/>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="967"/>
+        <source>Photo/Video info</source>
+        <translation>照片/影片訊息</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="970"/>
+        <source>Set as wallpaper</source>
+        <translation>設為壁紙</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="973"/>
+        <source>Rotate clockwise</source>
+        <translation>順時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="976"/>
+        <source>Rotate counterclockwise</source>
+        <translation>逆時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="982"/>
+        <source>Zoom in</source>
+        <translation>放大照片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="985"/>
+        <source>Zoom out</source>
+        <translation>縮小照片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="988"/>
+        <source>Previous</source>
+        <translation>上一張</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="991"/>
+        <source>Next</source>
+        <translation>下一張</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="994"/>
+        <source>Favorite</source>
+        <translation>收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="997"/>
+        <source>Unfavorite</source>
+        <translation>取消收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1000"/>
+        <source>New album</source>
+        <translation>新建相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1003"/>
+        <source>Rename album</source>
+        <translation>重命名相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1006"/>
+        <source>Page up</source>
+        <translation>向上滾動一屏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1009"/>
+        <source>Page down</source>
+        <translation>向下滾動一屏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1051"/>
+        <source>Photos</source>
+        <translation>照片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1054"/>
+        <source>Albums</source>
+        <translation>相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1057"/>
+        <source>Settings</source>
+        <translation>設置</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1629"/>
+        <source>Favorites</source>
+        <translation>我的收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1631"/>
+        <source>Screen Capture</source>
+        <translation>截圖錄屏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1633"/>
+        <source>Camera</source>
+        <translation>相機</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1635"/>
+        <source>Draw</source>
+        <translation>畫板</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1728"/>
+        <source>Unnamed</source>
+        <translation>未命名相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="2173"/>
+        <location filename="../src/albumControl.cpp" line="2177"/>
+        <source>%1Year%2Month%3Day</source>
+        <translation>%1年%2月%3日</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="2227"/>
+        <source>Channel</source>
+        <translation>聲道</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="2448"/>
+        <source>Pictures</source>
+        <translation>圖片</translation>
+    </message>
+</context>
+<context>
+    <name>DBManager</name>
+    <message>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="480"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="522"/>
+        <source>Screen Capture</source>
+        <translation>截圖錄屏</translation>
+    </message>
+    <message>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="481"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="498"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="527"/>
+        <source>Camera</source>
+        <translation>相機</translation>
+    </message>
+    <message>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="532"/>
+        <source>Draw</source>
+        <translation>畫板</translation>
+    </message>
+    <message>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2021"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2041"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2045"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2047"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2053"/>
+        <source>(copy)</source>
+        <translation>(副本)</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinStorage</name>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1116"/>
+        <source>%1 Drive</source>
+        <translation>%1驅動器</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1120"/>
+        <source>Blank %1 Disc</source>
+        <translation>空白%1光盤</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1124"/>
+        <source>%1 Encrypted</source>
+        <translation>%1已加密</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1127"/>
+        <source>%1 Volume</source>
+        <translation>%1卷</translation>
+    </message>
+</context>
+<context>
+    <name>FileControl</name>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="838"/>
+        <source>Fullscreen</source>
+        <translation>全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="842"/>
+        <source>Exit fullscreen</source>
+        <translation>退出全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="846"/>
+        <source>Extract text</source>
+        <translation>識別文字</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="850"/>
+        <source>Slide show</source>
+        <translation>幻燈片放映</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="854"/>
+        <source>Rename</source>
+        <translation>重命名</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="858"/>
+        <location filename="../src/filecontrol.cpp" line="950"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="862"/>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="866"/>
+        <source>Rotate clockwise</source>
+        <translation>順時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="870"/>
+        <source>Rotate counterclockwise</source>
+        <translation>逆時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="874"/>
+        <source>Set as wallpaper</source>
+        <translation>設為壁紙</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="878"/>
+        <source>Display in file manager</source>
+        <translation>在文件管理器中顯示</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="882"/>
+        <source>Image info</source>
+        <translation>圖片訊息</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="886"/>
+        <source>Previous</source>
+        <translation>上一張</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="890"/>
+        <source>Next</source>
+        <translation>下一張</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="894"/>
+        <source>Zoom in</source>
+        <translation>放大照片</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="898"/>
+        <source>Zoom out</source>
+        <translation>縮小照片</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="902"/>
+        <source>Open</source>
+        <translation>打開</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="906"/>
+        <source>Print</source>
+        <translation>打印</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="930"/>
+        <source>Image Viewing</source>
+        <translation>查看圖片</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="934"/>
+        <source>Help</source>
+        <translation>幫助</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="938"/>
+        <source>Display shortcuts</source>
+        <translation>顯示快捷鍵</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="946"/>
+        <source>Settings</source>
+        <translation>設置</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="954"/>
+        <source>Select all</source>
+        <translation>全選</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="962"/>
+        <source>Live Text</source>
+        <translation>實況文本</translation>
+    </message>
+</context>
+<context>
+    <name>GlobalStatus</name>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="863"/>
+        <source>1 item selected (1 photo)</source>
+        <translation>已選擇1項（1張照片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="865"/>
+        <source>1 item selected (1 video)</source>
+        <translation>已選擇1項（1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="867"/>
+        <source>%1 items selected (%1 photos)</source>
+        <translation>已選擇%1項（%1張照片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="869"/>
+        <source>%1 items selected (%1 videos)</source>
+        <translation>已選擇%1項（%1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="871"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation>已選擇%1項（1張照片，1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="873"/>
+        <source>%1 items selected (1 photo, %2 videos)</source>
+        <translation>已選擇%1項（1張照片，%2個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="875"/>
+        <source>%1 items selected (%2 photos, 1 video)</source>
+        <translation>已選擇%1項（%2張照片，1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="877"/>
+        <source>%1 items selected (%2 photos, %3 videos)</source>
+        <translation>已選擇%1項（%2張照片，%3個影片）</translation>
+    </message>
+</context>
+<context>
+    <name>ImportTimeLineView</name>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="211"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="430"/>
+        <source>Import</source>
+        <translation>已導入</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="341"/>
+        <source>1 photo</source>
+        <translation>共1張照片</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="343"/>
+        <source>1 video</source>
+        <translation>共1個影片</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
+        <source>%n photos</source>
+        <translation>
+            <numerusform>%n 張照片</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
+        <source>%n videos</source>
+        <translation>
+            <numerusform>%n 個影片</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
+        <source>%n items</source>
+        <translation>
+            <numerusform>%n 項</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>NoResultWidget</name>
+    <message>
+        <location filename="../src/widgets/widgtes/noresultwidget.cpp" line="39"/>
+        <source>No results</source>
+        <translation>無結果</translation>
+    </message>
+</context>
+<context>
+    <name>PathManager</name>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1098"/>
+        <source>System Disk</source>
+        <translation>系統盤</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/albumControl.cpp" line="635"/>
+        <location filename="../src/albumControl.cpp" line="684"/>
+        <source>%1/%2/%3 %4:%5</source>
+        <translation>%1/%2/%3 %4:%5</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="666"/>
+        <source>%1</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="672"/>
+        <source>%1/%2</source>
+        <translation>%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="678"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="289"/>
+        <source>%1/%2/%3</source>
+        <translation>%1年%2月%3日</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="397"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="404"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="361"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="368"/>
+        <source>All</source>
+        <translation>所有項目</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="412"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="376"/>
+        <source>Photos</source>
+        <translation>照片</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="419"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="383"/>
+        <source>Videos</source>
+        <translation>影片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1355"/>
+        <source>Trash</source>
+        <translation>最近刪除</translation>
+    </message>
+    <message>
+        <location filename="../src/unionimage/unionimage_global.h" line="269"/>
+        <source>day</source>
+        <translation>天</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
+        <source>Imported on</source>
+        <translation>導入於</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
+        <source>%1-%2-%3 %4</source>
+        <translation>%1年%2月%3日 %4</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="440"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2106"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
+        <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="48"/>
+        <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="164"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="236"/>
+        <source>Select</source>
+        <translation>選擇</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
+        <source>Unselect</source>
+        <translation>取消選擇</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView</name>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="762"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="764"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="804"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="807"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="809"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="819"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="948"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="965"/>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="772"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="776"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="828"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="836"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="838"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="969"/>
+        <source>Favorite</source>
+        <translation>收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="773"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="775"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="830"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="835"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="839"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="970"/>
+        <source>Unfavorite</source>
+        <translation>取消收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaildelegate.cpp" line="207"/>
+        <source>days</source>
+        <translation>天</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="723"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="726"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="730"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="782"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="868"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="876"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="882"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="950"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="979"/>
+        <source>Photo info</source>
+        <translation>照片訊息</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="724"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="727"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="731"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="783"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="869"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="872"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="883"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="951"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="980"/>
+        <source>Video info</source>
+        <translation>影片訊息</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="746"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="798"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="931"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="957"/>
+        <source>View</source>
+        <translation>查看</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="747"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="799"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="870"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="877"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="958"/>
+        <source>Fullscreen</source>
+        <translation>全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="748"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="874"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="888"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="897"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="960"/>
+        <source>Slide show</source>
+        <translation>幻燈片放映</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="749"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="754"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="817"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="875"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="889"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="962"/>
+        <source>Export</source>
+        <translation>導出</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="759"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="963"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="767"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="844"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="966"/>
+        <source>Remove from album</source>
+        <translation>從相冊中移除</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="769"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="873"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="887"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="959"/>
+        <source>Print</source>
+        <translation>打印</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="779"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="859"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="862"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="903"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="906"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="973"/>
+        <source>Rotate clockwise</source>
+        <translation>順時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="780"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="860"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="863"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="904"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="907"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="974"/>
+        <source>Rotate counterclockwise</source>
+        <translation>逆時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="781"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="881"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="978"/>
+        <source>Display in file manager</source>
+        <translation>在文件管理器中顯示</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="784"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="790"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="791"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="878"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="914"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="916"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="919"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>設為壁紙</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="949"/>
+        <source>Restore</source>
+        <translation>恢復</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="986"/>
+        <source>Add to album</source>
+        <translation>添加到相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="990"/>
+        <source>New album</source>
+        <translation>新建相冊</translation>
+    </message>
+</context>
+<context>
+    <name>TimeLineView</name>
+    <message>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="304"/>
+        <source>1 photo</source>
+        <translation>共1张照片</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="306"/>
+        <source>1 video</source>
+        <translation>共1個影片</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
+        <source>%n photos</source>
+        <translation>
+            <numerusform>%n 张照片</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
+        <source>%n videos</source>
+        <translation>
+            <numerusform>%n 個影片</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
+        <source>%n items</source>
+        <translation>
+            <numerusform>%n 項</numerusform>
+        </translation>
+    </message>
+</context>
 </TS>

--- a/src/translations/deepin-album_zh_TW.ts
+++ b/src/translations/deepin-album_zh_TW.ts
@@ -1,781 +1,782 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="zh_TW" version="2.1">
-    <context>
-        <name>AlbumControl</name>
-        <message>
-            <location filename="../src/albumControl.cpp" line="278"/>
-            <source>All photos and videos</source>
-            <translation>所有照片和影片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="306"/>
-            <source>Disk is busy, cannot eject now</source>
-            <translation>磁碟文件被占用，無法彈出</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="307"/>
-            <source>OK</source>
-            <translation>確定</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="928"/>
-            <source>Fullscreen</source>
-            <translation>全螢幕</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="931"/>
-            <source>Exit fullscreen/slideshow</source>
-            <translation>退出全螢幕/幻燈片放映</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="937"/>
-            <source>Help</source>
-            <translation>幫助</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="940"/>
-            <source>Display shortcuts</source>
-            <translation>顯示快捷鍵</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="943"/>
-            <source>Display in file manager</source>
-            <translation>在檔案管理器中顯示</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="946"/>
-            <source>Slide show</source>
-            <translation>幻燈片放映</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="949"/>
-            <source>View</source>
-            <translation>查看</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="952"/>
-            <source>Export photos</source>
-            <translation>匯出照片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="955"/>
-            <source>Import photos/videos</source>
-            <translation>匯入照片和影片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="958"/>
-            <source>Select all</source>
-            <translation>全選</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="961"/>
-            <source>Copy</source>
-            <translation>複製</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="964"/>
-            <source>Delete</source>
-            <translation>刪除</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="967"/>
-            <source>Photo/Video info</source>
-            <translation>照片/影片訊息</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="970"/>
-            <source>Set as wallpaper</source>
-            <translation>設為桌布</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="973"/>
-            <source>Rotate clockwise</source>
-            <translation>順時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="976"/>
-            <source>Rotate counterclockwise</source>
-            <translation>逆時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="982"/>
-            <source>Zoom in</source>
-            <translation>放大照片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="985"/>
-            <source>Zoom out</source>
-            <translation>縮小照片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="988"/>
-            <source>Previous</source>
-            <translation>上一張</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="991"/>
-            <source>Next</source>
-            <translation>下一張</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="994"/>
-            <source>Favorite</source>
-            <translation>收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="997"/>
-            <source>Unfavorite</source>
-            <translation>取消收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1000"/>
-            <source>New album</source>
-            <translation>建立相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1003"/>
-            <source>Rename album</source>
-            <translation>重新命名相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1006"/>
-            <source>Page up</source>
-            <translation>向上滾動一屏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1009"/>
-            <source>Page down</source>
-            <translation>向下滾動一屏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1051"/>
-            <source>Photos</source>
-            <translation>照片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1054"/>
-            <source>Albums</source>
-            <translation>相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1057"/>
-            <source>Settings</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1629"/>
-            <source>Favorites</source>
-            <translation>我的收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1631"/>
-            <source>Screen Capture</source>
-            <translation>截圖錄屏</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1633"/>
-            <source>Camera</source>
-            <translation>相機</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1635"/>
-            <source>Draw</source>
-            <translation>畫板</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1728"/>
-            <source>Unnamed</source>
-            <translation>未命名相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="2173"/>
-            <location filename="../src/albumControl.cpp" line="2177"/>
-            <source>%1Year%2Month%3Day</source>
-            <translation>%1年%2月%3日</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="2227"/>
-            <source>Channel</source>
-            <translation>聲道</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="2448"/>
-            <source>Pictures</source>
-            <translation>圖片</translation>
-        </message>
-    </context>
-    <context>
-        <name>DBManager</name>
-        <message>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="480"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="522"/>
-            <source>Screen Capture</source>
-            <translation>截圖錄屏</translation>
-        </message>
-        <message>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="481"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="498"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="527"/>
-            <source>Camera</source>
-            <translation>相機</translation>
-        </message>
-        <message>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="532"/>
-            <source>Draw</source>
-            <translation>畫板</translation>
-        </message>
-        <message>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2021"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2041"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2045"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2047"/>
-            <location filename="../src/dbmanager/dbmanager.cpp" line="2053"/>
-            <source>(copy)</source>
-            <translation>(副本)</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinStorage</name>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1116"/>
-            <source>%1 Drive</source>
-            <translation>%1驅動器</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1120"/>
-            <source>Blank %1 Disc</source>
-            <translation>空白%1光碟</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1124"/>
-            <source>%1 Encrypted</source>
-            <translation>%1已加密</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1127"/>
-            <source>%1 Volume</source>
-            <translation>%1卷</translation>
-        </message>
-    </context>
-    <context>
-        <name>FileControl</name>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="838"/>
-            <source>Fullscreen</source>
-            <translation>全螢幕</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="842"/>
-            <source>Exit fullscreen</source>
-            <translation>退出全螢幕</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="846"/>
-            <source>Extract text</source>
-            <translation>識別文字</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="850"/>
-            <source>Slide show</source>
-            <translation>幻燈片放映</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="854"/>
-            <source>Rename</source>
-            <translation>重新命名</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="858"/>
-            <location filename="../src/filecontrol.cpp" line="950"/>
-            <source>Copy</source>
-            <translation>複製</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="862"/>
-            <source>Delete</source>
-            <translation>刪除</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="866"/>
-            <source>Rotate clockwise</source>
-            <translation>順時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="870"/>
-            <source>Rotate counterclockwise</source>
-            <translation>逆時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="874"/>
-            <source>Set as wallpaper</source>
-            <translation>設為桌布</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="878"/>
-            <source>Display in file manager</source>
-            <translation>在檔案管理器中顯示</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="882"/>
-            <source>Image info</source>
-            <translation>圖片訊息</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="886"/>
-            <source>Previous</source>
-            <translation>上一張</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="890"/>
-            <source>Next</source>
-            <translation>下一張</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="894"/>
-            <source>Zoom in</source>
-            <translation>放大照片</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="898"/>
-            <source>Zoom out</source>
-            <translation>縮小照片</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="902"/>
-            <source>Open</source>
-            <translation>打開</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="906"/>
-            <source>Print</source>
-            <translation>列印</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="930"/>
-            <source>Image Viewing</source>
-            <translation>查看圖片</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="934"/>
-            <source>Help</source>
-            <translation>幫助</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="938"/>
-            <source>Display shortcuts</source>
-            <translation>顯示快捷鍵</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="946"/>
-            <source>Settings</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="954"/>
-            <source>Select all</source>
-            <translation>全選</translation>
-        </message>
-        <message>
-            <location filename="../src/filecontrol.cpp" line="962"/>
-            <source>Live Text</source>
-            <translation>實況文字</translation>
-        </message>
-    </context>
-    <context>
-        <name>GlobalStatus</name>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="863"/>
-            <source>1 item selected (1 photo)</source>
-            <translation>已選擇1項（1張照片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="865"/>
-            <source>1 item selected (1 video)</source>
-            <translation>已選擇1項（1個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="867"/>
-            <source>%1 items selected (%1 photos)</source>
-            <translation>已選擇%1項（%1張照片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="869"/>
-            <source>%1 items selected (%1 videos)</source>
-            <translation>已選擇%1項（%1個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="871"/>
-            <source>%1 item selected (1 photo, 1 video)</source>
-            <translation>已選擇%1項（1張照片，1個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="873"/>
-            <source>%1 items selected (1 photo, %2 videos)</source>
-            <translation>已選擇%1項（1張照片，%2個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="875"/>
-            <source>%1 items selected (%2 photos, 1 video)</source>
-            <translation>已選擇%1項（%2張照片，1個影片）</translation>
-        </message>
-        <message>
-            <location filename="../src/globalstatus.cpp" line="877"/>
-            <source>%1 items selected (%2 photos, %3 videos)</source>
-            <translation>已選擇%1項（%2張照片，%3個影片）</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImportTimeLineView</name>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="211"/>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="430"/>
-            <source>Import</source>
-            <translation>匯入照片</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="341"/>
-            <source>1 photo</source>
-            <translation>共1張照片</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="343"/>
-            <source>1 video</source>
-            <translation>共1個影片</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
-            <source>%n photos</source>
-            <translation><numerusform>共%n張照片</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
-            <source>%n videos</source>
-            <translation><numerusform>共%n個影片</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
-            <source>%n items</source>
-            <translation><numerusform>共%n項</numerusform>
-            </translation>
-        </message>
-    </context>
-    <context>
-        <name>NoResultWidget</name>
-        <message>
-            <location filename="../src/widgets/widgtes/noresultwidget.cpp" line="39"/>
-            <source>No results</source>
-            <translation>無結果</translation>
-        </message>
-    </context>
-    <context>
-        <name>PathManager</name>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1098"/>
-            <source>System Disk</source>
-            <translation>系統盤</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <location filename="../src/albumControl.cpp" line="635"/>
-            <location filename="../src/albumControl.cpp" line="684"/>
-            <source>%1/%2/%3 %4:%5</source>
-            <translation>%1/%2/%3 %4:%5</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="666"/>
-            <source>%1</source>
-            <translation>%1</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="672"/>
-            <source>%1/%2</source>
-            <translation>%1/%2</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="678"/>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="289"/>
-            <source>%1/%2/%3</source>
-            <translation>%1年%2月%3日</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="397"/>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="404"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="361"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="368"/>
-            <source>All</source>
-            <translation>所有項目</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="412"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="376"/>
-            <source>Photos</source>
-            <translation>照片</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="419"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="383"/>
-            <source>Videos</source>
-            <translation>影片</translation>
-        </message>
-        <message>
-            <location filename="../src/albumControl.cpp" line="1355"/>
-            <source>Trash</source>
-            <translation>最近刪除</translation>
-        </message>
-        <message>
-            <location filename="../src/unionimage/unionimage_global.h" line="269"/>
-            <source>day</source>
-            <translation>天</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
-            <source>Imported on</source>
-            <translation>匯入於</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
-            <source>%1-%2-%3 %4</source>
-            <translation>%1年%2月%3日 %4</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
-            <source>Imported on</source>
-            <translation>匯入於</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="440"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2106"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
-            <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="48"/>
-            <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="164"/>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="236"/>
-            <source>Select</source>
-            <translation>選擇</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
-            <source>Unselect</source>
-            <translation>取消選擇</translation>
-        </message>
-    </context>
-    <context>
-        <name>ThumbnailListView</name>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="762"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="764"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="804"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="807"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="809"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="819"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="948"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="965"/>
-            <source>Delete</source>
-            <translation>刪除</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="772"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="776"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="828"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="836"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="838"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="969"/>
-            <source>Favorite</source>
-            <translation>收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="773"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="775"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="830"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="835"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="839"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="970"/>
-            <source>Unfavorite</source>
-            <translation>取消收藏</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaildelegate.cpp" line="207"/>
-            <source>days</source>
-            <translation>天</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="723"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="726"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="730"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="782"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="868"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="876"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="882"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="950"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="979"/>
-            <source>Photo info</source>
-            <translation>照片訊息</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="724"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="727"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="731"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="783"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="869"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="872"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="883"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="951"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="980"/>
-            <source>Video info</source>
-            <translation>影片訊息</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="746"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="798"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="931"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="957"/>
-            <source>View</source>
-            <translation>查看</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="747"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="799"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="870"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="877"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="958"/>
-            <source>Fullscreen</source>
-            <translation>全螢幕</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="748"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="874"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="888"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="897"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="960"/>
-            <source>Slide show</source>
-            <translation>幻燈片放映</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="749"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="754"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="817"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="875"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="889"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="962"/>
-            <source>Export</source>
-            <translation>匯出</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="759"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="963"/>
-            <source>Copy</source>
-            <translation>複製</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="767"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="844"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="966"/>
-            <source>Remove from album</source>
-            <translation>從相冊中移除</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="769"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="873"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="887"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="959"/>
-            <source>Print</source>
-            <translation>列印</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="779"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="859"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="862"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="903"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="906"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="973"/>
-            <source>Rotate clockwise</source>
-            <translation>順時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="780"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="860"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="863"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="904"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="907"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="974"/>
-            <source>Rotate counterclockwise</source>
-            <translation>逆時針旋轉</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="781"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="881"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="978"/>
-            <source>Display in file manager</source>
-            <translation>在檔案管理器中顯示</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="784"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="790"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="791"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="878"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="914"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="916"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="919"/>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="977"/>
-            <source>Set as wallpaper</source>
-            <translation>設為桌布</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="949"/>
-            <source>Restore</source>
-            <translation>復原</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="986"/>
-            <source>Add to album</source>
-            <translation>添加到相冊</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="990"/>
-            <source>New album</source>
-            <translation>建立相冊</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimeLineView</name>
-        <message>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="304"/>
-            <source>1 photo</source>
-            <translation>共1張照片</translation>
-        </message>
-        <message>
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="306"/>
-            <source>1 video</source>
-            <translation>共1個影片</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
-            <source>%n photos</source>
-            <translation><numerusform>共%n張照片</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
-            <source>%n videos</source>
-            <translation><numerusform>共%n個影片</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
-            <source>%n items</source>
-            <translation><numerusform>共%n項</numerusform>
-            </translation>
-        </message>
-    </context>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>AlbumControl</name>
+    <message>
+        <location filename="../src/albumControl.cpp" line="278"/>
+        <source>All photos and videos</source>
+        <translation>所有照片和影片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="306"/>
+        <source>Disk is busy, cannot eject now</source>
+        <translation>磁碟文件被占用，無法彈出</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="307"/>
+        <source>OK</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="928"/>
+        <source>Fullscreen</source>
+        <translation>全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="931"/>
+        <source>Exit fullscreen/slideshow</source>
+        <translation>退出全螢幕/幻燈片放映</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="937"/>
+        <source>Help</source>
+        <translation>幫助</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="940"/>
+        <source>Display shortcuts</source>
+        <translation>顯示快捷鍵</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="943"/>
+        <source>Display in file manager</source>
+        <translation>在檔案管理器中顯示</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="946"/>
+        <source>Slide show</source>
+        <translation>幻燈片放映</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="949"/>
+        <source>View</source>
+        <translation>查看</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="952"/>
+        <source>Export photos</source>
+        <translation>匯出照片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="955"/>
+        <source>Import photos/videos</source>
+        <translation>匯入照片和影片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="958"/>
+        <source>Select all</source>
+        <translation>全選</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="961"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="964"/>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="967"/>
+        <source>Photo/Video info</source>
+        <translation>照片/影片訊息</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="970"/>
+        <source>Set as wallpaper</source>
+        <translation>設為桌布</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="973"/>
+        <source>Rotate clockwise</source>
+        <translation>順時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="976"/>
+        <source>Rotate counterclockwise</source>
+        <translation>逆時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="982"/>
+        <source>Zoom in</source>
+        <translation>放大照片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="985"/>
+        <source>Zoom out</source>
+        <translation>縮小照片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="988"/>
+        <source>Previous</source>
+        <translation>上一張</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="991"/>
+        <source>Next</source>
+        <translation>下一張</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="994"/>
+        <source>Favorite</source>
+        <translation>收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="997"/>
+        <source>Unfavorite</source>
+        <translation>取消收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1000"/>
+        <source>New album</source>
+        <translation>建立相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1003"/>
+        <source>Rename album</source>
+        <translation>重新命名相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1006"/>
+        <source>Page up</source>
+        <translation>向上滾動一屏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1009"/>
+        <source>Page down</source>
+        <translation>向下滾動一屏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1051"/>
+        <source>Photos</source>
+        <translation>照片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1054"/>
+        <source>Albums</source>
+        <translation>相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1057"/>
+        <source>Settings</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1629"/>
+        <source>Favorites</source>
+        <translation>我的收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1631"/>
+        <source>Screen Capture</source>
+        <translation>截圖錄屏</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1633"/>
+        <source>Camera</source>
+        <translation>相機</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1635"/>
+        <source>Draw</source>
+        <translation>畫板</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1728"/>
+        <source>Unnamed</source>
+        <translation>未命名相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="2173"/>
+        <location filename="../src/albumControl.cpp" line="2177"/>
+        <source>%1Year%2Month%3Day</source>
+        <translation>%1年%2月%3日</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="2227"/>
+        <source>Channel</source>
+        <translation>聲道</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="2448"/>
+        <source>Pictures</source>
+        <translation>圖片</translation>
+    </message>
+</context>
+<context>
+    <name>DBManager</name>
+    <message>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="480"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="522"/>
+        <source>Screen Capture</source>
+        <translation>截圖錄屏</translation>
+    </message>
+    <message>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="481"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="498"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="527"/>
+        <source>Camera</source>
+        <translation>相機</translation>
+    </message>
+    <message>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="532"/>
+        <source>Draw</source>
+        <translation>畫板</translation>
+    </message>
+    <message>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2021"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2041"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2045"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2047"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2053"/>
+        <source>(copy)</source>
+        <translation>(副本)</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinStorage</name>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1116"/>
+        <source>%1 Drive</source>
+        <translation>%1驅動器</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1120"/>
+        <source>Blank %1 Disc</source>
+        <translation>空白%1光碟</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1124"/>
+        <source>%1 Encrypted</source>
+        <translation>%1已加密</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1127"/>
+        <source>%1 Volume</source>
+        <translation>%1卷</translation>
+    </message>
+</context>
+<context>
+    <name>FileControl</name>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="838"/>
+        <source>Fullscreen</source>
+        <translation>全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="842"/>
+        <source>Exit fullscreen</source>
+        <translation>退出全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="846"/>
+        <source>Extract text</source>
+        <translation>識別文字</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="850"/>
+        <source>Slide show</source>
+        <translation>幻燈片放映</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="854"/>
+        <source>Rename</source>
+        <translation>重新命名</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="858"/>
+        <location filename="../src/filecontrol.cpp" line="950"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="862"/>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="866"/>
+        <source>Rotate clockwise</source>
+        <translation>順時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="870"/>
+        <source>Rotate counterclockwise</source>
+        <translation>逆時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="874"/>
+        <source>Set as wallpaper</source>
+        <translation>設為桌布</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="878"/>
+        <source>Display in file manager</source>
+        <translation>在檔案管理器中顯示</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="882"/>
+        <source>Image info</source>
+        <translation>圖片訊息</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="886"/>
+        <source>Previous</source>
+        <translation>上一張</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="890"/>
+        <source>Next</source>
+        <translation>下一張</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="894"/>
+        <source>Zoom in</source>
+        <translation>放大照片</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="898"/>
+        <source>Zoom out</source>
+        <translation>縮小照片</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="902"/>
+        <source>Open</source>
+        <translation>打開</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="906"/>
+        <source>Print</source>
+        <translation>列印</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="930"/>
+        <source>Image Viewing</source>
+        <translation>查看圖片</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="934"/>
+        <source>Help</source>
+        <translation>幫助</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="938"/>
+        <source>Display shortcuts</source>
+        <translation>顯示快捷鍵</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="946"/>
+        <source>Settings</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="954"/>
+        <source>Select all</source>
+        <translation>全選</translation>
+    </message>
+    <message>
+        <location filename="../src/filecontrol.cpp" line="962"/>
+        <source>Live Text</source>
+        <translation>實況文字</translation>
+    </message>
+</context>
+<context>
+    <name>GlobalStatus</name>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="863"/>
+        <source>1 item selected (1 photo)</source>
+        <translation>已選擇1項（1張照片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="865"/>
+        <source>1 item selected (1 video)</source>
+        <translation>已選擇1項（1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="867"/>
+        <source>%1 items selected (%1 photos)</source>
+        <translation>已選擇%1項（%1張照片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="869"/>
+        <source>%1 items selected (%1 videos)</source>
+        <translation>已選擇%1項（%1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="871"/>
+        <source>%1 item selected (1 photo, 1 video)</source>
+        <translation>已選擇%1項（1張照片，1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="873"/>
+        <source>%1 items selected (1 photo, %2 videos)</source>
+        <translation>已選擇%1項（1張照片，%2個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="875"/>
+        <source>%1 items selected (%2 photos, 1 video)</source>
+        <translation>已選擇%1項（%2張照片，1個影片）</translation>
+    </message>
+    <message>
+        <location filename="../src/globalstatus.cpp" line="877"/>
+        <source>%1 items selected (%2 photos, %3 videos)</source>
+        <translation>已選擇%1項（%2張照片，%3個影片）</translation>
+    </message>
+</context>
+<context>
+    <name>ImportTimeLineView</name>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="211"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="430"/>
+        <source>Import</source>
+        <translation>匯入照片</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="341"/>
+        <source>1 photo</source>
+        <translation>共1張照片</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="343"/>
+        <source>1 video</source>
+        <translation>共1個影片</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
+        <source>%n photos</source>
+        <translation>
+            <numerusform>%n 張照片</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
+        <source>%n videos</source>
+        <translation>
+            <numerusform>%n 個影片</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
+        <source>%n items</source>
+        <translation>
+            <numerusform>%n 項</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>NoResultWidget</name>
+    <message>
+        <location filename="../src/widgets/widgtes/noresultwidget.cpp" line="39"/>
+        <source>No results</source>
+        <translation>無結果</translation>
+    </message>
+</context>
+<context>
+    <name>PathManager</name>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1098"/>
+        <source>System Disk</source>
+        <translation>系統盤</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/albumControl.cpp" line="635"/>
+        <location filename="../src/albumControl.cpp" line="684"/>
+        <source>%1/%2/%3 %4:%5</source>
+        <translation>%1/%2/%3 %4:%5</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="666"/>
+        <source>%1</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="672"/>
+        <source>%1/%2</source>
+        <translation>%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="678"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="289"/>
+        <source>%1/%2/%3</source>
+        <translation>%1年%2月%3日</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="397"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="404"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="361"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="368"/>
+        <source>All</source>
+        <translation>所有項目</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="412"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="376"/>
+        <source>Photos</source>
+        <translation>照片</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="419"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="383"/>
+        <source>Videos</source>
+        <translation>影片</translation>
+    </message>
+    <message>
+        <location filename="../src/albumControl.cpp" line="1355"/>
+        <source>Trash</source>
+        <translation>最近刪除</translation>
+    </message>
+    <message>
+        <location filename="../src/unionimage/unionimage_global.h" line="269"/>
+        <source>day</source>
+        <translation>天</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
+        <source>Imported on</source>
+        <translation>匯入於</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
+        <source>%1-%2-%3 %4</source>
+        <translation>%1年%2月%3日 %4</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="440"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2106"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
+        <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="48"/>
+        <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="164"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="236"/>
+        <source>Select</source>
+        <translation>選擇</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
+        <source>Unselect</source>
+        <translation>取消選擇</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbnailListView</name>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="762"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="764"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="804"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="807"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="809"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="819"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="948"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="965"/>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="772"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="776"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="828"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="836"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="838"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="969"/>
+        <source>Favorite</source>
+        <translation>收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="773"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="775"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="830"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="835"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="839"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="970"/>
+        <source>Unfavorite</source>
+        <translation>取消收藏</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaildelegate.cpp" line="207"/>
+        <source>days</source>
+        <translation>天</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="723"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="726"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="730"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="782"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="868"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="876"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="882"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="950"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="979"/>
+        <source>Photo info</source>
+        <translation>照片訊息</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="724"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="727"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="731"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="783"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="869"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="872"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="883"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="951"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="980"/>
+        <source>Video info</source>
+        <translation>影片訊息</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="746"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="798"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="931"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="957"/>
+        <source>View</source>
+        <translation>查看</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="747"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="799"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="870"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="877"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="958"/>
+        <source>Fullscreen</source>
+        <translation>全螢幕</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="748"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="874"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="888"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="897"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="960"/>
+        <source>Slide show</source>
+        <translation>幻燈片放映</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="749"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="754"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="817"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="875"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="889"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="962"/>
+        <source>Export</source>
+        <translation>匯出</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="759"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="963"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="767"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="844"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="966"/>
+        <source>Remove from album</source>
+        <translation>從相冊中移除</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="769"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="873"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="887"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="959"/>
+        <source>Print</source>
+        <translation>列印</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="779"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="859"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="862"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="903"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="906"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="973"/>
+        <source>Rotate clockwise</source>
+        <translation>順時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="780"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="860"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="863"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="904"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="907"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="974"/>
+        <source>Rotate counterclockwise</source>
+        <translation>逆時針旋轉</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="781"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="881"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="978"/>
+        <source>Display in file manager</source>
+        <translation>在檔案管理器中顯示</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="784"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="790"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="791"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="878"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="914"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="916"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="919"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="977"/>
+        <source>Set as wallpaper</source>
+        <translation>設為桌布</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="949"/>
+        <source>Restore</source>
+        <translation>復原</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="986"/>
+        <source>Add to album</source>
+        <translation>添加到相冊</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="990"/>
+        <source>New album</source>
+        <translation>建立相冊</translation>
+    </message>
+</context>
+<context>
+    <name>TimeLineView</name>
+    <message>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="304"/>
+        <source>1 photo</source>
+        <translation>共1張照片</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="306"/>
+        <source>1 video</source>
+        <translation>共1個影片</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
+        <source>%n photos</source>
+        <translation>
+            <numerusform>%n 張照片</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
+        <source>%n videos</source>
+        <translation>
+            <numerusform>%n 個影片</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
+        <source>%n items</source>
+        <translation>
+            <numerusform>%n 項</numerusform>
+        </translation>
+    </message>
+</context>
 </TS>


### PR DESCRIPTION
Fix translation errors

Log: Fix translation errors

## Summary by Sourcery

Fix translation errors by standardizing encoding declarations, locale identifiers, and translation completeness across all TS files.

Bug Fixes:
- Standardize XML encoding declarations to "utf-8" in translation files
- Update TS header attributes to use full locale codes (e.g., en_US, zh_HK, zh_TW, de_DE, etc.)
- Remove or resolve "unfinished" translation markers and supply missing translation entries in English and other languages
- Correct plural forms and placeholder usage for count-based messages

Enhancements:
- Reformat TS files to clean up indentation and unify `<TS>` tag attribute ordering