### PR TITLE
fix: Fix translation errors

### DIFF
--- a/src/translations/deepin-album.ts
+++ b/src/translations/deepin-album.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_az.ts
+++ b/src/translations/deepin-album_az.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotolar&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n şəkillər&lt;/numerusform&gt;
+            <numerusform>%n fotolar</numerusform>
+            <numerusform>%n şəkillər</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videolar&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videolar&lt;/numerusform&gt;
+            <numerusform>%n videolar</numerusform>
+            <numerusform>%n videolar</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elementlər&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementlər&lt;/numerusform&gt;
+            <numerusform>%n elementlər</numerusform>
+            <numerusform>%n elementlər</numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n şəkil&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n şəkil&lt;/numerusform&gt;
+            <numerusform>%n şəkil</numerusform>
+            <numerusform>%n şəkil</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n şəkil&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n şəkil&lt;/numerusform&gt;
+            <numerusform>%n şəkil</numerusform>
+            <numerusform>%n şəkil</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n element&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n element&lt;/numerusform&gt;
+            <numerusform>%n element</numerusform>
+            <numerusform>%n element</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_ca.ts
+++ b/src/translations/deepin-album_ca.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotografia&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografies&lt;/numerusform&gt;
+            <numerusform>%n fotografia</numerusform>
+            <numerusform>%n fotografies</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n vídeo&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n vídeos&lt;/numerusform&gt;
+            <numerusform>%n vídeo</numerusform>
+            <numerusform>%n vídeos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n element&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elements&lt;/numerusform&gt;
+            <numerusform>%n element</numerusform>
+            <numerusform>%n elements</numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotografia&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografies&lt;/numerusform&gt;
+            <numerusform>%n fotografia</numerusform>
+            <numerusform>%n fotografies</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n vídeo&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n vídeos&lt;/numerusform&gt;
+            <numerusform>%n vídeo</numerusform>
+            <numerusform>%n vídeos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n element&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elements&lt;/numerusform&gt;
+            <numerusform>%n element</numerusform>
+            <numerusform>%n elements</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_cs.ts
+++ b/src/translations/deepin-album_cs.ts
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotka&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotky&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotek&lt;/numerusform&gt;
+            <numerusform>%n fotka</numerusform>
+            <numerusform>%n fotky</numerusform>
+            <numerusform>%n fotek</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n videa</numerusform>
+            <numerusform>%n videí</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n položka&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položky&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položek&lt;/numerusform&gt;
+            <numerusform>%n položka</numerusform>
+            <numerusform>%n položky</numerusform>
+            <numerusform>%n položek</numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotka&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotky&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotek&lt;/numerusform&gt;
+            <numerusform>%n fotka</numerusform>
+            <numerusform>%n fotky</numerusform>
+            <numerusform>%n fotek</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n videa</numerusform>
+            <numerusform>%n videí</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n položka&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položky&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položek&lt;/numerusform&gt;
+            <numerusform>%n položka</numerusform>
+            <numerusform>%n položky</numerusform>
+            <numerusform>%n položek</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_de.ts
+++ b/src/translations/deepin-album_de.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n Fotos&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Fotos&lt;/numerusform&gt;
+            <numerusform>%n Fotos</numerusform>
+            <numerusform>%n Fotos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n Videos&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Videos&lt;/numerusform&gt;
+            <numerusform>%n Videos</numerusform>
+            <numerusform>%n Videos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n Objekte&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Objekte&lt;/numerusform&gt;
+            <numerusform>%n Objekte</numerusform>
+            <numerusform>%n Objekte</numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n Fotos&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Fotos&lt;/numerusform&gt;
+            <numerusform>%n Fotos</numerusform>
+            <numerusform>%n Fotos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n Videos&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Videos&lt;/numerusform&gt;
+            <numerusform>%n Videos</numerusform>
+            <numerusform>%n Videos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n Objekte&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n Objekte&lt;/numerusform&gt;
+            <numerusform>%n Objekte</numerusform>
+            <numerusform>%n Objekte</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_es.ts
+++ b/src/translations/deepin-album_es.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotos&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform>%n fotos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videos&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n videos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elemento&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementos&lt;/numerusform&gt;
+            <numerusform>%n elemento</numerusform>
+            <numerusform>%n elementos</numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotos&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform>%n fotos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videos&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n videos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elemento&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementos&lt;/numerusform&gt;
+            <numerusform>%n elemento</numerusform>
+            <numerusform>%n elementos</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_fi.ts
+++ b/src/translations/deepin-album_fi.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n kuvaa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n kuvaa&lt;/numerusform&gt;
+            <numerusform>%n kuvaa</numerusform>
+            <numerusform>%n kuvaa</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videota&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videota&lt;/numerusform&gt;
+            <numerusform>%n videota</numerusform>
+            <numerusform>%n videota</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n kohdetta&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n kohdetta&lt;/numerusform&gt;
+            <numerusform>%n kohdetta</numerusform>
+            <numerusform>%n kohdetta</numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n kuvaa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n kuvaa&lt;/numerusform&gt;
+            <numerusform>%n kuvaa</numerusform>
+            <numerusform>%n kuvaa</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videota&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videota&lt;/numerusform&gt;
+            <numerusform>%n videota</numerusform>
+            <numerusform>%n videota</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n kohdetta&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n kohdetta&lt;/numerusform&gt;
+            <numerusform>%n kohdetta</numerusform>
+            <numerusform>%n kohdetta</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_hu.ts
+++ b/src/translations/deepin-album_hu.ts
@@ -449,21 +449,21 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n kép(ek)&lt;/numerusform&gt;
+            <numerusform>%n kép(ek)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videó(k)&lt;/numerusform&gt;
+            <numerusform>%n videó(k)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elem(ek)&lt;/numerusform&gt;
+            <numerusform>%n elem(ek)</numerusform>
         </translation>
     </message>
 </context>
