### PR TITLE
fix: Bug in photo deletion logic

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.34.1
+  version: 6.0.35.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.35) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 03 Jul 2025 15:28:27 +0800
+
 deepin-album (6.0.34) unstable; urgency=medium
 
   * update version to 6.0.34.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.34.1
+  version: 6.0.35.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.34.1
+  version: 6.0.35.1
   kind: app
   description: |
     album for deepin os.

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -1838,9 +1838,6 @@ void AlbumControl::removeFromAlbum(int UID, const QStringList &paths)
     DBManager::instance()->removeCustomAlbumIdByPaths(UID, localPaths);
 
     DBManager::instance()->removeFromAlbum(UID, localPaths, atype);
-
-    // 删除信息使更新显示时不显示该图片
-    DBManager::instance()->removeImgInfos(localPaths);
 }
 
 bool AlbumControl::insertIntoAlbum(int UID, const QStringList &paths)

--- a/src/src/thumbnailview/thumbnailmodel.cpp
+++ b/src/src/thumbnailview/thumbnailmodel.cpp
@@ -399,7 +399,6 @@ QJsonArray ThumbnailModel::selectedUrls()
     for (auto index : m_selectionModel->selectedIndexes())
         arr.push_back(QJsonValue(data(index, Roles::UrlRole).toString()));
 
-    qDebug() << "Retrieved" << arr.size() << "selected URLs";
     return arr;
 }
 
@@ -410,7 +409,6 @@ QJsonArray ThumbnailModel::selectedPaths()
     for (auto index : m_selectionModel->selectedIndexes())
         arr.push_back(QJsonValue(data(index, Roles::FilePathRole).toString()));
 
-    qDebug() << "Retrieved" << arr.size() << "selected paths";
     return arr;
 }
 


### PR DESCRIPTION
When deleting photos, all connected album and collection contents are also permanently removed

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-322431.html

## Summary by Sourcery

Fix photo deletion logic to stop removing associated album and collection entries, remove redundant debug output, and add an ignore file for cursor indexing artifacts

Bug Fixes:
- Prevent connected album and collection data from being deleted by removing the erroneous removeImgInfos call during photo removal

Enhancements:
- Remove qDebug statements in ThumbnailModel to clean up console output

Build:
- Add .cursorindexingignore to exclude cursor indexing files from source control