### PR TITLE
feat: update changelog and version

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.29.1
+  version: 6.0.30.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.30) unstable; urgency=medium
+
+  * chore: New version 6.0.30.
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Mon, 23 Jun 2025 15:53:51 +0800
+
 deepin-album (6.0.29) unstable; urgency=medium
 
   * chore: Update translations (#343)

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.29.1
+  version: 6.0.30.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.29.1
+  version: 6.0.30.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
Update changelog and version

## Summary by Sourcery

Bump application version to 6.0.30.1 across all package manifests and update the Debian changelog

Chores:
- Bump deepin-album version from 6.0.29.1 to 6.0.30.1 in arm64, loong64, and default linglong.yaml manifests
- Update Debian changelog for the new 6.0.30.1 release