@@ -766,21 +766,21 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n kép(ek)&lt;/numerusform&gt;
+            <numerusform>%n kép(ek)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videó(k)&lt;/numerusform&gt;
+            <numerusform>%n videó(k)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elem(ek)&lt;/numerusform&gt;
+            <numerusform>%n elem(ek)</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_it.ts
+++ b/src/translations/deepin-album_it.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n immagini&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n immagini&lt;/numerusform&gt;
+            <numerusform>%n immagini</numerusform>
+            <numerusform>%n immagini</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n video</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elementi&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementi&lt;/numerusform&gt;
+            <numerusform>%n elementi</numerusform>
+            <numerusform>%n elementi</numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n immagini&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n immagini&lt;/numerusform&gt;
+            <numerusform>%n immagini</numerusform>
+            <numerusform>%n immagini</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n video</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n elementi&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n elementi&lt;/numerusform&gt;
+            <numerusform>%n elementi</numerusform>
+            <numerusform>%n elementi</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_ja.ts
+++ b/src/translations/deepin-album_ja.ts
@@ -449,21 +449,21 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -766,21 +766,21 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation type="unfinished">
-            &lt;numerusform&gt;&lt;/numerusform&gt;
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_nl.ts
+++ b/src/translations/deepin-album_nl.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n foto's&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform>%n foto's</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video's&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n video's</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n item&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n items&lt;/numerusform&gt;
+            <numerusform>%n item</numerusform>
+            <numerusform>%n items</numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n foto's&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform>%n foto's</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video's&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n video's</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n item&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n items&lt;/numerusform&gt;
+            <numerusform>%n item</numerusform>
+            <numerusform>%n items</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_pl.ts
+++ b/src/translations/deepin-album_pl.ts
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n zdjęcie&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n zdjęcia&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n zdjęć&lt;/numerusform&gt;
+            <numerusform>%n zdjęcie</numerusform>
+            <numerusform>%n zdjęcia</numerusform>
+            <numerusform>%n zdjęć</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n film&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n filmy&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n filmów&lt;/numerusform&gt;
+            <numerusform>%n film</numerusform>
+            <numerusform>%n filmy</numerusform>
+            <numerusform>%n filmów</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n przedmiot&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n przedmioty&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n przedmiotów&lt;/numerusform&gt;
+            <numerusform>%n przedmiot</numerusform>
+            <numerusform>%n przedmioty</numerusform>
+            <numerusform>%n przedmiotów</numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n zdjęcie&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n zdjęcia&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n zdjęć&lt;/numerusform&gt;
+            <numerusform>%n zdjęcie</numerusform>
+            <numerusform>%n zdjęcia</numerusform>
+            <numerusform>%n zdjęć</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n film&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n filmy&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n filmów&lt;/numerusform&gt;
+            <numerusform>%n film</numerusform>
+            <numerusform>%n filmy</numerusform>
+            <numerusform>%n filmów</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n przedmiot&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n przedmioty&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n przedmiotów&lt;/numerusform&gt;
+            <numerusform>%n przedmiot</numerusform>
+            <numerusform>%n przedmioty</numerusform>
+            <numerusform>%n przedmiotów</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_pt_BR.ts
+++ b/src/translations/deepin-album_pt_BR.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotos&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform>%n fotos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n vídeo&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n vídeos&lt;/numerusform&gt;
+            <numerusform>%n vídeo</numerusform>
+            <numerusform>%n vídeos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n item&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n itens&lt;/numerusform&gt;
+            <numerusform>%n item</numerusform>
+            <numerusform>%n itens</numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotos&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform>%n fotos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n vídeo&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n vídeos&lt;/numerusform&gt;
+            <numerusform>%n vídeo</numerusform>
+            <numerusform>%n vídeos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n item&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n itens&lt;/numerusform&gt;
+            <numerusform>%n item</numerusform>
+            <numerusform>%n itens</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_ru.ts
+++ b/src/translations/deepin-album_ru.ts
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
+            <numerusform>%n фото</numerusform>
+            <numerusform>%n фото</numerusform>
+            <numerusform>%n фото</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
+            <numerusform>%n видео</numerusform>
+            <numerusform>%n видео</numerusform>
+            <numerusform>%n видео</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n элемент&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n элементов&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n элементов&lt;/numerusform&gt;
+            <numerusform>%n элемент</numerusform>
+            <numerusform>%n элементов</numerusform>
+            <numerusform>%n элементов</numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фото&lt;/numerusform&gt;
+            <numerusform>%n фото</numerusform>
+            <numerusform>%n фото</numerusform>
+            <numerusform>%n фото</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n видео&lt;/numerusform&gt;
+            <numerusform>%n видео</numerusform>
+            <numerusform>%n видео</numerusform>
+            <numerusform>%n видео</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n элемент&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n элементов&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n элементов&lt;/numerusform&gt;
+            <numerusform>%n элемент</numerusform>
+            <numerusform>%n элементов</numerusform>
+            <numerusform>%n элементов</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_sk.ts
+++ b/src/translations/deepin-album_sk.ts
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
+            <numerusform>%n fotografií</numerusform>
+            <numerusform>%n fotografií</numerusform>
+            <numerusform>%n fotografií</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
+            <numerusform>%n videí</numerusform>
+            <numerusform>%n videí</numerusform>
+            <numerusform>%n videí</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
+            <numerusform>%n položiek</numerusform>
+            <numerusform>%n položiek</numerusform>
+            <numerusform>%n položiek</numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n fotografií&lt;/numerusform&gt;
+            <numerusform>%n fotografií</numerusform>
+            <numerusform>%n fotografií</numerusform>
+            <numerusform>%n fotografií</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videí&lt;/numerusform&gt;
+            <numerusform>%n videí</numerusform>
+            <numerusform>%n videí</numerusform>
+            <numerusform>%n videí</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n položiek&lt;/numerusform&gt;
+            <numerusform>%n položiek</numerusform>
+            <numerusform>%n položiek</numerusform>
+            <numerusform>%n položiek</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_sl.ts
+++ b/src/translations/deepin-album_sl.ts
@@ -449,30 +449,30 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n slika&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n sliki&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n slike&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n slik&lt;/numerusform&gt;
+            <numerusform>%n slika</numerusform>
+            <numerusform>%n sliki</numerusform>
+            <numerusform>%n slike</numerusform>
+            <numerusform>%n slik</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videi&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videev&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n videa</numerusform>
+            <numerusform>%n videi</numerusform>
+            <numerusform>%n videev</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%1 predmet&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmeta&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmeti&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmetov&lt;/numerusform&gt;
+            <numerusform>%1 predmet</numerusform>
+            <numerusform>%1 predmeta</numerusform>
+            <numerusform>%1 predmeti</numerusform>
+            <numerusform>%1 predmetov</numerusform>
         </translation>
     </message>
 </context>
@@ -775,30 +775,30 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n slika&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n sliki&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n slike&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n slik&lt;/numerusform&gt;
+            <numerusform>%n slika</numerusform>
+            <numerusform>%n sliki</numerusform>
+            <numerusform>%n slike</numerusform>
+            <numerusform>%n slik</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videa&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videi&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n videev&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n videa</numerusform>
+            <numerusform>%n videi</numerusform>
+            <numerusform>%n videev</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%1 predmet&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmeta&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmeti&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 predmetov&lt;/numerusform&gt;
+            <numerusform>%1 predmet</numerusform>
+            <numerusform>%1 predmeta</numerusform>
+            <numerusform>%1 predmeti</numerusform>
+            <numerusform>%1 predmetov</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_sq.ts
+++ b/src/translations/deepin-album_sq.ts
@@ -449,24 +449,24 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform>%n foto</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n video</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n objekt&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n objekte&lt;/numerusform&gt;
+            <numerusform>%n objekt</numerusform>
+            <numerusform>%n objekte</numerusform>
         </translation>
     </message>
 </context>
@@ -769,24 +769,24 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n foto&lt;/numerusform&gt;
+            <numerusform>%n foto</numerusform>
+            <numerusform>%n foto</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
+            <numerusform>%n video</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n objekt&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n objekte&lt;/numerusform&gt;
+            <numerusform>%n objekt</numerusform>
+            <numerusform>%n objekte</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_tr.ts
+++ b/src/translations/deepin-album_tr.ts
@@ -449,21 +449,21 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotoğraf&lt;/numerusform&gt;
+            <numerusform>%n fotoğraf</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n öğe&lt;/numerusform&gt;
+            <numerusform>%n öğe</numerusform>
         </translation>
     </message>
 </context>
@@ -766,21 +766,21 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n fotoğraf&lt;/numerusform&gt;
+            <numerusform>%n fotoğraf</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n video&lt;/numerusform&gt;
+            <numerusform>%n video</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n öğe&lt;/numerusform&gt;
+            <numerusform>%n öğe</numerusform>
         </translation>
     </message>
 </context>

--- a/src/translations/deepin-album_uk.ts
+++ b/src/translations/deepin-album_uk.ts
@@ -449,27 +449,27 @@
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n фотографія&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 фотографії&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n фотографій&lt;/numerusform&gt;
+            <numerusform>%n фотографія</numerusform>
+            <numerusform>%1 фотографії</numerusform>
+            <numerusform>%n фотографій</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
+            <numerusform>%n відео</numerusform>
+            <numerusform>%n відео</numerusform>
+            <numerusform>%n відео</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n запис&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n записи&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n записів&lt;/numerusform&gt;
+            <numerusform>%n запис</numerusform>
+            <numerusform>%n записи</numerusform>
+            <numerusform>%n записів</numerusform>
         </translation>
     </message>
 </context>
@@ -772,27 +772,27 @@
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
         <translation>
-            &lt;numerusform&gt;%n фотографія&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 фотографії&lt;/numerusform&gt;
-            &lt;numerusform&gt;%1 фотографій&lt;/numerusform&gt;
+            <numerusform>%n фотографія</numerusform>
+            <numerusform>%1 фотографії</numerusform>
+            <numerusform>%1 фотографій</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
         <translation>
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n відео&lt;/numerusform&gt;
+            <numerusform>%n відео</numerusform>
+            <numerusform>%n відео</numerusform>
+            <numerusform>%n відео</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
         <translation>
-            &lt;numerusform&gt;%n запис&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n записи&lt;/numerusform&gt;
-            &lt;numerusform&gt;%n записів&lt;/numerusform&gt;
+            <numerusform>%n запис</numerusform>
+            <numerusform>%n записи</numerusform>
+            <numerusform>%n записів</numerusform>
         </translation>
     </message>
 </context>


### PR DESCRIPTION
Fix translation errors

Log: Fix translation errors

## Summary by Sourcery

Enhancements:
- Replace escaped &lt;numerusform&gt; tags with proper <numerusform> markup in translation files for accurate plural handling