### PR TITLE
feat: Image format extension support

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.36.1
+  version: 6.0.37.1
   kind: app
   description: |
     album for deepin os.
@@ -23,7 +23,11 @@ build: |
   # 查找并移动目录下的所有文件（包括符号链接）到它的上一层目录
   find ${PREFIX}/lib/${TRIPLET}/blas -mindepth 1 -maxdepth 1 -exec mv {} ${PREFIX}/lib/${TRIPLET} \;
   find ${PREFIX}/lib/${TRIPLET}/lapack -mindepth 1 -maxdepth 1 -exec mv {} ${PREFIX}/lib/${TRIPLET} \;
-  
+
+  # 准备插件
+  mkdir -p $PREFIX/bin/imageformats
+  cp ${PREFIX}/lib/${TRIPLET}/qt6/plugins/imageformats/*.so $PREFIX/bin/imageformats
+
   # 更新ld.so.cache
   if [ -n "$LINGLONG_LD_SO_CACHE" ]; then
       ldconfig -C "$LINGLONG_LD_SO_CACHE"
@@ -47,1383 +51,1493 @@ build: |
     libffmpegthumbnailer.so
     libblas.so
     liblapack.so
+    ../../bin/imageformats/kimg_avif.so
+    ../../bin/imageformats/kimg_heif.so
+    # plugins for libheif.so.1
+    libheif/plugins/libheif-aomdec.so
+    libheif/plugins/libheif-dav1d.so
+    libheif/plugins/libheif-j2kdec.so
+    libheif/plugins/libheif-libde265.so
+    libheif/plugins/libheif-x265.so
   )
 
   # 生成.install 文件
   bash ./deploy_dep "${LDD_FILES[@]}"
 
+  ID_VALUE=$(awk -F ': ' '/^  id: / {print $2}' linglong.yaml)
+  # set LIBHEIF_PLUGIN_PATH for libheif.so.1 to load plugins
+  mkdir -p $PREFIX/etc
+  echo export LIBHEIF_PLUGIN_PATH=$PREFIX/lib/${TRIPLET}/libheif/plugins > $PREFIX/etc/profile
+  echo $PREFIX/etc/profile >> "${ID_VALUE}.install"
+
 sources:
-  # linglong:gen_deb_source sources arm64 https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release/ beige main community
+  # linglong:gen_deb_source sources arm64 http://10.20.64.92:8080/crimson_25.0 stable main
   # linglong:gen_deb_source install libdtk6gui-dev, libdtk6widget-dev, qt6-svg-dev, qt6-tools-dev, qt6-tools-dev-tools, qt6-base-dev, qt6-base-dev-tools, qt6-base-private-dev, qt6-l10n-tools
-  # linglong:gen_deb_source install libexif-dev, libstartup-notification0-dev, libudev-dev, libfontconfig1-dev, libglib2.0-dev, libxrender-dev, libdfm6-mount-dev, libdfm-mount-dev, libavcodec-dev, libavformat-dev, libavutil-dev, libffmpegthumbnailer-dev
+  # linglong:gen_deb_source install libexif-dev, libstartup-notification0-dev, libudev-dev, libfontconfig1-dev, libglib2.0-dev, libxrender-dev, libdfm6-mount-dev, libdfm-mount-dev, libavcodec-dev, libavformat-dev, libavutil-dev, libffmpegthumbnailer-dev, kimageformat6-plugins
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
     digest: db24bc67c73659376f0a1eae6d7c536aaa53eb75790e6bf51916a0cb2a630fbd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin4_arm64.deb
-    digest: 6dea84674ed887668dbcff5aa24049be9d6ab447c5a25efd0319daf262d678fb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin7_arm64.deb
+    digest: 6d594af95ee6ae34a14f687a619b97684e7e136ec2551a36157a456f1b718577
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-common_2.41-6deepin4_arm64.deb
-    digest: cd56d2bf469c714c7a3cd72bc5ce1d33eda15dacb552b561014ec73e44d752f1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-common_2.41-6deepin7_arm64.deb
+    digest: 29236b493e68174e0f83488bb022fc38af4e865bcbd88967cecd90cbf13138e9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils_2.41-6deepin4_arm64.deb
-    digest: e8ad011bfd66aa43901791b40aa6e681bfc388b562324eb5a00ec71714d3314a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils_2.41-6deepin7_arm64.deb
+    digest: 15363c40bc3eab055b05020a334149c727b0801eab7119ee689c4be62f8b4cda
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/bzip2_1.0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/bzip2_1.0.8-deepin1_arm64.deb
     digest: 5fc6a22a0ad720a1b8fc7f8ef83ddfbb0c59bfa43ad383c7052cf2adf9f3d0d7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
     digest: 11a42f07b2feefb7669441c3a67176cc32dc857c7d21b3290c464795fc514448
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
-    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg_1.22.6deepin3_arm64.deb
-    digest: 81d1a53d75115f01e303fcf8337493bc2850614b0a2e30b06b9e0fa67d0d5a80
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg_1.22.6deepin4_arm64.deb
+    digest: 395526d8605c5a34c3bea89d6c32781d3a5625eae82b77f598835c09524f51cb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig-config_2.14.2-6_arm64.deb
-    digest: aa64934dbf43b0dd0ffee2b7fbcce324b50b957b0a4f04c10d062a85d8847d8e
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_arm64.deb
+    digest: bedadcad1a6b77ae2842cb308003cfae181d382ee416ccbd9c35e309f1991d19
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig_2.14.2-6_arm64.deb
-    digest: 91c105d210849f97151c436e0cf9b77910bbc58ea9bbd40da4077219def10994
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_arm64.deb
+    digest: 6d7e0dca9ca1599c9950826e6c25918a3b30e7a37222ef980ae64fff2db42535
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
     digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
     digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
     digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin3_arm64.deb
-    digest: b39326ffa5eb7901d47273247b7da0ed48cd88d4d468606a48d25c0d6cff2b70
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin4_arm64.deb
+    digest: 781c11f578b76d0702466e2ecd81225460d64e1d70cd5f849159b84603028dff
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_arm64.deb
     digest: 44c091f38ef3e76d0b4d249b584a05e88b8e24a754834ba0bcde925734229ce3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_arm64.deb
     digest: 1afc84a191b5f3819a8bc441315d4ab876409ec711acf1af3eda81659f9e3abb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_arm64.deb
     digest: 4663b703fa834002da6bbd91431eeddad3eb2f235100782fb3cea7473afce618
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin2_arm64.deb
-    digest: cb78254303d5b726a280e5c2e6f6452f9121c3c9ddfaccf9be59e8773afe068c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin10_arm64.deb
+    digest: 3b0743eeaa97b139aed75f24128adfa5d8913a537f233389a1573b59afe97cd3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/acl/libacl1_2.3.1-1_arm64.deb
-    digest: 51808064361bdae539f985645eaee59b53c703b293174f761d996b27f2b8d860
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kimageformats/kimageformat6-plugins_6.10.0-2_arm64.deb
+    digest: 8a697dc3bbd6c2709d3d623de93a29fd236f739274eeded77303c3f03a67abbe
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/aom/libaom3_3.9.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/abseil/libabsl20220623_20220623.1-3_arm64.deb
+    digest: 4e7d08584337a95ccbb5167513fa590d5fe4614eb17860b743e190a49bdf9541
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/acl/libacl1_2.3.1-3_arm64.deb
+    digest: ea023a815c9257d7d4f2028037d8d2b19009d9e36d6ae7d6cd5b20ad38e90565
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/aom/libaom3_3.9.1-1_arm64.deb
     digest: 2ac174ee086466df9fc130a81c5f9aed2932b8de1b40ef60bd116a549d4af57f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/alsa-lib/libasound2-data_1.2.12-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/alsa-lib/libasound2-data_1.2.12-1deepin1_all.deb
     digest: 4990cab9125078d6b8ef1caaeabb597ecda80949d02d251903fd496272f59fbf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/alsa-lib/libasound2_1.2.12-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/alsa-lib/libasound2_1.2.12-1deepin1_arm64.deb
     digest: c6fcbfd312ce95f663f002d524ef94ce632c01610df801b64f459d5c7ef513e3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libass/libass9_0.15.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liba/libass/libass9_0.15.2-1_arm64.deb
     digest: f5fb080fb946561c37bc11f0fca6fa0c0231c6506c0e05c19e60b0ea2f3c61b7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libasyncns/libasyncns0_0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liba/libasyncns/libasyncns0_0.8-deepin1_arm64.deb
     digest: 6752ef532df114ff1b95a8755893ba10430d8dc817d55e2a290f1dc786f5a491
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-client3_0.8-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-client3_0.8-5_arm64.deb
     digest: caef7cbebe662623b30149c2a4301d2ffeb03071e545f030bb0cff9ba881d2da
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common-data_0.8-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common-data_0.8-5_arm64.deb
     digest: 5995162791c2d06696885bb9a0ba3f160071b28a810b0f0e68f13fcbb6e83fc8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common3_0.8-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common3_0.8-5_arm64.deb
     digest: 811cd69fd19e3765e96a76121722a3ed06966590e529793cb311dd3c0e27ceaf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin0_arm64.deb
-    digest: 83c6a24d4241e6370217c5e64fee07c51a4702c883412a4348b8fd6b8f272391
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin2_arm64.deb
+    digest: a4265ed3740370d970cdedc1f63bb079ee703878f7b70093a54fb73a4ab35285
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin0_arm64.deb
-    digest: bf6905458722a383dbdd69c2fe894b4d7d842d309713d21af9a8bb6a06aba779
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin2_arm64.deb
+    digest: 8d24a40a05ab5ff7dee8d5180acb049c984a18dafd632ffa23bf1c02dc4c1d0c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin0_arm64.deb
-    digest: 5b4fd7c461f9c6cd228e238f1a4587b336ef3428c7d824a4548daeef1d0044bb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin2_arm64.deb
+    digest: c1aed93e7d684d49f52f650f8af8a954f1137b24fd037573cff9302c05e65779
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin0_arm64.deb
-    digest: a4002f92ed4fa95538f098a3091a817b06e55fee12254c418f81c69656389628
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin2_arm64.deb
+    digest: e7fe724dbe16720b277180ca9eb89a894aa5bc92a8f51e54f4efca1ffd77285c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin0_arm64.deb
-    digest: c19ead041d82536839e168daa2739df61394046648736559ff840c42f328f08e
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin2_arm64.deb
+    digest: b309056f6e2f2b4d21606204ef7d585b3c087d8dfe7d88d79f46312a9f555f2a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin0_arm64.deb
-    digest: ba6646eeff6cadbf174105dd83dbb24806ccf92556772928f9d3a06d9e90ac3c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liba/libavif/libavif16_1.1.1-1_arm64.deb
+    digest: 81c56b58c9dab77a956155f45d7906fdf6a233bf28db48ebe858eb503203cb20
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin0_arm64.deb
-    digest: 4f26322eb48a311324e5473896ed167ad1f281d7266b4a35034fee1c56f4f62b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin2_arm64.deb
+    digest: 536f2812edf834c3cd7c6231283086fb9185f8cdd3871a06e84061e8e730a1a8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin2_arm64.deb
+    digest: 5d0554f80e21505d1c8f016ec911de7adbf3692150995243d806c68af667591d
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
     digest: cac541f3cf746d006b71a08f88364b6743222b8956fda9a7cbd35ffb1cf32ed9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libbinutils_2.41-6deepin4_arm64.deb
-    digest: a8b2e62f7a5b915def9b46d968118d26cf25df7695e28d13a6b1d58ebb6b400f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libbinutils_2.41-6deepin7_arm64.deb
+    digest: f3a6cc55f4f51a453f361aa91f3da7497d15c27001d779937952f2aea946393d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lapack/libblas3_3.11.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lapack/libblas3_3.11.0-2_arm64.deb
     digest: 3443bb4ac1a9dad808977f7f9e712efc54395f408a054a3f838b37a84f2742bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid-dev_2.39.3-6deepin1_arm64.deb
-    digest: a86d6e3229a0af4e39de917b5c49ab2b228ddf5dccd6e841a8944d19e62495b1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_arm64.deb
+    digest: 70ce30db93ccf7870f384aee1946b51da113cf55c7b046c443e8627d35cf73c9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid1_2.39.3-6deepin1_arm64.deb
-    digest: 9956f16990e98ff4a62e1730feec46eb2d57e4da93b9c138514423f593f272ae
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_arm64.deb
+    digest: 4bcb4a5b87eb5953643d6afbe829641df4d4f68a3fbecd978c6f5e3e61c6dc6c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_arm64.deb
     digest: 321b50e4ee0efc4aaa9e67168e4b88216733e1c012d269e6e9f2c04941a66ec0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
     digest: 016574d411e89311351ae6117b766a6bfa1ef7c0f49a4e17601200a33c2a19b5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli1_1.1.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli1_1.1.0-2_arm64.deb
     digest: 982215712f2faad9f502b5d82d60152aab99acbef30457c9839988264a7c9190
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbs2b/libbs2b0_3.1.0+dfsg-2.2-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbs2b/libbs2b0_3.1.0+dfsg-2.2-deepin1_arm64.deb
     digest: d008562ab238bc9339d89c40871cd2fec7d1ce9c7306f894c4c7b6e26fce884b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbsd/libbsd0_0.11.7-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbsd/libbsd0_0.11.7-4_arm64.deb
     digest: cb575189104cacfa40cd228b6fb11f4a90e1c2f6b258e1627c843ebe5cb36f09
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_arm64.deb
     digest: 0728bcbf280531a397947cba90fe861f3fde48a5811736509e2075c1f832dee4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
     digest: 502bf30d0f5d2a06d33495526cb4f5f7929623e87ed3c716aafb91f29565c1c3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc-dev-bin_2.38-6deepin7_arm64.deb
-    digest: 03dfd6ed282ba7086528a4d17621f64ddf8c2009cad2397379579be1fb678a3e
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_arm64.deb
+    digest: 6a0003821a9d50b196b9b9f38a5f1f60de910ac24d61208b457cdf3707e66f2c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6-dev_2.38-6deepin7_arm64.deb
-    digest: 5e337ca9bd7ca1a8e23ae5b5063e80f21d13d1abf9ca523e71fba78c607332a9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_arm64.deb
+    digest: 4c44dbb55a5c867b1116eb01c650066512ccd958d2eab84fda139250c8c5f65d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6_2.38-6deepin7_arm64.deb
-    digest: 22797cb5249c2a072b970159b606dbf4b6218e20e37b014b6a22bfc41642d6c3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_arm64.deb
+    digest: 2421a632cc90d03e652d8cddf07b614505a981adf16e40dc177b832b3d3892ca
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cairo/libcairo-gobject2_1.18.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cairo/libcairo-gobject2_1.18.0-1_arm64.deb
     digest: e2e55ba2dc67fc1df591b0bc7786865bc2db3c2fae937f36d9c31584e019fa92
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cairo/libcairo2_1.18.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cairo/libcairo2_1.18.0-1_arm64.deb
     digest: 419fb5f555309b00910e51c807295f6ddf931894df73e0de206d855740333042
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap2/libcap2_2.66-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libcap2/libcap2_2.66-5_arm64.deb
     digest: 6f196062b90716256bf2a57e919d18c74eb6cc19d98f1cf88e603cbd8d68b188
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/capstone/libcapstone4_4.0.2-3-deepin1_arm64.deb
-    digest: d0b09968beb885bb5386216c43308a721db3ea07f4cfe558e977979ea1624589
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/capstone/libcapstone5_5.0.3-1_arm64.deb
+    digest: 69c419efd4b58c93eadb583e4d1465b9d91355a3eb599c3d6ac0dcfacb685d8d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
     digest: 39486fac0b8bd52f8641e2586befaa00aeb6a03106f3b6c99e64039c8e7b4a6e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cjson/libcjson1_1.7.15-1_arm64.deb
-    digest: 2dae901869e9a50f832d6168942a0c8fe6e643e4f9f56f161cb212a6ad59c233
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cjson/libcjson1_1.7.18-3_arm64.deb
+    digest: 8ba115a3752e7445e5c684614ae1a057419721a601c4017ee0cd442414a3231f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_arm64.deb
     digest: 544520612dc6697c5165126dab9ec2cabae88d42678aaa5a762674559a6ace92
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_arm64.deb
     digest: 167b974f0fc6e2547f68b5b2f7add39efb575f3f0e36a14806fd779216d7b62e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/codec2/libcodec2-0.9_0.9.2-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/codec2/libcodec2-0.9_0.9.2-4_arm64.deb
     digest: e4e8c548add35a8933a2a2cba6faf36e5822e227eb8d582fb7f09f3444d154ab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_arm64.deb
     digest: 32582278847580e89bdab5abc948478e0dbe3c24959ff2b15d9af5a46cb111fe
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_arm64.deb
     digest: fbc8cb951f3a23a095dd6fc672832bb8dbfdde96725939bc3dc162584a9f2efc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_arm64.deb
     digest: 037584e67001e5de6f78c0d3acabe70a7b2e7dc592252ae0d9397c263c41c9f4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf-nobfd0_2.41-6deepin4_arm64.deb
-    digest: ba46c758512962bd4c7ec4b8a7856417ea16fd6b8eb1687b446adcf6afb83f6b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_arm64.deb
+    digest: e34f53bdde8f49dddfcbd7daa63d613f5c71b92d0e79683b500c8bccd0866bb4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf0_2.41-6deepin4_arm64.deb
-    digest: 3d0da144ea8f7405082586db7756754f3068936428e06abab6cb7b8c826c8199
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf0_2.41-6deepin7_arm64.deb
+    digest: bab638b4aed73a4a9420a17ec27f3120ff10404c3d3e6e1a66fe023fa8a44121
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_arm64.deb
-    digest: 1557184d0ba255ee05b5c929396c4c925e10782f9cba74f3514f96d3bf581ca1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_arm64.deb
+    digest: a72f4563335d016cf4a0f8bbf5d26b0ed90f554a8ff2e6b9701967daa114569b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2_2.4.2-5deepin1_arm64.deb
-    digest: e9754a238fed47dac0e3e6255697563494f6ca4b58313bc7f6183d4d0995d32f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2_2.4.2-5deepin2_arm64.deb
+    digest: 534a9ba35f69f93d103edbe1736a7ffe7f2b84a8e3746889d78feadfaa507d22
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_arm64.deb
-    digest: d0a1e93cb1b63e0040b50c924c8a7c9464494ef3547447913584d0a62999590a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_arm64.deb
+    digest: 01509b9730896972e09e937a3d27ae4c9cea9b536b0296db37af464314490934
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_arm64.deb
-    digest: 12003d3e5acd0a1c379f81e075b6171fb784666763813528fd18189beea9735d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_arm64.deb
+    digest: 24db7f1a3f57d436a532a215e32df71a9df3ff19731d81c7988c0d77df86b692
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdatrie/libdatrie1_0.2.13-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_arm64.deb
+    digest: 4fcab53e5e791e65cd9160e0e77eacec106bce0f5ea0567bcb1387b362101488
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdatrie/libdatrie1_0.2.13-2_arm64.deb
     digest: e0c2cfe68451fc2f325066806a0e158eda7d61a2ffacf988e248f8cd61844738
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_arm64.deb
     digest: ed96097c7b23c3224e448f430d8a6bee10a2ec736088eca565b99146b72d82d5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/davs2/libdavs2-16_1.7.1-1+dde_arm64.deb
+    digest: 1a7dd44072b582c34e49f0972fb97c2e9b861ee03ae04c660678c09266b9afce
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_arm64.deb
     digest: ee20a140ab90ce9fa2ab045eab6195b426d5c441459a788e15966687a1d57221
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/libdbus-1-3_1.14.10-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dbus/libdbus-1-3_1.14.10-3_arm64.deb
     digest: 7b736881f8730994a643683bec66e7105c23d0ecf5e407e21c427faf2428c237
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate-dev_1.18-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libde265/libde265-0_1.0.15-1_arm64.deb
+    digest: a13a2d2c3ba13b8f1d8bfd8b657665d3b1666c6fc954c16c8cec972e5af01c47
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_arm64.deb
     digest: d5e52d889f15c80ffe7214c06605d831488c2650ec00d7c9eb9b50ebbc108133
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate0_1.18-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate0_1.18-1_arm64.deb
     digest: 044cb710b30d6019492308216ead89b7a7357e4e63a2574929a85a167967f515
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm-mount-dev_1.3.4_arm64.deb
-    digest: 013dd9b04293671f6bd779ecf3b63e3ddef0517b1d3f61fe026b61793fe34d63
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm-mount-dev_1.3.9_arm64.deb
+    digest: 4d9c4e4039934a41818f2301d50449eb0ad9f2052f1e01172cebf8f85d55c0ba
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm-mount_1.3.4_arm64.deb
-    digest: 82b69fa13d4c57cacce14463e1fbef27d789b7224afafe4f9ab0ebbba3a576bb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm-mount_1.3.9_arm64.deb
+    digest: 1c06dac2351b2f57554d2a8997b862695b4bcad423648216f75e380bccb0ebab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm6-mount-dev_1.3.4_arm64.deb
-    digest: ec3877ad5f4615db8007c7831770105c1e8f67a5b04e6fa5f650c3e9783b19ed
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.32_arm64.deb
+    digest: cf26e08fe67b9866846e171dc1a1a73cf7b2bfcf6de6d7d71eded0c2e6bb5273
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm6-mount_1.3.4_arm64.deb
-    digest: f182df83fe3654a2c0bef8fbf2e478c47dcaad73805593101421fb2ad0a806ed
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm6-mount_1.3.32_arm64.deb
+    digest: a30a89229adb01f626642f3637d8f89e3fc572c87750a5a4744c5311f592b9db
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
     digest: 78e9245e377c8f61009cc60d2b55001aaddd7b656fceb916b3ba8f07344251b7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
-    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_arm64.deb
     digest: ea011d2a1b77d97ea5d538786dc3aece9a24e317489827cf5e4dfc6032cb61f4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
     digest: b8289eaa6341a8493f4c191a45165fe944248da69f675d09005a29058e7ae5a6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_arm64.deb
     digest: e1b45eb0e3b7599cb1010679fa97507f0c3a814d00ed37d7912fc2bb95270e35
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm2_2.4.123-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm2_2.4.123-1_arm64.deb
     digest: 6c900feb79b1e5f847a5b9f53c6bda3f6aa12a9abfcf106f872a3812ef78bbc4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core-dev_6.0.25_arm64.deb
-    digest: b8693fdd024188f811597e28d7d7e03dba17e811711883716b7ff76376801e02
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_arm64.deb
+    digest: c9472936e80c216fd09a2e9c5123ca1cedea9432294261178883d8a952c7f99b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core_6.0.25_arm64.deb
-    digest: 3442eb4010d5176f27e5062d6fb07f1d8afca80c59375f9c37aa65eea62a727c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core_6.0.38_arm64.deb
+    digest: e8a717160caa08f795f1f567ec57d2b661814e8084fe8d860d94f56a3e05ea47
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_arm64.deb
-    digest: 5b30d2ade934bf6b80f4fd6e9eecf7549d44e9df70c8e97266b720811c90ffb3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_arm64.deb
+    digest: a80d44bf31660feda6ed1208ff5521335b7fb201da93956945359b0549a8f7b8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui_6.0.25_arm64.deb
-    digest: 34a82a6a255c9d9ea99e12432c047cf0efafd61101a90ef319689d4940fa9767
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui_6.0.38_arm64.deb
+    digest: 1594a4003d6dfee6d91d2ed7a0af502f4ea38504631401f3a1baa5860c70cbb6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log-dev_0.0.2_arm64.deb
-    digest: 0e714a576b19f5a920d224ef1a1877e93c4b8aea1e49eba99df7316c72319910
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_arm64.deb
+    digest: 0d2a9910f59a67a92ae67c644d2a78df0476a710a1bd4284869a3e3a993d9734
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log_0.0.2_arm64.deb
-    digest: 67e687906a183922d6e510666f7637c45946e68f61bc4f0ce7fc2a840aaff3e0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log_0.0.4_arm64.deb
+    digest: 01a779e198b225da4069a480677d4e7c816f04309c3ce70829411b4bbe8b3a96
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_arm64.deb
-    digest: d77647f1b8ddc312041ad612cf3c1343bd3fbd8193b2a72e8bfae9ba64d4053b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_arm64.deb
+    digest: f1743536d71c1610937a548699d0bd40692b3ce34ce5ea591c4ad919d6ae1b6b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget_6.0.25_arm64.deb
-    digest: 146b21a131932f6ced35c1b74c912ae9794b9bdadbdceff37babece4c9eb90bb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget_6.0.38_arm64.deb
+    digest: 85c4766d67def86998b406625bc1a22eacf910a131bf1006735af2897efe3e1b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_arm64.deb
-    digest: 11cf667515ce2bcbc7ac6ae27bafc324f6cea17772d8e7aa43cfda6288713e67
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_arm64.deb
+    digest: 766177ea4c8c2a5cfdeb1b3eee5b31b62b72be9aa06744dd7a6542cc888c494c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkdata_5.7.5_arm64.deb
-    digest: b468b48c1f8fe5b98f4294edbe3b757726fcefbfdfb79ab54d3adffc293d17cb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkdata_5.7.18_arm64.deb
+    digest: a34538990a42f2be5b28b198b3b75d96ab6edfc9b850824c8ee222305f42c699
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libedit/libedit2_3.1-20230828-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/duktape/libduktape207_2.7.0-2_arm64.deb
+    digest: 514955337167c41ebe2aec0cab0cf30ebf6f47cb7893b0ae1db20590c3d29ad9
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libedit/libedit2_3.1-20230828-1_arm64.deb
     digest: ba394c531b520e3ee365d29c127505bce3554df15885dd53dbe9a9deee191326
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libegl-mesa0_24.1.5-1deepin2_arm64.deb
-    digest: e724f5cd1b97bacc4f2166cd81c970017ba8c57279c5d4879134ffc6b4ecd407
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_arm64.deb
+    digest: 426be89c01067a002f4d4873688297fa1444a5a3048baba3eba418febf47d143
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libegl1_1.7.0-1_arm64.deb
-    digest: e545d436bd07777713063cbbafcb75c2e2581d2f04ec697862380caf2074c471
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_arm64.deb
+    digest: 0b59eeb273489ae76f00c5192fac7d4fd7ca4db31b0f77b1424cbe6a70fa20f8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/elfutils/libelf1_0.191-1deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/elfutils/libelf1_0.191-1deepin2_arm64.deb
     digest: a3926debe22263846a70333372425e555a2ed796d44b8fe87eecd8116dedaf2c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_arm64.deb
     digest: d2e39d9eadc5fc955478dbe6f1a66627a770ffbe8f165f1f8700934f8263e576
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_arm64.deb
     digest: fbbe2a51d531e25bc6bd01b2a732ea480411f065940a2b581d47dcd98ec7fcc3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif-dev_0.6.23-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libexif/libexif-dev_0.6.23-1_arm64.deb
     digest: 48a63cf58da3e26ee5ef2cc4542a4bf43c828f10e563993ccbe914d748240696
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif12_0.6.23-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libexif/libexif12_0.6.23-1_arm64.deb
     digest: 0286b248296c6e66e209cb3f9b365e8133ede3911089ee68d8030a2a5212a8a9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1-dev_2.5.0-2_arm64.deb
-    digest: 06c39c3e78aba8616d2c7b43d7cc33cd60bcbfb7bc362e997b2bce1b24fd7460
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1-dev_2.7.1-1_arm64.deb
+    digest: c0b33ae628f9f7a2be567fc237b7c3f3c2ca1ef33360eff1718977c72d414a38
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1_2.5.0-2_arm64.deb
-    digest: 2c66c6eb5bb8e1f8dbb6449e3948e3a75add01415561c10a89ac1b238a9a24b1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1_2.7.1-1_arm64.deb
+    digest: 5cb7b15a898bfb29141bc121435c82871d5ac497035fae132c37df32e69eb388
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
     digest: 44b6f1a9aceead0cac121cfd13cdd9a529eb2b60522f8482c7dc4f67432d1904
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi8_3.4.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi8_3.4.6-1_arm64.deb
     digest: dd69564a592502ee67ae166c13d6d6a0a62021a47c2f3154589ed3bc62fe6b52
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer-dev_2.2.2+git20220218+dfsg-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer-dev_2.2.2+git20220218+dfsg-2deepin0_arm64.deb
     digest: 9d46f1ee87122acf5affac4ec9ce212cb91136464e9859b94fdac571d68c84a2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_arm64.deb
     digest: 5417b1bd3affb161bac0dcfd46df7ff9f431030d084a23652b9f04ef51a8ccf4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/flac/libflac8_1.3.3-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/flac/libflac8_1.3.3-2_arm64.deb
     digest: 8a6209363d55641f2e981b054bf9ade88af6c0de9b966107de96d1f6a1a792dd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/flite/libflite1_2.2-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/flite/libflite1_2.2-6_arm64.deb
     digest: afdb9c4b176b413ca36eece261a428324ceb9dccd0263e3b9faa673648316c0c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_arm64.deb
     digest: 65fdd731df6fc44891d7c77da9d16717fd23df0d4251085dc0c43b4313e903eb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_arm64.deb
-    digest: d965d2bee11b03bb0b86e876a78f5f3b3f5ae3b66ed3f74a8baed4f1a2edb058
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_arm64.deb
+    digest: bbbc845e4a6ade7d6fe9d7147e9891f1bcb60c971ef8d0ab7c253d7089fc1f8b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig1-dev_2.14.2-6_arm64.deb
-    digest: 6a01f4bc5a0369c10ce0021b23b3a4985c54672a05714b17b736f364f37805fb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig1-dev_2.15.0-2.3deepin1_arm64.deb
+    digest: 9c78753391c48f96ee3f099ad88d28c262f96c1b0f295c7d04e4c941d0e588e9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig1_2.14.2-6_arm64.deb
-    digest: 2088236fc9be4b0b363707d88c00eac4c082aa64f00c10f869c33884dee5772b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_arm64.deb
+    digest: 82b4c63adda13ee062e7cac011f49859d31b911c5e64678d8d1404e5da3a92da
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libfontenc/libfontenc1_1.1.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_arm64.deb
     digest: 222148f71812a1026457b2d86edfe68eac087f0063ab5e8159439e3d11793425
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_arm64.deb
     digest: dc1cc27076ac172ffd75b7fe88d5889be20c84eb0dbbeeff2a29f24c84d965dd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_arm64.deb
     digest: 5363e03d3eb944c73fbc75e303cca2814077607480b2e7f7c9015d70aee31a27
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fribidi/libfribidi0_1.0.8-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fribidi/libfribidi0_1.0.8-2_arm64.deb
     digest: 270c9b8a81001d31d84760347ddae209ac6d952e7e6b3a7c0b3ecebec2a7838c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgbm1_24.1.5-1deepin2_arm64.deb
-    digest: f43c0fa547c29116b1343f099253a24855539412e6b9a5ac3a80eb27b12cc01b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgav1/libgav1-0_0.17.0-1_arm64.deb
+    digest: 5cc11613698080e75822a0e20d7d6ad7e2fac8058bfd00e3fe5c54903af1fc1f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin3_arm64.deb
-    digest: 79f939554ee45564dc0ccef376ce412f1f7a92c1d0d953e61c65de40b1b484e5
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_arm64.deb
+    digest: d16ede274574a5ede58f7f2318cf33f2b0074ca31845097ce633393b87b3caf0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgcrypt20/libgcrypt20-dev_1.10.3-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_arm64.deb
+    digest: 6ed2090f5c442f6dbccfc825cf0303e42954ee2db527d4605435c09862a43d57
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgcrypt20/libgcrypt20-dev_1.10.3-2_arm64.deb
     digest: 63ef7a756243b2726138c2c959438e684e87d9bdcfcfb9b42f167ca95d4a6df8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_arm64.deb
     digest: 86a50d1b85ed82764e7f356b2e3e5543149cc778edca29dae9765ddbc3789d9a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm-compat4_1.22-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm-compat4_1.22-1_arm64.deb
     digest: d7dc16662376708bef84fd84bb79a769c443cfb2ce69e608c16c98f85080848c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm6_1.22-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm6_1.22-1_arm64.deb
     digest: ba32e543ec6296045f2680d23a890c315ab00c4a34201a7a55d3f72384518930
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdk-pixbuf/libgdk-pixbuf-2.0-0_2.42.10+dfsg-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdk-pixbuf/libgdk-pixbuf-2.0-0_2.42.10+dfsg-3_arm64.deb
     digest: c6dbfe1b5eec83470e14f8a5bfef5c84aba9b68e566897c184c042b3dacb62e8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdk-pixbuf/libgdk-pixbuf2.0-common_2.42.10+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdk-pixbuf/libgdk-pixbuf2.0-common_2.42.10+dfsg-3_all.deb
     digest: bcf7a388b33a76d765b3db4dc10fc0a946086bc7409228898ffbcc522e9dffc9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgfortran5_13.2.0-3deepin3_arm64.deb
-    digest: 17342f43614a4a53015c7d09540b69d5f494b1a9091a5ab055ab048bcb7ef6cd
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgfortran5_13.2.0-3deepin4_arm64.deb
+    digest: 3dd3c892014a1d9e170add45761bff2db8315d225da55ef0abbdbedf9fb95232
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_arm64.deb
     digest: 67fb7f1a7f5bf707a6dcead0b5b044c1704f454c2a51050fcb020ea9b1317913
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl-dev_1.7.0-1_arm64.deb
-    digest: dc7f67af872323ece8087a4dfdd6106b9faa71d490447003ef964043066bb2e1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
+    digest: ef605bf23fa580844d6a5faa61caf503f3825bc69acc9e30dab40689116a2627
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgl1-mesa-dri_24.1.5-1deepin2_arm64.deb
-    digest: a657f11469217681177afb16fe5189e4613f33781abfa91ea772bd0d92fdd185
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_arm64.deb
+    digest: 9a47b3a7b9568d735534ae7c949ef5bed2ff18975f0812d71acbd163c6f5030c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl1_1.7.0-1_arm64.deb
-    digest: 93917761c2f8cdc9dfec793a9e6aaedd05973aca3a19eb74f2d33e926c0d7c3e
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_arm64.deb
+    digest: fb58114fedbd3864291f2a6c3d7d5d1b62476a3532e98926774727988411b3e4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglapi-mesa_24.1.5-1deepin2_arm64.deb
-    digest: 90c916a34445b4fdb459cada39bdce3efce4b8048576295952016b5b94dd35ef
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_arm64.deb
+    digest: 82508b674b91518c3217f0d2f38ee78ed65a15fb6acb49420076d368e338af7e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_arm64.deb
     digest: bcd728365b170a9b2598f2c3a13a7b4b27bcbcc5c966610496f7a66c13d93394
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_arm64.deb
     digest: 5306892a7f1ea756d7c63a92aa346da632b78072b44ce30cf5f0567e22d7d39b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
     digest: 4e75a1c9e56c81ed2c1737e3e6fe590163a77ff45179101a4fcfb90b4c0d135d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_arm64.deb
     digest: 4a16ad0b756f1336f01999c1c55cd69bb576416f985bf0445c5f08cbc889ab96
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_arm64.deb
     digest: 894d0a7818c905544b7114e8c7268a3c8dded4395d3d859bdcb774e546e7ac98
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglvnd0_1.7.0-1_arm64.deb
-    digest: 3eaae06ffb183872a95c2c966050099ab9824b50ccab6802c1fdc95a7f6b25d5
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_arm64.deb
+    digest: d4371fcc299ddafc3230a139ecc4475dcd0b0dedb2746d46da1de9a951bf749a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx-dev_1.7.0-1_arm64.deb
-    digest: ef37a90a94a9e4ba16352663b2703df57e3816e406eec0225e6339a91ad498fa
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
+    digest: ff60370ae98f4515ea9eda99af3ab9d468b53b23bdd22f4b51abf8064655e810
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglx-mesa0_24.1.5-1deepin2_arm64.deb
-    digest: 32dca1addaca5c867106d908bcd58e08ecd1df65447a774d0a41d338cea8b76f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_arm64.deb
+    digest: 9388fddc0b068998f436342e6d562cc6f5553f34dbee9e86a51639a24d92dbaa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx0_1.7.0-1_arm64.deb
-    digest: 41d194b986ca2e07171948e6b0d09b2b51f068117ae2f0bd11105e0c7cae8d7f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_arm64.deb
+    digest: 0e206a1e5b7a0a16abefac96b5774e2740c0446d988488ba3ca3af616a4eb3f6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
     digest: 6be533a6b6cb8b661664fedbe661b316edd0bee46f51fe598d300c2efaf95728
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_arm64.deb
     digest: ccfd8cc3ef27d1a32ddb9f3a57f05ee35576482f640532be70dddeb98395193f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gnutls28/libgnutls30_3.7.9-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gnutls28/libgnutls30_3.7.9-2_arm64.deb
     digest: 88703de5a0a7bc5c03730e2de61ae40894fa6f4d6d1f89def93ec44055c6771d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgomp1_13.2.0-3deepin3_arm64.deb
-    digest: 894e50ae04621a65bf49f140666a798f2b39ccc22b980a588d056ad20bcba348
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgomp1_13.2.0-3deepin4_arm64.deb
+    digest: 5f619ecbd600ec16a9b65db818e1687594141a86fc843f971f4106ef3d12343d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error-dev_1.47-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgpg-error/libgpg-error-dev_1.47-3_arm64.deb
     digest: eb8cb105f5785ec8abdbf4eaec45302aac65c04b0a0356e21a705f9bb944ac20
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error0_1.47-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_arm64.deb
     digest: e67f481218dd4fc506bb97ebccacbbd39e5420caca6c71ba011b1efcc0f1f5a0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libgprofng0_2.41-6deepin4_arm64.deb
-    digest: 24f98baf5394f7976a7f9f41b9acf40df8983090e1f24b35fa66a53a0d10e0a9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libgprofng0_2.41-6deepin7_arm64.deb
+    digest: 640d2c1b93bfece28cb70c1213450ace0864adb34d288b00c6108bb5bc5cfdeb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/graphite2/libgraphite2-3_1.3.14-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_arm64.deb
     digest: bf8f6e987ba71ddd6161066f0828663b4ffc4af78acbdbff04b71e5c2b1e207f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgsm/libgsm1_1.0.18-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgsm/libgsm1_1.0.18-2_arm64.deb
     digest: 433078cb4127d8b89dbeaec5ba11ada27bb88ffb3e6a23bbfb882fe6e6a253f8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_arm64.deb
     digest: e09ffd8646be9798699b1324b7d6292382f7c8c3665fbd0a6aed4536561ff06c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_arm64.deb
     digest: c952bbe64709d944821b367c5c211af4447ddb59f58f1c2b2fa264ab234890bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_arm64.deb
     digest: 97b751c1e82af92962c3688f1bc9c0cdded3ea5bacc43d478f0780d22f8d6e6d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
     digest: 1af178c5a43fc3f1a40d90a4890bf8a00372449495bc32e6ddd82165927b3591
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_arm64.deb
     digest: b50ec89e04006c13764afac632d9fd4793c187d20fc54670018f76241fbe8495
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-aomdec_1.18.1-1deepin0_arm64.deb
+    digest: c2b72a9c15f9e8af99c3b24255732179e4a98d3a50b995d3ef4e2cb2ff61f245
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-dav1d_1.18.1-1deepin0_arm64.deb
+    digest: e62c458f9a7fd60bae178b8387c7fc4610a59c23a95c2715b0a42f3cf5732abf
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-j2kdec_1.18.1-1deepin0_arm64.deb
+    digest: b6a1f3dd596fac168cf7e381420b36863aea0b922e53b69fa35a3541e8c0ec19
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-libde265_1.18.1-1deepin0_arm64.deb
+    digest: ccf7f3acbcf1edb65d19ef98159421f1d87ee56048bdc7c7253812d62856e3b6
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-x265_1.18.1-1deepin0_arm64.deb
+    digest: a55ad10eb2a51bcf6782df7030940d47a0f65c54219a3ae6cac1da63344e689b
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif1_1.18.1-1deepin0_arm64.deb
+    digest: 068ea1e11c4877204aab8777f4909276aba3bb09cfd1813c358853ff29f85700
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb
     digest: 0caf1aec7651bca8c8c0646eb87b064e522fbdc654edebc8c7e10e0a12f77c94
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/h/highway/libhwy1_1.0.7-8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/h/highway/libhwy1_1.0.7-8_arm64.deb
     digest: 0fe21fd8b6d8fcd5f72a3fc4a1f69df1e5dbfbbbbcef34f24e4c057bb42bf98a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libice/libice6_1.0.10-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libice/libice6_1.0.10-1_arm64.deb
     digest: a1910186258a924c4367673da786e7200f32e54ea54f65e2b885e3e451197e0e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/icu/libicu74_74.2-1deepin0_arm64.deb
-    digest: 1c4e3bdde2f6491c580aa9ffd47e42c5ac310614b9f042f9bbb40a10ec5a4367
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/libicu74_74.2-1deepin4_arm64.deb
+    digest: d5bc8f5eb78bf50444fec39a361f43c52b13d13a9c2ea45c272b05d1c8afbb5c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libidn2/libidn2-0_2.3.2-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libidn2/libidn2-0_2.3.2-2_arm64.deb
     digest: 66be80634fd2243b4741bc12bf02ae140d4af694da58e23415130322eb8e17cc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/imath/libimath-3-1-29_3.1.9-3+rb3_arm64.deb
+    digest: 3600b6792211ea1861c439a136640ed35a7297f824efd4d033b512f2ae245e93
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_arm64.deb
     digest: 0c312f699653f007733afd743554d7200cc43d9fa3d74ba23622165f75cf23f0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_arm64.deb
     digest: 18bc7373f096e8017e59bfdeb551589ca0fe341dbbba016b2d648914770fe3e7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput10_1.26.0-1deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_arm64.deb
     digest: 9a6aaef5f1bd4c34230d194a5d13354b0e614fe330d77bee0c293b9a627ca752
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jansson/libjansson4_2.14-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jansson/libjansson4_2.14-2_arm64.deb
     digest: ef540161f4618cca67a1e5c14ff7e1531f85b8066ced54f873e249bbd89287de
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
     digest: d554b612e70c2416c6d831b575c1bc1c3f4c0143454ada80203e08f918143e77
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_arm64.deb
     digest: cce7a06a6c026ffde094ac6555c1feff1763121dd88bba0d2977bfa59cdf403b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
     digest: 7eb0cf9914476bdf669f0087c7fcba1d0cfd49f9697804d72fd2869e6fc3ecf6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
     digest: 4355b250325f762945b8d68dbb1e39fd0847230f9bf56284c35d4a69aa819e5a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_arm64.deb
     digest: 127ab1d74ddbf0f1620b8a2b907d9160a359079c49fdef8e07ee6ef795b502ff
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_arm64.deb
     digest: 05fee10e849eed1621ca9bdd41b4fca3f6dd342a477e05f2eaa182f57f8319a4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libk5crypto3_1.20.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libk5crypto3_1.20.1-5_arm64.deb
     digest: b25339e6e18dbdd4ea57d508158d999a86e539045789a5885667c6d6ecb81c9d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_arm64.deb
     digest: 91223dc8480403e5770986e2fd73b8a92ce1e74b9f52b442616cc3ef0ff59dc7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5-3_1.20.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-karchive/libkf6archive-data_6.10.0-1_all.deb
+    digest: 4ca53184e68be4a5b171d50896da08b26a634ae6f57a14cc9384ce4fb025abfd
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-karchive/libkf6archive6_6.10.0-1_arm64.deb
+    digest: 026c6476f6ee372ebe539356faff56660c88832a2e5988ea1f651dc11748eb5e
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5-3_1.20.1-5_arm64.deb
     digest: 32e10af6aefa67b71ea312c55b8f9a3f7c016d1edc6bd30907ed38ec27aef8d8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5support0_1.20.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5support0_1.20.1-5_arm64.deb
     digest: 50aefca2b75fd2478e62ac9c7c5571e7e510ffa697207e78e29bfa6d40f3271d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lapack/liblapack3_3.11.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lapack/liblapack3_3.11.0-2_arm64.deb
     digest: 8f5adb747ccc2f41b64e43fca35b41deb3f597dacbe91c7ba180c13fe11a23e4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lcms2/liblcms2-2_2.14-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lcms2/liblcms2-2_2.14-2_arm64.deb
     digest: ce6ca7ecc06a131d36a0cf01b7e0a2774bc0b75abc8c29aa432a6c6ed2d2ba3f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_arm64.deb
+    digest: d055aef7a24526618a27b82b62d9a220e1fdb93f5cb0e49bc1b083693a43b607
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
     digest: 1084fe140088878214dd72f6c8ebf4f4835b83f542ed443ce79cc2f43821d6d9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc4_4.0.0+ds-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc4_4.0.0+ds-3_arm64.deb
     digest: b2510d375b08fc5b324dcc39a234971675c787d7b9a5cdfcbd8fbb414f9549e7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lilv/liblilv-0-0_0.24.12-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lilv/liblilv-0-0_0.24.12-2_arm64.deb
     digest: 8051b7cde63544279cd3c2e86653aabba8d26981d1d747ba00b0074fab9cc31b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
     digest: 82d472f20711c3b0eee4afb2b8bc8a0971f6fb7ced7612317f07597768e6ddad
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_arm64.deb
     digest: 7faa4f0b4e3c95e4f0fa1ef4bc52329dbed095bdf87d495d0f8c21b934c78319
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lz4/liblz4-1_1.9.3-deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-19/libllvm19_19.1.4-1_arm64.deb
+    digest: c31aea104e1ce9b782ae8525506c3fb4fc8e9a2f0f19ceebc00d28fd69214fa4
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lz4/liblz4-1_1.9.3-deepin_arm64.deb
     digest: 9de94343c0eaf87ec1b298d8f5dbfe42f06316f8dc608968e0718437035c1ee9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
     digest: 0e91a2383f5ab980fb06cb347c66dc6b6480a7b76cb67ded44bb4b183f295d21
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma5_5.4.5-0.3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_arm64.deb
     digest: 89bd6cb9e9f756b25b0e973012a88d2df0c273c0dc44ab0cbc2a0bb6b773ba55
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_arm64.deb
     digest: 53601fc7779c338a250335a69a55adecec0f0f6f16f0fb7ccc69437188c01947
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmd/libmd0_1.0.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmd/libmd0_1.0.4-1_arm64.deb
     digest: a1f7a672a07a62b85c2651bdba09552498db565da6ecf5748be618812124acc2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
     digest: 8b58cf124cb0a435765f6cbc7bc8a59d431a8f84babbc2956beb1a46b53b99f5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
     digest: 15763cf880b4073ba036e05f2a3b9b46aa43802f9d2c49848fd315a9229d9be8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount-dev_2.39.3-6deepin1_arm64.deb
-    digest: e04e69e0e1079164c9625eeee3c2153f7a642c4dcc270c0e9a0aa359e3127d09
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_arm64.deb
+    digest: 62f3c994934747f7cb43813a34b1090787d0f7471d4c1f0607b2ad476f5f7105
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount1_2.39.3-6deepin1_arm64.deb
-    digest: 34cacc70e4fb7db8f0fef17546f574e900975b0b6136ffdc8b79e0840ba9009d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_arm64.deb
+    digest: ef3494fcc16550aa223cffc70e189fa2355dd5bcebc8b78dc303250063cd7dae
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lame/libmp3lame0_3.100-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lame/libmp3lame0_3.100-6_arm64.deb
     digest: 3362ecfa4b431c335a8833e3c5014f24ea43d6f1f398831c48fa03c2234f7059
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_arm64.deb
     digest: 54405180731f47ec74f3cad85575beb66fa5d8f2bafc20e414f90d1515dd0ba8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
     digest: 17fc6b739d5d25e6139f8786daa9ac90b81315dfde9df401d7a8896831bc1828
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
     digest: 646172dd88b260728ef1da45a78d41c78161a8341d0ce43de738c63f2e4089ca
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmysofa/libmysofa1_1.2.1~dfsg0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmysofa/libmysofa1_1.2.1~dfsg0-1_arm64.deb
     digest: 7b334d29e8aba558029270b847e25a91ccab562bdfee82d09558225eefce2705
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncursesw6_6.4-4_arm64.deb
-    digest: 4919576b45fe077f2b0f1365cafa0abb0cd29232a6bb2ffa4016df8926c64ce0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libncursesw6_6.4-4deepin2_arm64.deb
+    digest: d13327f9f92ee7c7b2784dddd987a3cd1380f176f7b3dc2c0ba8022cbafc8743
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb
     digest: 94f6240b06e89b83e43b85f3ac482f57468f7b78b3a356f692a9a2508b4b62f2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_arm64.deb
+    digest: a4a4ad6f2f5e0bf234331c7e22f12e13b7b5f52f6ee93188517427f88cda3b8f
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_arm64.deb
+    digest: d64740b68d9dafdb6c4cb6fbf944281d6e88036b8fb3bfc228c235b8f3ab25d7
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_arm64.deb
+    digest: 510f2bd3d9d32bfcccbd68838d57698ec80337b5e2ca1ea1273d82733ff10c95
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_arm64.deb
+    digest: 6bbbeeb6977d1080858dfa0fa2d179c1e351cfa01afd661b6b3094c8dea59d76
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
     digest: 06f3609b64811a80941b259736bb1f71a58633df1300b979a4458fd92a3d634e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl-dev_1.3.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_arm64.deb
     digest: f6267e06818bde69c32fcb07f15807e9c0240561de3c4bbe90e1cc4189a12d22
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb
     digest: 08c95ea4d7177490751748ac26160236580dd2351a4e8ffdb57774e7874a40a7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/numactl/libnuma1_2.0.14-3deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/numactl/libnuma1_2.0.14-3deepin1_arm64.deb
     digest: 975f33301315941ea6ff79bd2e9d561f4722cb27ea10138da991cf7c86b6fb8b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libo/libogg/libogg0_1.3.5-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libo/libogg/libogg0_1.3.5-3_arm64.deb
     digest: f38444dd8eefeaff0d041a17e7bd024fb08e056753ffff220c13bf770a023191
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_arm64.deb
-    digest: 4183274244acfc897705999133091b52af3c9c1ec54ed4b67319e9b044281434
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openexr/libopenexr-3-1-30_3.1.5-5.1deepin0_arm64.deb
+    digest: 50b26243cf98b750b89e60a9a0e02b637c695781c1267395f3564f388d26dd8e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl0_1.7.0-1_arm64.deb
-    digest: 84392d66b03e40078cb2fc079e1a3b8bdcc5d6606e24e9846b552ee73e2ffb03
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
+    digest: d52a6102a07d9cff9066f0e3ebd802ab14e119bd1f9a890999be8cfda4c2cdce
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_arm64.deb
+    digest: 74251d10b4940be8c9fe26be6c337af904a1f0494723882d50dd1bcb04189416
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_arm64.deb
     digest: a7dd240a390ebad6e63a7b7ce985a54e2e3753d025f5a040c6c28727e6741461
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_arm64.deb
     digest: 04f4ffdf19ebd3ccfbcbc32489b3fc651ef75dd1b33cae10e5ecb3c8c4287332
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/opus/libopus0_1.3.1-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/opus/libopus0_1.3.1-3_arm64.deb
     digest: c46fdbd130a878dff3b384ef37d302f4c7c72da43b05eb91e07fb62cf9928a6b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/p11-kit/libp11-kit0_0.25.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_arm64.deb
     digest: a8cf0f0f9be1f016846baa4b2d2012fbef8b560dfc3cfa920b3d8ebb920038a4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_arm64.deb
     digest: e0e7f4dc1eec6896e186bf9eb6083a22471d09b5175c5e909400fdc6a84f5bea
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpangocairo-1.0-0_1.52.2+ds-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pango1.0/libpangocairo-1.0-0_1.52.2+ds-1_arm64.deb
     digest: 695d843ba51d24abfe9827eeb6eb79ff0a7df22e015f701921f4402a12e9ba0b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpangoft2-1.0-0_1.52.2+ds-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pango1.0/libpangoft2-1.0-0_1.52.2+ds-1_arm64.deb
     digest: 1731585688b59ca0706d36388506f3a4a3ddde5077a4d5c67191fa15e5593f3b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-16-0_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-16-0_10.39-2_arm64.deb
     digest: b417f72e1d3895f3350645ac7f10859246808db988273031cecc41fbec6f567c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-32-0_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-32-0_10.39-2_arm64.deb
     digest: c50abb1ce61a1a2d6a3ec98848f179da3b9e000672f7278f0f1c865cb998fb37
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-8-0_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-8-0_10.39-2_arm64.deb
     digest: f721d2c4a9224b106c26b793af1f4a0c884184766e8e3d005369b4f265e0637e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-dev_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-dev_10.39-2_arm64.deb
     digest: ba71787ac1c892e4b8fe9aa1544ecd81a7d9436538c3bb28b0d710fc391143d3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-posix3_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-posix3_10.39-2_arm64.deb
     digest: 6bb5a3b25014a1b3d0daff71338861f704defc4a1d7d5a2896b58604716914f3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/libperl5.36_5.36.0-10_arm64.deb
-    digest: efe41ac688ac3c99eb41a36854ac9883e877d0b5f0a52a844b752ded579ebc57
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_arm64.deb
+    digest: 0845846b66b31eedd72c968130416fd011806d63c87506237ef08fa765edfc28
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
     digest: f09601fbb60184cf2257b12a7eec5e39ae0d8659ae517bb42de686abc791f5a4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pixman/libpixman-1-0_0.42.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pixman/libpixman-1-0_0.42.2-1_arm64.deb
     digest: 7195e91186e69bd55b9c05269973f6351a3a09470ce297610cf3d22ef6cac45e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/libpkgconf3_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_arm64.deb
     digest: 225ac12d1f1dbf507b8b994fcd0e127f24287b2f5cef5a2b86d85677c8576ec9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libplacebo/libplacebo338_6.338.2-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libplacebo/libplacebo338_6.338.2-2deepin0_arm64.deb
     digest: 0ccf5dabb32afae3905e903872c5bb24d1e2178c70b6ed1af19de2555afb36b4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng-dev_1.6.40-2_arm64.deb
-    digest: 9fa36c78edb32a573134c374484986e40a8a69867676919726a14264e1658a02
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_arm64.deb
+    digest: 36ef5b74e950afa328783b48852de9093f39a157287fcc5d407671a752de8212
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng16-16_1.6.40-2_arm64.deb
-    digest: 2c5ca3dc54e748c3b7df0a89a2f1e2379ed60ead17d15a6c9cb18e0bf706dc3b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_arm64.deb
+    digest: 6d1a2ce1e132e24abc4c04edab9f0c9a0d180ed01e1f49f19c9391f1e0c926d0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_arm64.deb
     digest: 9523527a9becdf223c0c367aaaa04cb9db76cac405316314ee5216f991384fb5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin0_arm64.deb
-    digest: fd4cfe4e776eb26907c33a896dca9daf8e0c82ac834bd7e662605d1d8df6a86a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin2_arm64.deb
+    digest: 55e73753b0ae18a65a7aa9c126f52524a93888f7cd2b8fe1503a9cbc140cfb51
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_arm64.deb
-    digest: 641e0a94a253612ff4e7be672d7ee28f5a9c98e263a5f065d9e4cf47dfe00681
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_arm64.deb
+    digest: c4961acabed64ea88a254ba89930110925ea89fb182f5d088e428503d9c531fe
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_arm64.deb
+    digest: 906e8192d44527cb25bcbfd2a90992b25acfc3698a6b0cc6536edc6e935d64e6
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
     digest: 3c2fef66a85ca8d8219283c1402eb66500b8587fa4f4495d327515e12b71e710
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pulseaudio/libpulse0_16.1+dfsg1-5.1deepin1_arm64.deb
-    digest: 90867fcf545872e7a1818b2fe4892e7a12eaa166e14f990df2eb41126d992401
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pulseaudio/libpulse0_17.0+dfsg1-2deepin1_arm64.deb
+    digest: d5550a99b5654f86e4bfd43dfcc60574a1dbc606897f0edf5657edb0ab20c6d4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_arm64.deb
     digest: 94be53c10a1ed8538483d1dbd426700ff5a79ffffc7632c3a3eee0cd9ba2e869
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_arm64.deb
-    digest: b7e82676b670321d2d402bf6cfd9f8b031d1e25711409981609d86c11ce66395
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_arm64.deb
+    digest: 6dc58f5d2bda46ed44cadb9a08729430975a9a4dc41eb28f6633c6be041f9085
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_arm64.deb
-    digest: 7aa6784e459332f64d348c4d2e8d2f78ce167651d2be6361bd4e993c0923aac4
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_arm64.deb
+    digest: 73b9c0dcd766f4132d7aaff51f969d0ed8708f54355143d308aaa7033018d198
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 3cf53c5a9172bc03c318cbfeb04a27c3a18864d36640fcb3f3bdb0067912f8bc
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin10_arm64.deb
+    digest: c37dc4bd7ab67dbbe3662f0b87355fe3de5a1bb760a59a183da62d7078c7b14c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5dbus5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 4d1bc048a85e2f1da4a560a90e6414c2462325f7a52a35c3da1e3c4a6079b376
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5dbus5_5.15.8-1+deepin10_arm64.deb
+    digest: e838620af68834e7a3d8f56f7e69d3cd63f8b2fef61779e7aa74bdc6eecea949
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5gui5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: b6c7cf8460dd602ecbed114ca0e65fdec06530a8225b60102c5912352835f31b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5gui5_5.15.8-1+deepin10_arm64.deb
+    digest: f13e3e0b32533d27d5587be4c332b75eb48514b951776b9d2269461ef1be24ab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5network5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 450a311182923d757261fd29988b6a31884c982d3a49c21f701cfc5818fb7cfa
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5network5_5.15.8-1+deepin10_arm64.deb
+    digest: e3686b81ab0344abcb360a8c912931f265f4ba70f31a47c920c018a6cc0d2a1e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5widgets5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: a79351641eb886cb98d75f566b9f8b033c1d33f9d2d82626b6bbb5193c41175c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5widgets5_5.15.8-1+deepin10_arm64.deb
+    digest: bc79c330aa1eca16a6a4188db0c40347fbd9ed0e960e6349679aae6512364c3d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 4487ef000bab280d24e5796107f266dbcc7bd98da9107fa46622ec2466c7b16e
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 3ed642827043b354e44832524287cc3808804c996e5c9fcd18a3ed7b051f435c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 8e79cc85474e16b11086c3943e9f68ba2980cd02c25126441d5787a9cac9f126
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b2ec9e16dd93f9fcc6db6a8213ada4c6a032263dc26ebaeaa518e1020587e33c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 7b23577876590b68e561e40905d17bdd102d05ec005bd3f3aa02085435f729c5
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: f23850190fc6dcfcb2e9552ad18a861690f1c9d3a5b2ea8d7c1726ccb3d7ccd0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
     digest: 82c28b84f82cbf7e3d9098c0f856b955e811a65b1fd42c8515711aecd05fb894
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
     digest: c183e82838d5b340b4273253e90667078512862e1f8e9781b72b7ce048bf54d3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: fbc7604f9d54ffef67fac1b67eed229d14ca15d06a45984e316768b7c63bd930
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 865f2bc49642dca8ed4b823a6cd6e286e0e38922b94b333b3d1c6a135b068a0a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
     digest: d725d7423abfc45ea48abf3d9cc444b95af145636802254bb44565f31d4d4245
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 34ef8390fb279d048e66d691572247d54ea7e04222db0507c44ac113914c0cd8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b4adf25025b9ac22a52f68777b8b0e35acb2259b0c5dbb6d21d1e390bf272246
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 2280d74bd82b5e9d3a065c9acaeedc7d9f3c222517588c7777a62de2b30ff51a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 14b464d8f9c3c54bb8adf97c276cb3862e37403897250d96dc3cd2918d2c4ce0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: d79ad717b4275bb2dec400e7fa3ae8045c4d93b38fbc5a9c5eece9e9d7d3d14b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: abc3d24f963cab39c953bb44b1f1d258a0cb06716345f71bebf7bb70deee3f17
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 0a2c121bca7a1b60607aed1855b50fd2c630622bbb2f4b9fe5362a4a187893eb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: ded05e7b5416ee5139309098046f51d68eeea2f646c234113f0c4b754e7c362b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 8c18da39ba69ceef945d4c64e3a0e62a1bdcbe2b41921ead0aa08f4cc52c459e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 27a13b40585767a4e67f2aecfc130574be84c8f42b086c3479aa4aa178465dcb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 19c0e1c50056e4bffc43d46122f7661ebb8985750066dc772884cf1196ef1f44
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 9e46187cdd05eae2b1113623f827e080aa663da7919c1d87b44dbb03792b4dbf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 1f084ff72c612db83096eb3dec73f6101af9fe977f3376badf680a07926ccaef
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: f7b98e59524a570d02433e2773cbac7cb14f1c2862bd5252b9decd75e8921489
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: b8b4da1591cec015ace3dd8953ccca06f19f3430ddfc39faadcc6a65eda21965
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b9e0a5ee05c9c86e240c655e6e78b96ac25ab93b082f9ab04139be82dbe60327
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_arm64.deb
     digest: 9902fd043a3e62bba9f7d13edccd49a25d8d17ffa0ec5cdc761dd7a5c0d8b63a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_arm64.deb
     digest: 34f386ccca09b000fd6621ede73daa2fac0b94f8fd9af514767a94ed39a15bf7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: a69495c011e5db7fd0552ffbe180cfb43640c35271ffe21be3bcf44053ff72b8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 2ac2f2f94233663607c1664831330558c716de3f588ad4658b82f45085d5bd7b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
     digest: 75ef6edab7f429e473a3f73bed21049eaa774f3e6333cc583e55b1f6bda9f016
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin4_arm64.deb
-    digest: 5b45baf715d8ee4a73b7e018ab9558efbcfd7e284a6da9082b9d83a0481af8b8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_arm64.deb
+    digest: f4b2cfd1d6b0a4573939eee7d9a48133e1068fb741d0b4ec8dc18889bc24fb8a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 3f27c16a00798b99ae45f723331d3601e3c3741e6041a0ea4bbaec0ee7873c16
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 3b09263af197ed4bb2ca92e54db9b7e14e141d78de8f143a578e01bf707f4094
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: e1cdb4a74a5f30c6580796070a19e575e0f6c5f9467c5f1c9561bb113cf66d78
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 5336d29dac452ff7e4f227f421dcb52bb6278488d4ed2833663d109e85126f49
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
     digest: d38dc8bd34b4cf0fe94e16797f662191b91eb9e16f9f0b44bbaaa9b4b4d736f4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rust-rav1e/librav1e0_0.6.6-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rust-rav1e/librav1e0_0.6.6-3_arm64.deb
     digest: 36122d25b77930e8af01a82c4e39faac2f4f328efdd80a1247a4d8ed57337bae
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/libreadline8_8.2-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/libraw/libraw23_0.21.1-7deepin1_arm64.deb
+    digest: 59fc3963d505de503d87e672ada94960c4b0548aad5229937a7533f507b870ba
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/libreadline8_8.2-3_arm64.deb
     digest: 9bb27a75806c579d3ec78f6a455fccbd771b345a4b72014614392cf835a249df
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/librist/librist4_0.2.7+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/librist/librist4_0.2.7+dfsg-1_arm64.deb
     digest: a50896e0d12d2d03cc208dd2e7e2e6ff999b3bb1b77e3661a74c20acbe595086
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_arm64.deb
     digest: ef6aca74556a5b9b40db979a33f9fdcb9332596e4deb617249c690746d1812f6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rubberband/librubberband2_2.0.0-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_arm64.deb
+    digest: 06467b3c81e07336f2e7381ebde3b511f8a1d1dfa5c6ef8c74504589445a86fb
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rubberband/librubberband2_2.0.0-2deepin0_arm64.deb
     digest: a831854bcca08be14cf747e497ca6aaf68290ddf6341bf0fbb71f86696e7c524
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_arm64.deb
     digest: 84c039697e041663bd4b7de673b0755d8ea5375a7c026809a81d986c0a3f6683
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/libsecret-1-0_0.21.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_arm64.deb
+    digest: 15b8585dbd98a84d43b18797fb0619363087f91bff7ca70f042a9d0a63c9060b
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_arm64.deb
+    digest: ff33028cb84a0712ccf76443ab69e9b52dfeeb33e2aa20a98c2f4a0a6ed97a4f
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/libsecret-1-0_0.21.4-1_arm64.deb
     digest: eda190ae2c1cba3b2a13359a8f61aa841258587c30aed4318d64c0cd9f32b396
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/libsecret-1-dev_0.21.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/libsecret-1-dev_0.21.4-1_arm64.deb
     digest: 7dba343ad13d54f0e18f90b02f555fed96f17f847cbbeeaf93d80b07cd3b2142
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/libsecret-common_0.21.4-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/libsecret-common_0.21.4-1_all.deb
     digest: 2c12c067604e4872a281ddd17347c2a8bfa35ec65c086d46aed37414786205ab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_arm64.deb
-    digest: 503a2e758120d6eb2225f02eb4f509ed636560c343e42a685b68a74345c7c11d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
+    digest: aa09e909d7f1ba4c18ed4aac21d5aac26637731dbc0580e01cd76ee3cb8103c0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1_3.5-1deepin2_arm64.deb
-    digest: 9a9a27dec46d935b4ae8318b26d91c347e2adf9d6e7904f4e465c0ccfed535bc
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_arm64.deb
+    digest: cb9047fe72aeb8caaf8ffd6d7be6fb0f307df7d382d167aec933327ed83c87b8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
     digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors5_3.6.0-7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors5_3.6.0-7_arm64.deb
     digest: 1d958884723ef414ba8ac8c05701ec36cbf81ac586ea2b5a2a042b3efd0f2342
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
     digest: c55790b3f227a9f9b3736f40c03c8881adcf60732ce7be9a04c7b79fed7240e4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol2_3.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol2_3.5-2_arm64.deb
     digest: 2b1f781c87f8381b9cb83ae410f7607c56e42cc15c1c5d85cc2ef9c0364141c7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/serd/libserd-0-0_0.30.10-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/serd/libserd-0-0_0.30.10-2_arm64.deb
     digest: a6f20251e1d90a0011aebaf7405ef9bb5b06e34c69d83be7a017610eb1ab8e31
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libsframe1_2.41-6deepin4_arm64.deb
-    digest: 930fcc8a3d3ff4200dd9a39b1bf61d0422cf9754d31787776412fb1f605232e4
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libsframe1_2.41-6deepin7_arm64.deb
+    digest: cdddf20e77c1b89542721df1e13d34bfc4d38d1477b32f0370b21a6d6af2990b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
     digest: d989b877a836aa9d00d3d211dec9ecdbd06a1a18bd5683f154ad12c42f8b5bff
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_arm64.deb
     digest: e3544fe81f21e00b53d6b9bf1be9efbc2aea360e5e074d726832f228db44cd82
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shine/libshine3_3.1.1-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/shine/libshine3_3.1.1-2_arm64.deb
     digest: d5007b42903e1000baa20e8d02043d58152f92ffbe50275c39ae6d62b020a860
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsm/libsm6_1.2.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsm/libsm6_1.2.3-1_arm64.deb
     digest: 04dcd31830a75668f1114bff0dd08033af565b7f4f05cdb411d101ccff99d6e3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/snappy/libsnappy1v5_1.2.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/snappy/libsnappy1v5_1.2.1-1_arm64.deb
     digest: c99a4ed8067e624491b4e6b0062688fe835b06c1db21a901e8a29926caec9d90
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsndfile/libsndfile1_1.0.31-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsndfile/libsndfile1_1.0.31-2_arm64.deb
     digest: 297e9c2e5ccf243020307d68e6306b938af5b2c85fcf521c9a56978f340a2fb0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsodium/libsodium23_1.0.18-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsodium/libsodium23_1.0.18-1_arm64.deb
     digest: ed58a5ca7a8a4646f503396064852c8a1ec2da9a377a0626deedd2536172fced
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_arm64.deb
     digest: ac1056d07a450cced3125de43a15682b7cdc7060781697be7349235eb4e18093
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoxr/libsoxr0_0.1.3-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_arm64.deb
     digest: 57472a0be9bd78ef65aa7f486c6b1236c956798c2af1152d7fd71bcc71d73bd4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
     digest: ffeba610e1f0ffa299499d88562b65eece4f9865d8810d3a6194ff5d2cd02b38
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/speex/libspeex1_1.2.1-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/speex/libspeex1_1.2.1-2_arm64.deb
     digest: 20acbb41e1401455da4e83c2a76438395765b1578e2352b0060e1376f2297a06
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sphinxbase/libsphinxbase3_0.8+5prealpha+1-13deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sphinxbase/libsphinxbase3_0.8+5prealpha+1-13deepin1_arm64.deb
     digest: 327d4f0f51e729d63b3277fa3617517e13f83f4bd2a5816e057e6fa125fe16c3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_arm64.deb
     digest: cae5a428e02558cdccde604a755eb1fb983a252597224050f4683437147e6af1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sratom/libsratom-0-0_0.6.8-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sratom/libsratom-0-0_0.6.8-1_arm64.deb
     digest: f184d5380c0f3bd1ee7259ece200d19d472733682aadcc40049c697bd9569041
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
     digest: 359f8bef6d4a77cd5875d210c50dad400ba3cb6625929fc9fbfa5d56d6027a02
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_arm64.deb
     digest: 830239bef63460fabeb07413177ff1377da7b67edb62fb4710ee06c764f232c0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openssl/libssl3_3.2.0-2deepin2_arm64.deb
-    digest: f7644a7984de1e0c7d867c5794537d7df6f0ee634850ed607a3098d3368cc163
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_arm64.deb
+    digest: 08093eb78fa9240413e29c306f3af7f2ce9cd2599d0905cbbc48166518849895
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/startup-notification/libstartup-notification0-dev_0.12-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openssl/libssl3_3.2.4-0deepin2_arm64.deb
+    digest: 52f865e7d1f3a927ba35308dd28a7aa3856dbda643b4976595519e652c7bf850
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/startup-notification/libstartup-notification0-dev_0.12-deepin1_arm64.deb
     digest: de1e4b2c4d7142f338b425cc3b9ac72fd6e509fe72b3ba9dea64d8eb1b34c146
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
     digest: 6afa3a2ae947564d05b220d89298c7e6e1f875cb05b4ed1a9a450be99a3ba47d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin3_arm64.deb
-    digest: 8a8f599b667a55f52af1059338cbe93cc1415301cd688f6cb206e6efe5b34736
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_arm64.deb
+    digest: a4c67085eb06e81f133feb7cd9309cb5582edcc256cbfe3a2a534f37d1a09da5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_arm64.deb
     digest: cc104e0d2a339b388906430c5ddde52273cf42871c3d5a1c488732d17647e782
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin0_arm64.deb
-    digest: f5f56c24271c5c3aa01a4b2fdd4a80100ba9508a25b1fe1c80255b98316ef015
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin2_arm64.deb
+    digest: 5d81c28d2b2e4350e9148bb22369737492d6d41d67ab46875c05d3136efad05a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin0_arm64.deb
-    digest: 644fe45e5ec69ae506a241ecc35405367e96fc96a6415600303b5fa1cd21e36b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin2_arm64.deb
+    digest: 74bdd2a07078ea6a0934bfc4bbdd5a6a722f5c808f0b397bc87430ce4b822da1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin0_arm64.deb
-    digest: 6ecc0d9b8a6bff03f7217a159c6642bd09481fc1cb164faaeb1c6f6995a1a3c7
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin2_arm64.deb
+    digest: 60b250c05f6bbc0a570f2b484a50b2599b90e73a3616acc0fdaf9cd0d4958d40
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
     digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd0_255.2-4deepin3_arm64.deb
-    digest: b30e099836df2bc77e96a03c45fffdd484de29c357009cccdf95b692259f046b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libsystemd0_255.2-4deepin11_arm64.deb
+    digest: 694573210aea6173c54cc5084a8c29aa2001200e0a1e2144d6338463050f3979
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_arm64.deb
     digest: a193d7e19d36227ab39cc199ed2601bd6bbb91baddaa26dad3a2530288a57cab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
     digest: 3a87af58b0b3becac7062da11264d083cd68190e7dd421c2cbd00da8841cfa25
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libthai/libthai0_0.1.29-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libthai/libthai0_0.1.29-1_arm64.deb
     digest: a66f94b4ee2e6fe64aa3b80a0fcd53ac1ece9cbb88f5a03cbc6bd6540ec4650b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtheora/libtheora0_1.1.1+dfsg.1-15_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtheora/libtheora0_1.1.1+dfsg.1-15_arm64.deb
     digest: 5bb4d414e7ef844ec1c4917ae67cfb52737a4cbf5421f3cdd28de0628f7b5d31
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff-dev_4.5.1+git230720-1deepin0_arm64.deb
-    digest: e540263bfa05d263acc1f89a45a416399ac8b02a2837ab5de3c23c7de833410b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_arm64.deb
+    digest: fd7e6348b6fa6351d03f5bb80c2a64231ba0fb9379ccffd2effed33debdaebc1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff6_4.5.1+git230720-1deepin0_arm64.deb
-    digest: 761b852f1061b80cedbb6a60415d883c0ed00b027a773786c2ebb88d0f5c8b7d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_arm64.deb
+    digest: 31c5f7d8398f83511d35d4357bcaf81f701d81ff300d6de741250d4fec1721a5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiffxx6_4.5.1+git230720-1deepin0_arm64.deb
-    digest: 357960be12d31ebc9f21ab28dbd3ac650fcdcd35c9246d23070d8b4af1850580
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiffxx6_4.5.1+git230720-5_arm64.deb
+    digest: f5f19efd2db90b958cab21bcdf5be58393937b5c370e8e94d87798e5314d9b8e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libtinfo6_6.4-4_arm64.deb
-    digest: fe1fa74066ca1e08a176095b1aa5b6782e427a10c30650e33b189e7a30da9436
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libtinfo6_6.4-4deepin2_arm64.deb
+    digest: 4fb5668afdea19caf1057ea0e2e4c1c27a7411f87c924e72055a29e7cc76a6e3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
     digest: 74bddc18e3289947b20653433e82025873f5679ccba52f258ca4912e435a09ee
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_arm64.deb
     digest: 02edc284e6a4be67f3bc1bdd8660f0a310ca8901c583cd18542450cdc947ebc3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc3_1.3.2-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc3_1.3.2-2_arm64.deb
     digest: 917ce3bf402df16ea74ccc1f67e1b1d97b09286609087461dd09c9c265f694c0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
     digest: 790a0e469c3b174d03eb0eb64f4a69ddddd95ddfd4b8daf930e4b4ac7cde179b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/twolame/libtwolame0_0.4.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/twolame/libtwolame0_0.4.0-2_arm64.deb
     digest: a247a9281bd98fc91f1a6ad3df03546b2e98885a02a72c8d827ea77558ea3c83
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev-dev_255.2-4deepin3_arm64.deb
-    digest: 43a672ea158c20ea80ce9f3181d219646455d04f9582ee796976688c29f0daaa
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev-dev_255.2-4deepin11_arm64.deb
+    digest: d1cad5842de92817d400e8fce7df7f7f1ea1d786356f7f9b9169509030030fad
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev1_255.2-4deepin3_arm64.deb
-    digest: 0061474a0f2cd7e2645c49e354f3bec5fb471bee654c194edabdaa927d926d25
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev1_255.2-4deepin11_arm64.deb
+    digest: a6e7866b11d30f3c747d2b1a9cac9c4e9c8c233ff4c546946d75345fc3352aff
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
     digest: 4e25fbdfe08288e6f58cbf5a02a5147f4c2d6f41927020d20cc1a60ce49b5c0c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin2_arm64.deb
-    digest: 66c4b06f718cf1b66b799cb23c4abe63dfc1fe9b5e41f7181ecc7a01db6dcfc3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin10_arm64.deb
+    digest: 64227cc0428eba7a95ceb96941b1d152002ab0990ea733c14a2911deb2bba587
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin2_arm64.deb
-    digest: d9269dce28144c4053ea3a2bef750a6392dae283af047feca5cc804f0aaae9c1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin10_arm64.deb
+    digest: e388219b67c2fd9b42a1129d33c6fc2304986229709accb2e26d40e9c51cde71
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libu/libunistring/libunistring2_0.9.10-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libu/libunistring/libunistring2_0.9.10-6_arm64.deb
     digest: 55c2f09476f2f0e2949afdab39939e5cb62cd99976bf36ee189011e34553b06f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_arm64.deb
-    digest: f085d875204b2c41158ad83c96da354d4ce53c724106857b861cca425170ed2f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_arm64.deb
+    digest: 35e273e250258aec0345b1fb3659e26fe1c31ca0516e749f5dc663435a993e5f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva-drm2_2.20.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libva/libva-drm2_2.20.0-2_arm64.deb
     digest: 9a61323993ee5414465bffd67342d3f96932516459f43434b16fb82bd75508b8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva-x11-2_2.20.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libva/libva-x11-2_2.20.0-2_arm64.deb
     digest: 9b434dbd2a5f2f2f8f81dd2e9d9a2534e1734c4e05fd10945e70264883852d98
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva2_2.20.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libva/libva2_2.20.0-2_arm64.deb
     digest: 84af17750d36690d65ea6fe710aff9e92b56931916084126308db3068e84525c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvdpau/libvdpau1_1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvdpau/libvdpau1_1.5-2_arm64.deb
     digest: f403c96a9343009e7f3870c69d32c0e1a7f61b764122c08e31bad6d560ceb37c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvidstab/libvidstab1.1_1.1.0-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvidstab/libvidstab1.1_1.1.0-deepin1_arm64.deb
     digest: 20d3e9a821dca4e8837a2f4802b2d503fe6471b3c1767dd251786bc75701568c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvorbis/libvorbis0a_1.3.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvorbis/libvorbis0a_1.3.7-1_arm64.deb
     digest: f8b0ae274417d953a9f9bc73014194c4862e82422e6f4d97cf646d5430beb003
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvorbis/libvorbisenc2_1.3.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvorbis/libvorbisenc2_1.3.7-1_arm64.deb
     digest: 7b31cc78f8316a47839cdb34c734a6e25fa7adf1f3cd965570f0bdec2b7cc118
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_arm64.deb
     digest: 03f79776d79c5798181a5c7cbeec4c2af9971b4956e9a574b3d4ea07c742c0a5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvpx/libvpx7_1.11.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvpx/libvpx7_1.11.0-2_arm64.deb
     digest: e2921a1c7b0d58e16c782801bfcd84680dbabcea87714ee274bc5bf17acdf4dc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_arm64.deb
     digest: 358dfa214cce0157b019b7f2016e7a112c6461a708e2e8d54af0d2b25c26feda
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_arm64.deb
     digest: 3f4142af12fb84600c5f5b9458f7fd06d28ff6f7f5bcafff4c507624d16e3126
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
     digest: 3d5a7ebd49f242956b1058290b1a909c4b5e687529d3b4e8530c1556f3d99b40
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
     digest: c07692f2fda707855dbdd2f4586f8f1acf5b9cfc9618db7c08bf3442e4b7af3a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-client0_1.23.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-client0_1.23.0-1_arm64.deb
     digest: a4670daba8af6be69669976cad828b8e161c15f2707a4dfd2a67e7e1c56e775c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-cursor0_1.23.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_arm64.deb
     digest: c055857df620bf9ae756fdb5f55c8aad8a74d32eb26fe4a7d8df5e97589cdefc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-server0_1.23.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-server0_1.23.0-1_arm64.deb
     digest: 4f70d6062b322d7a3fd0a56c01399b5e24ea2dab26b1a5530392b26ac315d1a5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
     digest: f783e2d15596e657a9077db7a3dd7e8de84360a27ab504644069df49922a9545
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp7_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_arm64.deb
     digest: 72524d566f18c5461925b1bb5d352d312034f118bf5b039d76f248a682c64449
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
     digest: 9115ed02a3d0d9de956bc1474b608f922aa61feecfd27e267d88e2687caa19b1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_arm64.deb
     digest: 55519f654e68fcbcb5aecd7812a217b8ee836e7f6372487571a355b210f07224
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_arm64.deb
     digest: 5473ae2903e00b0fa112a226da1db479e7ad8006ef170a650a4292704f5d9723
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-6_1.8.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-6_1.8.7-1_arm64.deb
     digest: ac2d623345cb425a3c38685f0b2d61022ac9c4092a141099dcf818d8361e7d7d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
     digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
     digest: 1c6d4a10271b55eaf39aa83f76851047669a842f2c15b18282f2851bf29644d0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-xcb1_1.8.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_arm64.deb
     digest: 6293185372418e4f14c17d5c4d14cb631ecb1474be1b3d81d00a61f984bef922
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/x264/libx264-160_0.160.3011.1+dde-deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/x264/libx264-160_0.160.3011.1+dde-deepin_arm64.deb
     digest: 4a54e946793a6dd6c9236ec3cf2d8f1ea5b762f8f9e54ec8be1d0320026d6880
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/x265/libx265-199_3.5-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/x265/libx265-199_3.5-deepin1_arm64.deb
     digest: a75ff12857847ef498350dd942a1fcf313e652f40f38d618fa49f02f91bf16d8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
     digest: 28ba4c91230a4d8e3caa43b0897bc56960e5b07eb6e8297ddfe3d57c3514457e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb
     digest: 82a1fcfe359eeb57e4c0dedd434719360650ed2423d08af807a06d0a0ba91bae
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xavs2/libxavs2-13_1.4.1-1+dde_arm64.deb
+    digest: 16865284f307e4c2a2fe25a00dd50b4a6d32d8079f9615f30a913f41aec36e37
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_arm64.deb
     digest: 3e5079ca95b7a9f560cd332344e808d35a4cc1d90b57737abd43c8807fd9cd93
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri2-0_1.15-1_arm64.deb
-    digest: 76c404684ca22486f102a44dc00bb8c0240aa02dcbf321f9733759da84fd4286
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_arm64.deb
     digest: 66f3b86e8de5a56edf32de02641ad515380cf3fa84d219523c2a04dd7d2bd602
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-glx0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-glx0_1.15-1_arm64.deb
     digest: 8f251424b4a32ab7b0341578f3421c3eb15d25362117994350a6786f0b251f00
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_arm64.deb
     digest: 58945d6723d8d5b00b0524877f5dd8c4cd4292ff73c561d72feb68f46e1acc42
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_arm64.deb
     digest: 15b4c9739300d22125e53ccd84636ed156d0df2b62b49519649aa2076cd0c343
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_arm64.deb
     digest: 1044daab8cffa74f4c4dcbe8009ba2efa1cc9b5dd4dd615b0ef1207d3feed915
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-present0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-present0_1.15-1_arm64.deb
     digest: 4eb85646303b49b352e71e9c83e41ab3d66bf6729728e6b0a5545e9383a10c7c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-randr0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-randr0_1.15-1_arm64.deb
     digest: 57ae90f4b2a203258755300a18e6cdf3bdd30055b49f2b2931d76e4f39930691
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_arm64.deb
     digest: 1cc4fbb689677ac40edd81fdf7fad185847826720e9b4a974b4de4fa505ba7a5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-render0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-render0_1.15-1_arm64.deb
     digest: a94a481050202abd6227bb5df04eebd5d41243c51ac611490f79bffc9210d56a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shape0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shape0_1.15-1_arm64.deb
     digest: 02dec7d7fa38f1a3bcc8df6f3d3882fe660e5e84abaffd73055d495b558fae7d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shm0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shm0_1.15-1_arm64.deb
     digest: 8270f8631c37a5ce16edb733617bebfdaa4bfe0d9885a95b565ac39d76c7dba0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-sync1_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-sync1_1.15-1_arm64.deb
     digest: c447e06e8318215b440f20992c69647cee90c31d9158cef9f16ec00424f7f509
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_arm64.deb
     digest: 18e3bc7f50b606984f78dcd7f2a137f68a8fde96ef17da18c7195242f1313c84
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_arm64.deb
     digest: c3c442fc82728a145e47ff2ce37bf173cc96bd26dc3329f8eed3daec2d47c211
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xinerama0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xinerama0_1.15-1_arm64.deb
     digest: bbc6e81ea9cadae29200ea4b3072c4778209bc04b9f46244c42c19574fc139fb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xinput0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xinput0_1.15-1_arm64.deb
     digest: 78982b10c6d3417c59de87de7554b1b5bb2e1f494b5a8d5e7d0dbe109ece7f57
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xkb1_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_arm64.deb
     digest: 0386603371b588c01d5d5114b96c0a05c62b9107ee8033807a9c14e8e466da98
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
     digest: f655f75fb5205cb90667bd2e1b1c08ccd93e0f937d1b4124b10afbab5bd4bc54
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1_1.15-1_arm64.deb
     digest: 6a66b765b483884d4a8edb62dcbca87acae889488fba889b8e631982d0e35467
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_arm64.deb
     digest: 26b4210ed6ce4e5d1dc2f766ae3b47dc36442294c8b7e8eaed61da9792f76130
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb
     digest: 1ac4558b1438d14fbc93d8c969bafac2ac7cfe4f4ec609d6ef34a47d73eda2dc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxext/libxext6_1.3.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxext/libxext6_1.3.4-1_arm64.deb
     digest: 1018afc359feea593e136caed0273075e2d92aa9848bbb63b70fd55730fc4046
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxfixes/libxfixes3_6.0.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxfixes/libxfixes3_6.0.0-1_arm64.deb
     digest: a7bdf32460674bb76bb938273beac4003841dec058b335a609884287cf8d5326
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxi/libxi6_1.8.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxi/libxi6_1.8.1-1_arm64.deb
     digest: 7469379eee4164ad50e2d1369cff5f8394b1da88c92fac8f04fee521da5634b7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
     digest: 941544912030ac7a4ef2b1c3944932245be753179c8b83f93f2ecce2286ad833
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_arm64.deb
     digest: baaa366b8142ee3eac7bb178b46096caf39bcfb7b4772857af8b795d2dc6cd29
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_arm64.deb
     digest: f17db6332bf3598ce69a9e82ead1270c456976d1313365c0f4b2414a919338da
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_arm64.deb
     digest: 821afd2170d402ff5a6f4cf852f27b329dd267a2a3d8ef10a0dd84c034ba83df
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxrender/libxrender-dev_0.9.10-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxrender/libxrender-dev_0.9.10-1_arm64.deb
     digest: c4b25618b505b9ca714b8d5b95641ac2ce9ecbe87b71f5e4a712c47a9e4f0506
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxrender/libxrender1_0.9.10-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxrender/libxrender1_0.9.10-1_arm64.deb
     digest: acfd6bd44d5303a379bf438bff1a27026605309ef58f326aa3f1eee34e4480e0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxshmfence/libxshmfence1_1.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_arm64.deb
     digest: 60d857474c350e734ae71d52d2f178bb094040eee606ad3b492e7bad7d105e35
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xvidcore/libxvidcore4_1.3.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xvidcore/libxvidcore4_1.3.7-1_arm64.deb
     digest: 45d524b5413da4cd49fdd35e29065d3a88e0eba81e481d17c9a76880bc52b84d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_arm64.deb
     digest: 03c6008b099fcb1e65cb6616159d20db0bdb71c201ca864f7b88e54e82d8541d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_arm64.deb
+    digest: b52472dfffeef92c3a6d937a0c1e7eedf0010c4c889970c009acb2b9ff1f7d16
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_arm64.deb
     digest: 0ef6e252cc4bc0db0aa9ac30c918a210d8abcdcd059f4c5f7cc6d6cef7b10600
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zimg/libzimg2_3.0.3+ds1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zimg/libzimg2_3.0.3+ds1-deepin1_arm64.deb
     digest: bd1359078d13886451f058d7f32e66137f06d6ab4674d3e6c4e491e710d45a42
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zeromq3/libzmq5_4.3.5-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zeromq3/libzmq5_4.3.5-1_arm64.deb
     digest: d0604b09daeb5a092bc3b7d77625f48456e3b5a5a3fb660122d36107e8a14ec3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
     digest: ca9575f6503945c733c4dc2ce78dee09745bdb6eef34f631212d2311e1d635f1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_arm64.deb
     digest: 36724ed79e7cc83e5357ab2f3e8c2ca75362b5352611bf5bc3c54289191f3e02
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zvbi/libzvbi-common_0.2.35-18_all.deb
-    digest: 1fc738c696936a298eab3f5a6061ae0189078abddbdf7ef3da2b39537d47aa85
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zvbi/libzvbi-common_0.2.43-2deepin1_all.deb
+    digest: 8c4f70100c1fcb2755b08644f2326f0c42cf037e89c22cb69e4d0dd0798cae8f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zvbi/libzvbi0_0.2.35-18_arm64.deb
-    digest: ca07a0b3834361af09936a24dfd36d16a41a3db8199cd41f666d979de8da902a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zvbi/libzvbi0_0.2.43-2deepin1_arm64.deb
+    digest: accd5ecbd68485a1e997c1cf0a234f32aa21c87f39053af484c5e18a8211040a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
     digest: 467675c0f4007bad669a8fefe0ec4ab45f1d356f947afd7aabba2f17b88401fb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/linux-upstream/linux-libc-dev_23.01.00.41+STE_arm64.deb
-    digest: a82c1e4813646205565ce061878a2a4b044fb2c01fbe310f2e42baaf840147a6
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_arm64.deb
+    digest: 7a770cbb690f79ec2702611e320d3eced7565598bd3db72ac9eb060c476979a2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
     digest: 0e32f0eef7e7f5effe89929ad9a1c14a2838e5033fa9142cf0b3e6bcb81f8573
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/make-dfsg/make_4.3-4.1_arm64.deb
-    digest: 5605fd4da45b98e233ed57ac481699a81a65c06194983be07892ff1a60be0c76
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb
+    digest: fd601544bf60cf407d143282c4fb1296842e0cb583308339bde436df40c45b36
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/media-types/media-types_4.0.0_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_arm64.deb
+    digest: 60d8a9cf9d9fa0751184d40ff2771f8f832d3c27458af93be77c37f4e9c63b56
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/netbase/netbase_6.4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_arm64.deb
-    digest: 2411c1cc39eb107516938b83b1eb50c29e9a6deb232723d65e17cbf592df8609
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.3.3-1_arm64.deb
+    digest: 0bc26fc52fe1ee1f328e814871a257169d1844be51b74531ce255104ef6862be
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/patch/patch_2.7.6-7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/patch/patch_2.7.6-7_arm64.deb
     digest: d69d6e60753f09647125fa0991f7bda438f75c33708a9ca01dd6f1b6b87a3bd7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-base_5.36.0-10_arm64.deb
-    digest: 304683781e224018ad5ded38b86cf929281ced3eb79e456761479b7db9dbf641
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-base_5.36.0-10deepin1_arm64.deb
+    digest: e98e08d6308dadcd156dfe5bb14d8f12ad9bef51804dc6caa6cce6f157dc0f1a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
-    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
+    digest: b79ccae8397e919ee917cd187b8be2d3b10eb598f43cf72a9d9a50c3d81ec288
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl_5.36.0-10_arm64.deb
-    digest: 78c75ef3cfd45150fdae9a88e5fca3d7d5c2b1f4d1ad84fe914a3aa0bccfe77c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl_5.36.0-10deepin1_arm64.deb
+    digest: f4769ff0d6a971a7fc77d5f80e5cf6333da1ad8e2589da461c26c3744e944888
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkg-config_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkg-config_1.8.1-4_arm64.deb
     digest: 8b40ce5f7439c482fa8800f2a60160fb34fd46492d8ed397480ca0471b7fc9d8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_arm64.deb
     digest: fb3f32b7b567509b63afab51fdf5afbef9f9af569f10aac490b98d34feab8670
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf_1.8.1-4_arm64.deb
     digest: 141f5145e6adf2f9519d95a6e4ec3b1410e829621777b48c7c48bc02bc779c40
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_arm64.deb
     digest: 2456806adbaacfe2d195ee74a70141e692fbc364152c5f7a19d36697a518ed8d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_arm64.deb
-    digest: 836c3af36831db46782bf20488cac27e14f2ce63e4d186c9cd8972593dc47056
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_arm64.deb
+    digest: f646ff8063d6635c9df51bf873deecfda699a61dc0db1f51745f770d4f9ae0bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12_3.12.4-0deepin1_arm64.deb
-    digest: 0ce1f946a32af79b183fdb194c49a21742209a5c4b123608de8f39443f9a57ab
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_arm64.deb
+    digest: 0d85d36c0e59a7b1986cfa894814256a7361d2ccb5818e623712faa65795fc44
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3_3.12.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_arm64.deb
     digest: 18b254c8a2ea4801a79cab3d7946d9730e41360e251094765cf8c4928f448a23
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
     digest: 2608678aef17e7c03c4b1fc3f3e8e10b91c7ec523471e4e4cd7790be50ef8a40
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin8_arm64.deb
-    digest: 49e6ba1265c701ac04b43dac6c79dd4f53a82341cc518c688af640243c3e339d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin15_arm64.deb
+    digest: 55e2c35946568735e4a644448f43482b0e8e44fa3aadddd14ac00167af6525a6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin8_arm64.deb
-    digest: 54a5c004ec17699f9e2949bb36b4ed8a95e610385453cacc40988a03fcbb24a5
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin15_arm64.deb
+    digest: 5de313fef4619d871c8abb52b17193b009df347e43e15991256a4f9dba6f571b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 01b961cefebb3c8c0f30ffd65c461f0000340eb4413763f621a42b41418eb905
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: ce44156c4871fe1af1cf1c7113d623489f7789b0cca8ae63a3acba72ff176889
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 3b73805c92b8937fddc76aeaae447efca88be5c4edb906dbe86185adc47da0fb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: cc0a67ca33b3c44efeb4723a95d34b986eb989278c17e9d9c6dcfa21aeef9b73
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 3f2442b73e48918050635d141f1ea8112442ff9217e92bd998bc9155ad201411
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 96f2f1d1953e3a48542911d7d13f179fc9e7766a462f5941a995f56455c9fc63
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: f1c60c7ab3ec69c9fd52a1d42fe8afdb1555e7e54bca71f417e48908b8868038
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 1789a73946e436fa2aaa758278d023c47ba8cc0cfe2547ac70c18f77058ba834
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 65ffeb095fc0fb17977dd797bb410d7a401f94e8dfb981813a3e6af39c54b7b2
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: f86c153ce4628e34e8f59d66ecd3a001016cdc9cfa43e03756581a177be17e40
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 3c69f6dc4b35a09be2f9d76b42be9d47a633fa223a34119dbdf33baca1fed658
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 651905afd63f5427e9b9a14d9a667709ef7449d7dcd140ec62aa1fe05ed13828
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
     digest: 719086d3983481e4d78e4c7424a796831db3925c1ca6b3495513e9cde674565b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_arm64.deb
     digest: 4e4323c9a9a51342c64424187e92f7653a7aead8899f523561bc2bf8215ed513
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
     digest: 9265848cc3a9da02d8de859a7705604e75d2baef2fc16cd243485e56f15ccf5a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 87651591e1fd396c4af3a4073c2ae33690e34706110f882a05d984bdd895a2f4
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b5dc6687475a84e1aa544d8fa3cc1eb80c13ada54c0c3b10625fc96a605c6518
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_arm64.deb
     digest: e6732e7d1132d2a84254c8868b2c4cbf36e2afc4db8f82859bd8e5b9f40bbc7c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
     digest: c45c4550873e94c31f4372e71b06dd80d8e634f532585d496dbfc60218fa49d4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
     digest: 03bb344dd34bd0076551e13b833b014c2c379d13213a0d0668af15544e509de4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/readline-common_8.2-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/readline-common_8.2-3_all.deb
     digest: 35fe59faceb8d9def8b6aa664e091eac8444887bc1f33ba2cf22099c3646e7bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_arm64.deb
     digest: ae2f397b418bbed8a068fdc9223133120390dbe734734c72b8e152962a76da91
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shared-mime-info/shared-mime-info_2.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_arm64.deb
     digest: e026d478f271cdce55bcc623fea311ee9605e39bf17ee3919b2502221d0e86e0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb
     digest: 9e736851d33ca49a6e7ae4b188c480ea0929cb8e322da77174570c64a1037175
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/uuid-dev_2.39.3-6deepin1_arm64.deb
-    digest: 7094c9e4b23c9651ba3bb49b5c13883ff2bcd12cd4f30d291a2c29cc4fd34d52
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_arm64.deb
+    digest: 079ee6193e894d85bdb6c51b4318514bf0f788c12560b7bd05b46d6f12df388a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
     digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
     digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-render-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-render-dev_2024.1-1_all.deb
     digest: 7fb5329b624a9bcf86b4c6f4a3df92650c1c6a2041f0a75f4ae5c6f819915eba
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
     digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_arm64.deb
     digest: c92b2bd8b458619a6f6fdca530fe2b8d9faf3ed273cd867126898275078c1ec7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
     digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/xz-utils_5.4.5-0.3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/xz-utils_5.4.5-0.3_arm64.deb
     digest: 8df904affdf74d76f6a265ba072c57844c981ae39074c5526c763752cb03f100
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
     digest: 29a1888f6b7be54992868b36050c68d6063820ae6c4a2e09ffa2317a7e0b6d6f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
     digest: 2c38eb2adccdb6baf292a182b5963a7eee5895afd657917be10282bdb2b2139f

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.37) unstable; urgency=medium
+
+  * feat: Image format extension support
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Wed, 23 Jul 2025 15:12:27 +0800
+
 deepin-album (6.0.36) unstable; urgency=medium
 
   * chore: Update deepin-manual resources (#354)
@@ -60,13 +66,13 @@ deepin-album (6.0.27) unstable; urgency=medium
 
 deepin-album (6.0.26) unstable; urgency=medium
 
-  * Update version to 6.0.26 
+  * Update version to 6.0.26
 
  -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 22 May 2025 16:10:43 +0800
 
 deepin-album (6.0.25) unstable; urgency=medium
 
-  * Update version to 6.0.25 
+  * Update version to 6.0.25
 
  -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 16 May 2025 17:51:07 +0800
 
@@ -147,9 +153,9 @@ deepin-album (6.0.14) unstable; urgency=medium
   * chore: New version 6.0.14.
 
  -- xiepengfei <xiepengfei@uniontech.com>  Fri, 20 Dec 2024 11:51:44 +0800
- 
+
  deepin-album (6.0.13) unstable; urgency=medium
- 
+
   * update version to 6.0.13
 
  -- renbin <renbin@uniontech.com>  Sat, 14 Dec 2024 11:56:30 +0800

--- a/debian/control
+++ b/debian/control
@@ -45,7 +45,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
     qml6-module-qt5compat-graphicaleffects,
     libqt6sql6-sqlite,
     qt6-image-formats-plugins
-Recommends: qt6-gtk-platformtheme, deepin-ocr
+Recommends: qt6-gtk-platformtheme, deepin-ocr, kimageformat6-plugins
 Description: Simple description
  A detailed description.
 

--- a/deploy_dep
+++ b/deploy_dep
@@ -40,7 +40,7 @@ for LDFILE in "$@"; do
         # 添加依赖库到 install 文件
         for SOFILE in "${PREFIX}/lib/${TRIPLET}"/${LDFILE}*; do
             if [[ -f "$SOFILE" ]]; then
-                echo "$SOFILE" >> "${ID_VALUE}.install"
+                echo `realpath -s $SOFILE` >> "${ID_VALUE}.install"
             fi
         done
     else

--- a/install_dep
+++ b/install_dep
@@ -120,6 +120,8 @@ while IFS= read -r deb_file; do
     # 复制/lib,/bin,/usr目录
     cp -rP "$data_list_dir/lib" "$target" 2>/dev/null || true
     cp -rP "$data_list_dir/bin" "$target" 2>/dev/null || true
+    rm -r "${data_list_dir:?}/usr/share/systemd" 2>/dev/null || true
+    rm -r "${data_list_dir:?}/usr/lib/systemd" 2>/dev/null || true
     cp -rP "$data_list_dir"/usr/* "$target" || true
     rm -r "$data_list_dir"
 done <"$deb_list_file"

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.36.1
+  version: 6.0.37.1
   kind: app
   description: |
     album for deepin os.
@@ -23,7 +23,11 @@ build: |
   # 查找并移动目录下的所有文件（包括符号链接）到它的上一层目录
   find ${PREFIX}/lib/${TRIPLET}/blas -mindepth 1 -maxdepth 1 -exec mv {} ${PREFIX}/lib/${TRIPLET} \;
   find ${PREFIX}/lib/${TRIPLET}/lapack -mindepth 1 -maxdepth 1 -exec mv {} ${PREFIX}/lib/${TRIPLET} \;
-  
+
+  # 准备插件
+  mkdir -p $PREFIX/bin/imageformats
+  cp ${PREFIX}/lib/${TRIPLET}/qt6/plugins/imageformats/*.so $PREFIX/bin/imageformats
+
   # 更新ld.so.cache
   if [ -n "$LINGLONG_LD_SO_CACHE" ]; then
       ldconfig -C "$LINGLONG_LD_SO_CACHE"
@@ -47,1392 +51,1502 @@ build: |
     libffmpegthumbnailer.so
     libblas.so
     liblapack.so
+    ../../bin/imageformats/kimg_avif.so
+    ../../bin/imageformats/kimg_heif.so
+    # plugins for libheif.so.1
+    libheif/plugins/libheif-aomdec.so
+    libheif/plugins/libheif-dav1d.so
+    libheif/plugins/libheif-j2kdec.so
+    libheif/plugins/libheif-libde265.so
+    libheif/plugins/libheif-x265.so
   )
 
   # 生成.install 文件
   bash ./deploy_dep "${LDD_FILES[@]}"
 
+  ID_VALUE=$(awk -F ': ' '/^  id: / {print $2}' linglong.yaml)
+  # set LIBHEIF_PLUGIN_PATH for libheif.so.1 to load plugins
+  mkdir -p $PREFIX/etc
+  echo export LIBHEIF_PLUGIN_PATH=$PREFIX/lib/${TRIPLET}/libheif/plugins > $PREFIX/etc/profile
+  echo $PREFIX/etc/profile >> "${ID_VALUE}.install"
+
 sources:
-  # linglong:gen_deb_source sources amd64 https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release/ beige main community
+  # linglong:gen_deb_source sources amd64 http://10.20.64.92:8080/crimson_25.0 stable main
   # linglong:gen_deb_source install libdtk6gui-dev, libdtk6widget-dev, qt6-svg-dev, qt6-tools-dev, qt6-tools-dev-tools, qt6-base-dev, qt6-base-dev-tools, qt6-base-private-dev, qt6-l10n-tools
-  # linglong:gen_deb_source install libexif-dev, libstartup-notification0-dev, libudev-dev, libfontconfig1-dev, libglib2.0-dev, libxrender-dev, libdfm6-mount-dev, libdfm-mount-dev, libavcodec-dev, libavformat-dev, libavutil-dev, libffmpegthumbnailer-dev
+  # linglong:gen_deb_source install libexif-dev, libstartup-notification0-dev, libudev-dev, libfontconfig1-dev, libglib2.0-dev, libxrender-dev, libdfm6-mount-dev, libdfm-mount-dev, libavcodec-dev, libavformat-dev, libavutil-dev, libffmpegthumbnailer-dev, kimageformat6-plugins
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
     digest: b6175963d3e4cf00d76fe431e75e52450bad93604945040d706d97b65cd8623d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-common_2.41-6deepin5_amd64.deb
-    digest: 48d5bb1b38c184c7099393a89ffd3c01abb2d2f64c3c9aab4045e2ba1271570a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-common_2.41-6deepin7_amd64.deb
+    digest: 479ecc732776fe043e2ee3c652f10258c5dac413324566c1bdb594b026d6bf5a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-x86-64-linux-gnu_2.41-6deepin5_amd64.deb
-    digest: 4becb0add7af644bb663a914d805394e6b9a84d148950d12a1e6148a827f657a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.41-6deepin7_amd64.deb
+    digest: 59150923974958d8ca8e64d1e7bdfd983c03b44e83c28287cc57eb7fc8b612a6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils_2.41-6deepin5_amd64.deb
-    digest: db40885cb122564840d3f259169e1dbcfc7f0dfd5e210ababf2bbbb99eb92283
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils_2.41-6deepin7_amd64.deb
+    digest: 676af766071e8edcf4e35a85a1a0eb3907ec6be6036c0dce3cdb0fa91700fc50
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/bzip2_1.0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/bzip2_1.0.8-deepin1_amd64.deb
     digest: a67b553f354a824475090fcd7a1b6fe237598a1445158526027f2970aa976def
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
     digest: f0e1fe7a35fc386fb5944eb9bc4325c4e2d8913f43639ab6791ed3ea6084f584
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
-    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg_1.22.6deepin3_amd64.deb
-    digest: f9c758ed0204b1fe515c70b6419f80fdeb4773ac3f498a79ea1e6a6e6971157f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg_1.22.6deepin4_amd64.deb
+    digest: 2837fb44598aa57a0fc7d2b477c6539b3c268a1312f2580d4fb227e83d023d9b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig-config_2.14.2-6_amd64.deb
-    digest: ca239a17d79f439fc02525b3b3c83d6cdf0be1a90c6aa6ec6c19b2b92b0d6586
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_amd64.deb
+    digest: 70df7073f2ddecf0ecce688b92939d7bf31268d37d299a416243dd6a114a96ab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig_2.14.2-6_amd64.deb
-    digest: 1018476410ec372cb5f96e3a4d4b4d51781c613212eb71f91bcc939c2de0e8f2
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_amd64.deb
+    digest: c3c6ce170d17d875a72e644f67be87e47ae19feb7682517eab59259591348441
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
     digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
     digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
     digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin3_amd64.deb
-    digest: d9c679af2dd0d3878d823075b2fb1433618bd3227cbae336e11d8e89274b5ab1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin4_amd64.deb
+    digest: 67ac59a7c56a0c1ea647222bfa7830ac81d98895867a348fc30746e2176ec9bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_amd64.deb
     digest: 19242756d4cc8125e5b18e34319ba4f4445aeff9bc3c1560e9dc5a87fcacb0d2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_amd64.deb
     digest: 3cbcb69c6edaebc428fc9f7c19a4a4e7a057bb980ab6b6f754561e3aee3ea011
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_amd64.deb
     digest: 101c6cc50091fefd708f98e3a9cbb3b8e6a6cb93d52bb45537c13ee0fa5e1678
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin2_amd64.deb
-    digest: da1ee5e685d83c9bf161be38e4d708d27d9cd4becd9db90acc679de8f25d32ad
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin10_amd64.deb
+    digest: 42b5e9a5ffca17eed9ead1844ea6ad75c66e1d87d0f95030a150d35f24d9d993
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/acl/libacl1_2.3.1-1_amd64.deb
-    digest: f06e936eb913b8e9271c17e6d8b94d9e4f0aa558d7debdc324c9484908ee8dc8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kimageformats/kimageformat6-plugins_6.10.0-2_amd64.deb
+    digest: 2a180dd5018d568c4f36a19a14753d5589174de6bfa66118230dddf103f4b7b9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/aom/libaom3_3.9.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/abseil/libabsl20220623_20220623.1-3_amd64.deb
+    digest: 23ce45fe62610dd94dd8df7f0237509622e65c12334ea84d21ceaefc901d195a
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/acl/libacl1_2.3.1-3_amd64.deb
+    digest: e7235d27da99795b0ca6c6bc5e8d6e84702335063fe9d08b19320c0bc965679c
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/aom/libaom3_3.9.1-1_amd64.deb
     digest: 6cfd746dd55a96fca3e058faf82c7400ddf50017bff6f7cfed6ad1f6ee637ad0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/alsa-lib/libasound2-data_1.2.12-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/alsa-lib/libasound2-data_1.2.12-1deepin1_all.deb
     digest: 4990cab9125078d6b8ef1caaeabb597ecda80949d02d251903fd496272f59fbf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/alsa-lib/libasound2_1.2.12-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/alsa-lib/libasound2_1.2.12-1deepin1_amd64.deb
     digest: 13c36d1ba89268f03f75be93ec321e393f377421f6867bfc22f243be102460b3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libass/libass9_0.15.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liba/libass/libass9_0.15.2-1_amd64.deb
     digest: 1c0c5c27e1ae950841911d144b4e3cd319ff90177e3dc046367585c7e6c88ab6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libasyncns/libasyncns0_0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liba/libasyncns/libasyncns0_0.8-deepin1_amd64.deb
     digest: fd200e6260ccf2169de1a42591f730bfda6ff0e64a80c8eb4bc167e875cc9fcd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-client3_0.8-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-client3_0.8-5_amd64.deb
     digest: 28bdf7a8c0529f6397921fe59358e8d94cf3d3f1e498f09e9b4035254ee15baf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common-data_0.8-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common-data_0.8-5_amd64.deb
     digest: 5fdc5ef24ff229630b683db663cb26e108aa719fd288b808c4607c680de52c75
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common3_0.8-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common3_0.8-5_amd64.deb
     digest: a966db72e688d76b06a665dfe894c66faae8d2033cf5dd8776bf56f41912035f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin0_amd64.deb
-    digest: 8af2330b798a2170c1af0bb977a4994adee215082808038c33b57ee454e87ad4
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin2_amd64.deb
+    digest: d0a4109d18b3ed289e6a148c81e73d4db5f788bf552749993aabab720208202a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin0_amd64.deb
-    digest: 5c879f2bb5e245e3620f30fac20b046e2e1770b3db8d101fd3d77f1bf13374df
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin2_amd64.deb
+    digest: 11c11308dd570baf7d1faf87862c8edd5033a648dac4df9b3a14333d339b55e1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin0_amd64.deb
-    digest: c8716db260758b9dccd66343c82597ce5f239746288b24687d2c1dacf64d7760
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin2_amd64.deb
+    digest: 274d9c2fc032c05e8681123e433df396aeac198b820bb4de7ddf415f0eb6a6d9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin0_amd64.deb
-    digest: 9c7db47a9a14bdff9b5590452946818c5133ee56a0bd2740342ad1a6a866ef47
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin2_amd64.deb
+    digest: fa81ac48f28817544648e4c4b672041b66960d92ec9659b309bd1f62f3eb7d7d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin0_amd64.deb
-    digest: 9744ea02284ee606bfa0ce6243399199a861f8c967d16f2cb23e5e834c375ade
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin2_amd64.deb
+    digest: 5a9d472dc24c2fca1fdb108e4c63c28f1bcd4cf4921e8bdeaab9920b0c4c6cce
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin0_amd64.deb
-    digest: 330d381bda51be0dc9308f933868df9dbaa9802d43644e016664f5bdc3734215
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liba/libavif/libavif16_1.1.1-1_amd64.deb
+    digest: 9f08109a94f51b83d9b2d59bee2863a21eac1aca368a81ad7c1f8cabe4ad9167
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin0_amd64.deb
-    digest: a85ec638e75deef12fd30204d63112620d4e21e9a4887ae267081cd7512a4846
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin2_amd64.deb
+    digest: 136b999e1c176d32eb1f825c8e1fa88ae73eea4fc3469890bc2c0b0fcb8b70e1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin2_amd64.deb
+    digest: 3af976a0628eafd167b8652cebc99774f561255d338f9e874c9fdf20087e84b6
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
     digest: ad82b2de93cc49cdf37c861b03275245318b1555255639e5e805cf612a40171e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libbinutils_2.41-6deepin5_amd64.deb
-    digest: 6ddab823f38eb647e3c438c08401f450384d8b63e3b872f0ed8a31f854e1fbe8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libbinutils_2.41-6deepin7_amd64.deb
+    digest: 10e86800f4da1db706020bdcf6642096be3c093759d41631cf6492237e26748b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lapack/libblas3_3.11.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lapack/libblas3_3.11.0-2_amd64.deb
     digest: 4593968beae667f8d58b700e63c047f3f0ecab70482cd4696246ded9ae7294ac
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid-dev_2.39.3-6deepin1_amd64.deb
-    digest: e9a309e022e159bcd90fdf4b710e8a6597368a234fd3d102af67cf471ae16703
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_amd64.deb
+    digest: a4d108ebdc3c5710be943be9fc8b480e7db0704da63fb2c041dc2865df4ce4f9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid1_2.39.3-6deepin1_amd64.deb
-    digest: 1c0d4c5b5efec4a282652df9793083bdd4e7fc0ed634dc76f3bf6ee700dfa8c4
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_amd64.deb
+    digest: 567b0f1dfc7844c74fcca08a18d6f0d527caf16278e205095522a0454ca23918
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_amd64.deb
     digest: 563f4d3b275996192a906b926390435bb3e444294f8766b8db5ba66f199db55d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
     digest: 87226cff96c560b3ea8b15110f7f2b00047b0cc9dd29c9fdbc372b4d9154de80
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli1_1.1.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli1_1.1.0-2_amd64.deb
     digest: c90c041d2069cc78a80e07d62ce3e251306a81b23f9b95fa35a65ce7af87ad04
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbs2b/libbs2b0_3.1.0+dfsg-2.2-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbs2b/libbs2b0_3.1.0+dfsg-2.2-deepin1_amd64.deb
     digest: 6854e7f16cf2a724490b7f7a60cc6acdee2474637466b258e1d7c4ddae5477dc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbsd/libbsd0_0.11.7-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbsd/libbsd0_0.11.7-4_amd64.deb
     digest: 40e8755d2d6de7ee5c90483c74d586c6270f088eaf630acdc32bc848c09cedfe
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_amd64.deb
     digest: 42c04d805408bc1f10872e8394e26d3ff1bc6aa3477efac7e94612f9b7b2d972
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
     digest: 60e1d9cbac4fafa4f7823e6495212ec02805997e64dead0f40de1d86ff138d41
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc-dev-bin_2.38-6deepin7_amd64.deb
-    digest: 2fb2db05a0e86ea279c81e5c4a3bbbcc8931d7fb54296748853061e44e6ae0f3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_amd64.deb
+    digest: 00d51bccb99085bb8b797d1da104893235789b72dc88f42f5d5d7b50d2139874
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6-dev_2.38-6deepin7_amd64.deb
-    digest: 6659347f85e23081d30ea809ceba563fd696bd21f8831a5e37115131864a8f35
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_amd64.deb
+    digest: 4a8025393fce99a77e4428caee83481ffe9bee64c2b985d0ac96c2ab2ab86893
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6_2.38-6deepin7_amd64.deb
-    digest: d8928f5bfe6dfaa9b64ea2354c9d933c51805aa137e52d834efdd4a1b220f031
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_amd64.deb
+    digest: cdf2227d3d1614bb3c643012dddb2daa52abc647f90a820beb07f19b8ed6bdf3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cairo/libcairo-gobject2_1.18.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cairo/libcairo-gobject2_1.18.0-1_amd64.deb
     digest: 58dc2ae2cd25e9ba5e45c571fd4c0fe77450cd98128dc28c2183b7434aa4d914
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cairo/libcairo2_1.18.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cairo/libcairo2_1.18.0-1_amd64.deb
     digest: cbf026997021678131d706318414a498b8054291185be3fa095fe8ea9fe162fc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap2/libcap2_2.66-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libcap2/libcap2_2.66-5_amd64.deb
     digest: f4f581c5ed9c6576ff284117ee51ae8b4e47e6799d71fabc7c0aa2d3a260752a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/capstone/libcapstone4_4.0.2-3-deepin1_amd64.deb
-    digest: 6b82dd7f3f4ff2bc1c59d2cd7180600bc9cafa1ec8752689e301ab04dd4e9713
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/capstone/libcapstone5_5.0.3-1_amd64.deb
+    digest: 0e6b1c94b28127dbb067f7ded642625abd26fac8bce528aa9bad37e5b66836f8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
     digest: 1ee2dbafa2c331d58cf10cdf546c760d7a734c5d9fab1b16d2e04e51f6e38623
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cjson/libcjson1_1.7.15-1_amd64.deb
-    digest: 57a3cfa5dc3847d978668e57cac797681cac10be5f6deb6ed3955f23fad0ac24
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cjson/libcjson1_1.7.18-3_amd64.deb
+    digest: e638d498f51d1c6b3a67b0463fb57269e996b572f59237b041d07ada88d7a69d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_amd64.deb
     digest: a34b10500cae17c2c122760901c453df850a968a32699978c2015cf355fd5580
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_amd64.deb
     digest: 7fd516db3504bc518b5c3911819880a8296964af7089e4c6d39753096a668fed
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/codec2/libcodec2-0.9_0.9.2-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/codec2/libcodec2-0.9_0.9.2-4_amd64.deb
     digest: a3161c3417d9cb176b29e51e176aeb1733a5eb515143f056b5f9256ccae2af22
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_amd64.deb
     digest: 016e7e4d9ff3fa97f1631669aba86aebe7bd1d1c8d04fd8ec66b38c87cccab05
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_amd64.deb
     digest: 3505f9548808b3e2e06dac00d3c674a023815c011ab6ddad1bc85283e899adc6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_amd64.deb
     digest: a7af8c9a2b767781d83f60fa32553f6a713569a0f7c4666e68dab41c46feaf1c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf-nobfd0_2.41-6deepin5_amd64.deb
-    digest: c5320294cbb1a5a19f7eb0de0a2669a613f576db2612037a766a5bf44f766191
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_amd64.deb
+    digest: 44b5e0a887f8b8d84166ba81f4cf1d70b607914c8b59959c47bde1ce750645bb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf0_2.41-6deepin5_amd64.deb
-    digest: dd486930909e67f021d0739101803cb08c8491e2ce2923bb5b65a88311a24105
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf0_2.41-6deepin7_amd64.deb
+    digest: c58e37fce60c661d023d37f46d1af34772c40783b2be220f0d11eb8e2d8029b4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_amd64.deb
-    digest: 45ca2c611835e500875ddd500f2618ec97d6bfa51735ec3d276a72fb110e544e
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_amd64.deb
+    digest: 57726c5fbe502348eda3a0ba248978a0769eb7fd134d8998386e3216875e18d9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2_2.4.2-5deepin1_amd64.deb
-    digest: e48aff0e7bd13a310516cfc5dcbdb68d789ef8e4c949afe7e638fb402a90f150
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2_2.4.2-5deepin2_amd64.deb
+    digest: c3677b705c3b3214cec20cc24f7a4e4a05c975e1de8834e4647f5f2575b114e5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_amd64.deb
-    digest: 14f6bb47e2fb92849593a1440cd87393d7920f5b7a0fa1932165c6bc8c96e890
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_amd64.deb
+    digest: 94aabf445b3d15c635a2a1710066107e3f3860bcc15cdd982b3ae5581b132960
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_amd64.deb
-    digest: 7e35233d2f74d5344630efc3bb2f91d2efb8ba7e62f01d5b095bb6bacc3c7010
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_amd64.deb
+    digest: 35286abdab600d5aede3a3e77030ad9f65535287d63be8140f0959fa9e0641f8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdatrie/libdatrie1_0.2.13-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_amd64.deb
+    digest: c8fd9506ce9de38317bc40295bd9c673d332e444771e00c6bf249373e424b82d
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdatrie/libdatrie1_0.2.13-2_amd64.deb
     digest: 07aa08beb07e987772c31ef3865ef65b8ea37069c7c840c8a2a56c6d0019df07
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_amd64.deb
     digest: 258bd4678ba2f0f0a63f00e630c890efb34a1adf65e1017308e28a16ddd25eb5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/davs2/libdavs2-16_1.7.1-1+dde_amd64.deb
+    digest: 7f8747a9b3a5322649d4cde69fb09fffb310ea0b02bca7df6f60db383484c1c4
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_amd64.deb
     digest: 98830ff429c7212767f0de4d239870f1936b37527ce365287de30eb8276a8330
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/libdbus-1-3_1.14.10-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dbus/libdbus-1-3_1.14.10-3_amd64.deb
     digest: 1dff3a63259f14e7de7c4502e7083f7077b30a274f09d195176d566406b1b827
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate-dev_1.18-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libde265/libde265-0_1.0.15-1_amd64.deb
+    digest: 70349a1252f96e510b63a9f6ae3ddcf0ef771c82f7c0bd0a6931cb83ad4c5305
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_amd64.deb
     digest: 04a8d4c536a9f106a9f4b38fdc012fbe745b928e32ef3f05db4704d30c1023b5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate0_1.18-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate0_1.18-1_amd64.deb
     digest: 1b411007d982c5f2f2a6d1e2d0af7a85cbc274770e533fbd895fc54956a995ba
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm-mount-dev_1.3.4_amd64.deb
-    digest: 33b4e58088fde72718b6a69a5e6db416b851e4a755118ce56c59fedd2bf73933
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm-mount-dev_1.3.9_amd64.deb
+    digest: 5cf13f51c721e49caa7b63c26bec646661f2a4e711c07811da55d372fa656181
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm-mount_1.3.4_amd64.deb
-    digest: db7949793ccac7181a91bd4d610b26c80db7c8431474e8f4cf558d584a7c9155
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm-mount_1.3.9_amd64.deb
+    digest: 9b86fc2b2d93b68979615b8594e885795c93a098826c7aedb8839c455a4dd9a6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm6-mount-dev_1.3.4_amd64.deb
-    digest: 35a03c937c778504469b9b2d33d2828ceedbd625e75d3809944de04ad6cc0ff9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.32_amd64.deb
+    digest: 18a55a3be60b821e0bc224a61b86d0fb93b353804468a48c0b57f904dcfa9373
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm6-mount_1.3.4_amd64.deb
-    digest: 51a48cf85be8f72645bd2c85c49a88a5ec62a85ba0069563a02493c2fac0603c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm6-mount_1.3.32_amd64.deb
+    digest: 64c632c3bf21a92cedf025b40520d47973fc425bef0ce9b6c45757fe26413488
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
     digest: e6c6d028a74d0a752ae638ec19b8239f404c36d676c7569936f31000d25a75f4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
-    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_amd64.deb
     digest: f58eaae37579b2a3964f84993a8893fe00a05447b23f5e937102c30f64fead50
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
     digest: b8289eaa6341a8493f4c191a45165fe944248da69f675d09005a29058e7ae5a6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-intel1_2.4.123-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-intel1_2.4.123-1_amd64.deb
     digest: 9de0a6e4bea3c7244aa6c88ccb46c7297fac4b475756b4885b7eec53191eaa17
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_amd64.deb
     digest: 6c5a1a1849b24b6b02608d28fe9294c85f366f3bdf94f46cc622c4f2e980774e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm2_2.4.123-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm2_2.4.123-1_amd64.deb
     digest: c2f1676c3335ab76ff829190951052abef661b735f2ddfefdb8d6c0698c41756
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core-dev_6.0.25_amd64.deb
-    digest: 8ceffb3810d88965cf8f4b9cff067f53011112dd32a211495e0c37a9a8a948bc
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_amd64.deb
+    digest: dc0e1738af9ccdb458d217b3d2eecb2ffbb49092f6247b6021f786b0548d12b0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core_6.0.25_amd64.deb
-    digest: 60ed25c9a9cb998a21b97cbd0451f4df0f5bd9f3872eef1d809575eaa6048c9f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core_6.0.38_amd64.deb
+    digest: 00964a07edce1826a9ca23dc820091f95c77da6950ff704aab34d59ace7bdc3b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_amd64.deb
-    digest: 9a7716eaa20196761a0f87a86035bfb1bb2b0be1bf485b0697a70927f60a99cf
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_amd64.deb
+    digest: 242c7b48aac3fe35579fdd2f52cfa88e12a8f0df5ed29926d042441e4d449471
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui_6.0.25_amd64.deb
-    digest: 2c91aaf3f276058f1c190d355ccdccbe699c6c1b5999edf9256fee34b5343d66
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui_6.0.38_amd64.deb
+    digest: 43302b4536ee242e84c461c32eff19e794a892636734c15ee2c8094ad77cd28d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log-dev_0.0.2_amd64.deb
-    digest: 203f1e94dcaa537929ad7df2c33f9ae6f006985fc56829a37c67dce2c11660c8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_amd64.deb
+    digest: f9e6c1e18e5166aea09e13367e954c527f0d8b7f5cbdcbd9493d933a65ec7fd1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log_0.0.2_amd64.deb
-    digest: 4af48ee588e9a27ca3663193177c4fd2b4e455cff00dbff0aa5fc2ec4bdd24d5
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log_0.0.4_amd64.deb
+    digest: 4fecfdb38533bc2e6b9a16e559cb70c56ec50fa061b92b1124b606d28d7b3887
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_amd64.deb
-    digest: 34b0abc672d2c5af743d1a0836af2a258428422c3d1b87fb71507b0abc8073c5
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_amd64.deb
+    digest: 4e0ae6248f9f3c03765a71c4cd4df02f2a7ff242c4e7bb45d1617c9d234084d0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget_6.0.25_amd64.deb
-    digest: 2d4d30307bcc41eb6cef9608603ee999aabf3a81d4ba2a7008e6bfbc232e0689
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget_6.0.38_amd64.deb
+    digest: 649ec642a62e9ac7aef520a41b14f0d3b09bccee17b4676790ea45ec15a37c1e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_amd64.deb
-    digest: 880d256182fe9891a7874473fdd1f18439e5c1625160214adb9167fdba3159da
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_amd64.deb
+    digest: c490431f2dcecb0bc945f62ce139994ed039098c4c803a14c39b37c65e6d0698
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkdata_5.7.5_amd64.deb
-    digest: 75824b67ac4979f023f9a22ed326157e76f0c4d7739474145e4b51fdf55f83a0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkdata_5.7.18_amd64.deb
+    digest: b68e4815cea197c703fe17fc8cd90206bd6cbd9a582edb909cf8f641ee1e313e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libedit/libedit2_3.1-20230828-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/duktape/libduktape207_2.7.0-2_amd64.deb
+    digest: 03743b861cdfa66aa9a94608574f3c6c784fa0ede3264e70d436c2fc8e902b95
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libedit/libedit2_3.1-20230828-1_amd64.deb
     digest: 72d015604676696e4e10e238f4795fbdc3d7c0e241147d55c9782ea8baf9a03c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libegl-mesa0_24.1.5-1deepin2_amd64.deb
-    digest: c74aaf2b940df7a190e076c949c46064371bd71a7f72c3068364b093a5c502ac
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_amd64.deb
+    digest: bb9a950bed0f7a14f62e0787bc8b650262a6094c5b244d7771ef9f4514a0dfc2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libegl1_1.7.0-1_amd64.deb
-    digest: 8c883a493c299a9cc4bf8814dc98b8d22ef4902f2e29b84e47c05075807785b9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_amd64.deb
+    digest: 1675190466ac26b2ae0f64131a83aef2663c42ee1c1775aafb2ab6878df3f235
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/elfutils/libelf1_0.191-1deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/elfutils/libelf1_0.191-1deepin2_amd64.deb
     digest: 27dd39d5858cff9969ff58d01f7fe44a846dc9e9477898e250633c7b96c72757
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_amd64.deb
     digest: 7e338355abfb198b7fe4ff9d02f4b950f822965712d429e3a623e25509e41daf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_amd64.deb
     digest: 48c0a7c73d835054b291645fa21fd597271e28a6eb98d8b22f2283e364e83893
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif-dev_0.6.23-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libexif/libexif-dev_0.6.23-1_amd64.deb
     digest: 717f1d0dbc6464516c5898479a9907f526dfc9e42df66db1d44dcd3a9c54c93c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif12_0.6.23-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libexif/libexif12_0.6.23-1_amd64.deb
     digest: 777bcea02800cf2c508fff7e5af7fac426da67dd4d9fc21599f5fb43a7dd171d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1-dev_2.5.0-2_amd64.deb
-    digest: 4d0a6ecc7857dc60dddbbd6872c2587f1081ce0d75b84c22ee8641a082fd6e24
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1-dev_2.7.1-1_amd64.deb
+    digest: 8dcb891102e9f4dd8a9903bffde5576f017d651927538d613b664c92c6130ab2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1_2.5.0-2_amd64.deb
-    digest: 5be8be254b82a58e77549b1784520f1f7ebb395b57982f87524533e1f061f75a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1_2.7.1-1_amd64.deb
+    digest: 5b7f0cea08bc334eb501726e90caa650c72fb86b2fdd09e653688ac0a184bbb3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
     digest: eadc61825e77bad028fd5eff398ac0e13da7a08870261058525d3f620d90cb7b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi8_3.4.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi8_3.4.6-1_amd64.deb
     digest: daa2aeb5a23c7dea09b2f16b94d15fa6f015ad5ff8c3db15bd0ab890fc920dd2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer-dev_2.2.2+git20220218+dfsg-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer-dev_2.2.2+git20220218+dfsg-2deepin0_amd64.deb
     digest: 77090ec896ce0b01ecf60889622faa1034d01870f4ff57df0182c8af8b12b299
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_amd64.deb
     digest: 0f6db203dd26d4eebe637a1e0a50a75c99a2fb34bb81222660307ee6c0a1a9b9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/flac/libflac8_1.3.3-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/flac/libflac8_1.3.3-2_amd64.deb
     digest: 176363ec9b23f4b24a1bf8f8d0523eab3a34bd5b5d995c7efa2575f5371f749b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/flite/libflite1_2.2-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/flite/libflite1_2.2-6_amd64.deb
     digest: b051da086707e0aa6576b97646a5f4ab6a4d0ef16e1657d06bee41d50d2be9af
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_amd64.deb
     digest: 63b2c4d61d1e41070896b399b52c4b38cd5cc529b66692394b4dbe7f5375dad4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_amd64.deb
-    digest: 1b8d5463ae362465a609408e932ad0bb6968737a59af9669c1c1d3801a31ef16
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_amd64.deb
+    digest: f24f727e6c0976f6f7a728eadc4c887c847c6fa241f40c72b0db90d53441fe75
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig1-dev_2.14.2-6_amd64.deb
-    digest: b4851121202b85ff91dc5023277cbe9e0431744ef3c9e7a88aedb8f9e9c52d66
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig1-dev_2.15.0-2.3deepin1_amd64.deb
+    digest: 361c9ce99546dc7c4ac638132521b5c01d8c52b7a619702fd4d357f510e34e4a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig1_2.14.2-6_amd64.deb
-    digest: c4c5fa416637a08cf925dd4ec0115631b69e4f2f5f46f2094f3239167f781085
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_amd64.deb
+    digest: bda58c37ad85fd9f7d0498483b11cdcf250eda86fff6e399d13105594737857e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libfontenc/libfontenc1_1.1.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_amd64.deb
     digest: 758a94a3acf10d671cc056981255d2bca91e42d74e46edb27f3c89b9c5d5d3cf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_amd64.deb
     digest: 96d67a80be9adf8a9418e1dd33d2bf12d36bb12d4518297842fc8de29bf50763
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_amd64.deb
     digest: 362fcb4c7c381338fd78bfa018b17b25f00596afb9c7d99c28b075944b20eb2b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fribidi/libfribidi0_1.0.8-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fribidi/libfribidi0_1.0.8-2_amd64.deb
     digest: cb0bd9ae5b3c84a26fa8de5a614b557caa3e312fb93b35c46e551c8135275e90
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgbm1_24.1.5-1deepin2_amd64.deb
-    digest: 48a32e67388800832f6a893ac7227ca6d21235f4f4394029d4adafb0e4db4f52
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgav1/libgav1-0_0.17.0-1_amd64.deb
+    digest: a4589dc11a92741054acd8ea7e7c53557cc38a7a0ae44e0c164219e8da298110
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin3_amd64.deb
-    digest: bfe5009a5995e8e9d8206188394c5422b9c7fbbbea954bc632abab9e6699f35c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_amd64.deb
+    digest: 4022d612b88be490e20eea8ce8d3ee2862a2c3fd563e549a523eca14cee34639
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgcrypt20/libgcrypt20-dev_1.10.3-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_amd64.deb
+    digest: e70f1a5d9e15b85cc026d9a816064453dfb05a78fc4891a3da8b595a67debd9a
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgcrypt20/libgcrypt20-dev_1.10.3-2_amd64.deb
     digest: 97b7627a6850415f5c8c72bbf83dcce65cacf88c800676a02456f4a902bc8ea4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_amd64.deb
     digest: f377a741b54094b2b71a461878bf012c8d602d9af146be9826ce058767e396d5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm-compat4_1.22-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm-compat4_1.22-1_amd64.deb
     digest: 35bdaf12b3222875708f4f3967f4517897062a05730f38893695d6344e4f496e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm6_1.22-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm6_1.22-1_amd64.deb
     digest: af88f48a9978a03543cb1bb5170ef936fb80595c8621d73137ba47bfef0de0d3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdk-pixbuf/libgdk-pixbuf-2.0-0_2.42.10+dfsg-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdk-pixbuf/libgdk-pixbuf-2.0-0_2.42.10+dfsg-3_amd64.deb
     digest: ae9e961d452cbbcb9b8be26835441805f05888a1840799162c2c1ccff924f9a9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdk-pixbuf/libgdk-pixbuf2.0-common_2.42.10+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdk-pixbuf/libgdk-pixbuf2.0-common_2.42.10+dfsg-3_all.deb
     digest: bcf7a388b33a76d765b3db4dc10fc0a946086bc7409228898ffbcc522e9dffc9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgfortran5_13.2.0-3deepin3_amd64.deb
-    digest: c3b604bb7a87f8153683bde3116d12afe6f5d9b6baf2f98a8324a013b143b03f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgfortran5_13.2.0-3deepin4_amd64.deb
+    digest: 8e62468483e18f9922bd64d2874c2fe03b3a9fda23dfa0a04d7e8db0bbf8dd0e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_amd64.deb
     digest: 6340c9628c7bcfda4c6826a49c52bc8bf28bfb8d12c163eb19ebde7b0ad61578
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl-dev_1.7.0-1_amd64.deb
-    digest: 0682d06faaefd4fb61e5b8daf45ff4318d9bd96e279792bb4a6eb16b0cc61ba3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
+    digest: 9555387119d2c7118202da7424f3d95a358843cb6e3369135979bf3fb1e7586e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgl1-mesa-dri_24.1.5-1deepin2_amd64.deb
-    digest: 354d263de6831a20606a81fec21621d4040252cf7a7b0e0d91c149b61e244dc0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_amd64.deb
+    digest: e98cff9eb0e1302ecc54f63bfedd21b9b1d96a9aa81f0c224363a26c7380755b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl1_1.7.0-1_amd64.deb
-    digest: 1889b6be38cb7319734d330c232b64aff31845745c74732bf824fe39bcbfdb6e
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_amd64.deb
+    digest: a80285158761a0fb609a7a27676b6ba15f9e30b12985012de34ffd84a8d03e95
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglapi-mesa_24.1.5-1deepin2_amd64.deb
-    digest: 008619449b06981f0bc592e88bc8af8abb5e3c76ce90d047ba9b37db1f5a7e9a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_amd64.deb
+    digest: 90ec3a2e108d28d421cb65fe9245dbeeb0cc923d81f1da45a1af6ec6be5d4024
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_amd64.deb
     digest: 33857078b63370d9edfbceec5a4f8d159db6f75da9f486dd12c97711598f43de
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_amd64.deb
     digest: a90fbe965ef03785f21e55dc04d550243495e96ba47107ddf0874bd0bde8a416
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
     digest: 4e75a1c9e56c81ed2c1737e3e6fe590163a77ff45179101a4fcfb90b4c0d135d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_amd64.deb
     digest: 47e6ec3f082c09540ec0ce8ec0358e9d0d28ea7822e9e7cd5000672f6fd35adb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_amd64.deb
     digest: f6e2df667c442e8ad0305ec62c85227aead61ff85d591ef32ec9de31d086a74e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglvnd0_1.7.0-1_amd64.deb
-    digest: dbc3b9a38a5527c8a02d8edf0f87779993272d61d9b24c3209df69d1ebf3e540
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_amd64.deb
+    digest: 58699e543f5a5135c84153224efd63d61c3312201debeb93430014dbd28f313b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx-dev_1.7.0-1_amd64.deb
-    digest: 31a76ec3d0a13d2340d8f89769770655ead3d477c918082fe4fad249c6d51258
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
+    digest: 5b8281d799f1b3844524c1baa475e4876665b4d6062800655e180586dc0015bf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglx-mesa0_24.1.5-1deepin2_amd64.deb
-    digest: f0dd6385f2f49cd6f955c090b1409b8cfe528a1bd712e47516a60f09ee627bfd
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_amd64.deb
+    digest: ff5c14a729458868c87b7eaeca9e9dab4c06f2f5eec59d71382d36e36f79f3f3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx0_1.7.0-1_amd64.deb
-    digest: 30197452c9ee62b7a7063d1a9f208ffae0eefec86800340a104a884543d133d0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_amd64.deb
+    digest: c7571d6a7a90722d85f06bda863fbae2a42ab73f0b4162ce89b5b6c87382dc59
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
     digest: 6f185c6ac2987d5d8ac0f81be7f0377ac34c00ba45ba8d206ae7ef5888bbca00
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_amd64.deb
     digest: a809596d1ce3a18f2965759b2443fdcb83edd50ae143d61c60cd26862b57850b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gnutls28/libgnutls30_3.7.9-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gnutls28/libgnutls30_3.7.9-2_amd64.deb
     digest: d56ddf6802b16bc9c2ba21d8c5d6312e0620c9b96dfc11f8345d42c8233e9e74
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgomp1_13.2.0-3deepin3_amd64.deb
-    digest: d61e37e7145c09d12cc290022c5361750c93a2f6e4435c52b88dd5a098c19102
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgomp1_13.2.0-3deepin4_amd64.deb
+    digest: bb63b95d0f3cd0b62509318e31af201db37434c93337268db2b366214f85ad71
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error-dev_1.47-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgpg-error/libgpg-error-dev_1.47-3_amd64.deb
     digest: 1ca737a33cb23aee5903ddafe201198357593bd015f5097c68fb99efced85458
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error0_1.47-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_amd64.deb
     digest: c7c00dbad22e7c549a25c147e3d471fae76d0c22d479c0de61aac4cf60e97f36
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libgprofng0_2.41-6deepin5_amd64.deb
-    digest: 0d8d6027c510e0e063e26a85eed097089887027ff8cdbb29cac437cba43e4675
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libgprofng0_2.41-6deepin7_amd64.deb
+    digest: bb74544850bc21a47d09919728769c419233639c8d9e8b1f07679d652b1549bf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/graphite2/libgraphite2-3_1.3.14-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_amd64.deb
     digest: b4697179666eb012313127a7ff04d286f427b49523f50ada6d593694030c0b51
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgsm/libgsm1_1.0.18-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgsm/libgsm1_1.0.18-2_amd64.deb
     digest: 7f037b2ffe20f167cdac62840fd0a333d15b9a13b58220db8094fdfb081d262d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_amd64.deb
     digest: dfa250b0e4ecb5b3c359f49161b460b0139c38b1592b6d6538395855f6c952f1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_amd64.deb
     digest: fb9f1c72e40fd7fece5eab37c9eb473bf3d19c84fb808512d60af3bc909a8c5f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_amd64.deb
     digest: b0b603d7732573aed035c0ab43d92a054eb4351a7098fe6f37e4c736c1b5bd12
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
     digest: b4036cefbbc4f6a5f73f6ac19d3065c52dc6b923691268c5b3032971465c35ac
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_amd64.deb
     digest: 29f8f51877821f22adc742cab010c0f627ff4db8ffb03a1479441c5f2061f9e3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-aomdec_1.18.1-1deepin0_amd64.deb
+    digest: bfcc4990b101e8ba69e7e3b62f1bb5c7f06acb9485f143b9928ef995b656efe2
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-dav1d_1.18.1-1deepin0_amd64.deb
+    digest: 9361b9c37510512513c87f138f06102c4ec0815efad4cbf88b4387b249218883
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-j2kdec_1.18.1-1deepin0_amd64.deb
+    digest: 66e9edeee8eadde39e913b255af05fe253280bbd93144e0aa2536073ee0e4393
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-libde265_1.18.1-1deepin0_amd64.deb
+    digest: 14721c4e958b6926be9c576c4ee9a45733f18bed63fd70346b425888a40c6c22
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-x265_1.18.1-1deepin0_amd64.deb
+    digest: 9ec0bed7ac0cd5f119568774969e118b7aac39070108de9f5814adafd4afed15
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif1_1.18.1-1deepin0_amd64.deb
+    digest: 6414cf814a8f55b1f53239df48cbfe6cbc931dbbeb26212ab50d364526884b24
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb
     digest: 0557f0e34a15444b6792c2726b5d1eb48f9ea8cd42bc7f4d697081e804ced558
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/h/highway/libhwy1_1.0.7-8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/h/highway/libhwy1_1.0.7-8_amd64.deb
     digest: 29de8ab6f7b757646f288b5d13cca950dc4f8bad7b9a018a3951cb141c21e9d1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libice/libice6_1.0.10-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libice/libice6_1.0.10-1_amd64.deb
     digest: 03da9ec604f5bd9ba6526c4e6cf90c5b4266818b2c9a34110d74c42b9be87646
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/icu/libicu74_74.2-1deepin0_amd64.deb
-    digest: 880a9b880d1b4d6f31901541483fa40c9c041dd0949c136e27ace3af3541ddfe
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/libicu74_74.2-1deepin4_amd64.deb
+    digest: a1afb2975773d7ee675f61ea12720c79002d6bcb6b586a5e6975a997b60775fb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libidn2/libidn2-0_2.3.2-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libidn2/libidn2-0_2.3.2-2_amd64.deb
     digest: 0ac47209fe66a5906497d6fb1c76a2addaa8daa2becaa434b17d32b98dd057cc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/imath/libimath-3-1-29_3.1.9-3+rb3_amd64.deb
+    digest: 91682baa98432075d03a7b6069572acc60322c52af51178e681cf2ad783cc4eb
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_amd64.deb
     digest: eb9aca98fdaf66cc394f87b65799ae177c2f97ca300e0c55a34ac736525c9733
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_amd64.deb
     digest: 9153a6287da744a308744636d0e39ed6a92c25f51d00d50e0376203a48e300c3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput10_1.26.0-1deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_amd64.deb
     digest: 52cbd20e0fc0708991bf66a0af9f5ad9a18d88a7552a8a1b46e209a2f54d25f0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jansson/libjansson4_2.14-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jansson/libjansson4_2.14-2_amd64.deb
     digest: bbf5325c3ccfd468e1d8fdafb68c3ffaa89db1e0043e8e757b9f240452c67c26
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
     digest: 7ce8d535aa0768ca1cf24178b956b3bbbc82cca19ce4bbe91ab32c36038ae336
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_amd64.deb
     digest: 98eb75afc9dd66ec83f782a46aad59b0add9aad5ac521e91e35d606bb6313147
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
     digest: fbc596effd2b0a596b71e306d120e5b660bd478c8c9d24e47c61b4ce2db33d27
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
     digest: 126fa110768ecfbb4569ddb66d53621f7007dcefa1234e0ba4f37e364903a607
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_amd64.deb
     digest: 664abd1a931622f6d14cced9ea87f3b4f201adf9616e6ef2daf1b044903f699f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_amd64.deb
     digest: e050a7e05c09e76575d85e0f909aa23ed84e2e80918a601ca753df79f5aba566
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libk5crypto3_1.20.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libk5crypto3_1.20.1-5_amd64.deb
     digest: 203bda60f112a6eb51bfb431c1c9287ff1dbfd4f8bacb931b8ab5aacf52ed4e3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_amd64.deb
     digest: 784e45679941a3e3de3d747f94f215a6fd4b3767aa0b92c4e66a43cc5d628d33
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5-3_1.20.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-karchive/libkf6archive-data_6.10.0-1_all.deb
+    digest: 4ca53184e68be4a5b171d50896da08b26a634ae6f57a14cc9384ce4fb025abfd
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-karchive/libkf6archive6_6.10.0-1_amd64.deb
+    digest: 81ce6ab12ac4d1447502e6f74deecb27c5d74fee2560891fc6a9230024edff24
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5-3_1.20.1-5_amd64.deb
     digest: ae4f1183b97f1f376f8caac13b739865aba4b4b77bcfec8d9dd86c85e6977411
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5support0_1.20.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5support0_1.20.1-5_amd64.deb
     digest: bdc056efb59abe666c17a028924d456a5660c45b68259d2525b9a0d08a8524a2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lapack/liblapack3_3.11.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lapack/liblapack3_3.11.0-2_amd64.deb
     digest: 8c370498cc58fad13de40aa3e50103f38763779d55a2acd9aacd3cdaf7f552c8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lcms2/liblcms2-2_2.14-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lcms2/liblcms2-2_2.14-2_amd64.deb
     digest: a8630b7a9f07ca87612fdfe486941211598f4fe3148235746f001e68ce91114b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_amd64.deb
+    digest: 35570c1c9b06d39aea8c6d2a149f420dfcd1d7503db10e6e5753e0245e1c681d
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
     digest: 9bf199c57795a3e4c8e7cce1ef1803e32e9d31fc7cb82b5db8275f654e19b655
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc4_4.0.0+ds-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc4_4.0.0+ds-3_amd64.deb
     digest: 4024f109044643693dad079fce71b942ffba3bf3ec994d523130c33e776ea06e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lilv/liblilv-0-0_0.24.12-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lilv/liblilv-0-0_0.24.12-2_amd64.deb
     digest: 0efb7ab23ebf1a16f538a85dfe97ede84bfd81b347e67248fad44ec1163172b7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
     digest: 44596cdf0fefdc6412af3e1e0d0a4bdee4762d348cdf3818a2cca0daab437285
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_amd64.deb
     digest: f2d4e6214fdc72ee0c23079e0418dcf190fb41fc10612f9ef21ac3cbcbd701d3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lz4/liblz4-1_1.9.3-deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-19/libllvm19_19.1.4-1_amd64.deb
+    digest: ac9aab75b71b3b452d5bc1245e1bea4f62ee9ca50d4e7efdcaa640495888a39d
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lz4/liblz4-1_1.9.3-deepin_amd64.deb
     digest: 9808e49cf41c4a38f0ff4f4de7080ae392682f3cea166abc079a26625c8233aa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
     digest: 0e611c43cc8cee4b31dd530ef21f4efbb16caab257685a770b612146e18a6b8b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma5_5.4.5-0.3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_amd64.deb
     digest: e8051c2b44fa1cc020c12ef45f4918c1dd7595532af89df0c583b4b3f333fa56
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_amd64.deb
     digest: 1e2259f608a4bd66990c6ec31539f6b328776721a6ab5893e172802db5b4d952
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmd/libmd0_1.0.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmd/libmd0_1.0.4-1_amd64.deb
     digest: 755e2a59d76415999f46b0c307ade64df3788013286e902e2531e07ff58ca781
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
     digest: 9f1630409adb3464aa42afc519d2163a7741d152b53c937eddea55b9fb6fb10a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
     digest: 256423c8e3c4afcbdf72973db84b1e919187b65955c685ee16f9a5635d436943
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount-dev_2.39.3-6deepin1_amd64.deb
-    digest: 5b8858e4a945774d52c40824a44668cd0b5e260c61b7f9bd6685fac1cad27698
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_amd64.deb
+    digest: b88f61259a6d84105bed6041a41348d696d49ff8aea65ef1308e84d9399999fe
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount1_2.39.3-6deepin1_amd64.deb
-    digest: a6c22f3b3c30d72424a05ee1c8874674d4e69b5dd703aa7b8936c7c21ab8c009
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_amd64.deb
+    digest: 0034e277c6bcae0dec03e27a6b1ce99bac79a04e2157fd3a8448c5141bfd3fbc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lame/libmp3lame0_3.100-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lame/libmp3lame0_3.100-6_amd64.deb
     digest: 79b03dd6b90ece528ed2103c0ad41785290e6ef4d80991179c15f11992031bcb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_amd64.deb
     digest: 8da2a921507884c5bb32854be4feaa1fcf5cd51d5d41b413e0f75982ad578a9f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
     digest: 92553337dcd1837205a4f136419b0cf40956e0975a938ad8e8e7b586659d0e46
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
     digest: 28686d830a44272e63013aae1e508f0f767ea28c2a4856d6c6724e11b2a6f93e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmysofa/libmysofa1_1.2.1~dfsg0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmysofa/libmysofa1_1.2.1~dfsg0-1_amd64.deb
     digest: 1c6cdb1193c443eb151333e709047eaaab206e22e48430fa59d298a0d7f37bb0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncursesw6_6.4-4_amd64.deb
-    digest: 9993f7cfcc8cf37e6474d7b570faf1d5a19187af8a820f38cd5315461c765f2f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libncursesw6_6.4-4deepin2_amd64.deb
+    digest: 05ebb9cc9fd97fb54ce586388387e309068c027a45d94f31b5c9dd99b0d06fe2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb
     digest: d19dd4ebabccc00232223b414732c26b63d4ee67f4147ad5a105795f4514382a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_amd64.deb
+    digest: 9221a35b50f8c23ddb78e93ea4cc66ffaf96586d38503ce4b8b61f6995739847
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_amd64.deb
+    digest: c8c7b6f84833ae5fb50f7e6d127d07ad09a356f952b191edbf0542af500aa796
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_amd64.deb
+    digest: 81438d30b8448343632bb615c15ac772214df4ffbeba7a4e5fc3e87afae28a45
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_amd64.deb
+    digest: 526bdadbb91c83e044e49e2f270684e1de60790897c9c912d3abdbef5c7c5796
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
     digest: 5b552cdd40095bd94c6276021dfc5360f2a6289aa94f155ab3ab3daaef341c1d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl-dev_1.3.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_amd64.deb
     digest: f17e04a96da2dcb260bf75ac750a63d238942ecd9550ce41cc3530774c3ae807
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb
     digest: 27219179fd316e3bdc7f9556d1852fcec175d13334b5aadf6274c19be98fb268
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/numactl/libnuma1_2.0.14-3deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/numactl/libnuma1_2.0.14-3deepin1_amd64.deb
     digest: 865f9d820329453a390a1c21375d7d7db3c6c68b36924eb6ac81a56cecd09874
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libo/libogg/libogg0_1.3.5-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libo/libogg/libogg0_1.3.5-3_amd64.deb
     digest: 6de429751d24e788ebc92ecb3e4c24c49f6aca67e0a9584f999d387bc4cefd7b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_amd64.deb
-    digest: b91f22b0ab692fa36eff6fe2acc7e5878ab99d56177f3983cec1db54bd9c7f72
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openexr/libopenexr-3-1-30_3.1.5-5.1deepin0_amd64.deb
+    digest: d9d8f5d2235a3c572580ebbc59c0dbfd80625c8269cc8adc0df9f4cccdcda74b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl0_1.7.0-1_amd64.deb
-    digest: 85398c86d394fb5d1c7b1f75cc6f3f3045424224493853cb94880a82baaddf8b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
+    digest: 178ad33f72e1905c6d777a680fad42295608be7a6f8f95dfe5f2f27dbfcd5505
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_amd64.deb
+    digest: 8cc2d909d52c3346a714c2eb5d0115db214f8aac5eebfb5e41bc91eb48f7f951
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_amd64.deb
     digest: 1d7109a9c3f29c8bde7b4f92866d28860ee641dcfe3a718f4b730f845e63a4a4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_amd64.deb
     digest: a037354a8429c3c32358ee745ab5dfe3d92cc60b74fa68d6355e8b63ce100fcc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/opus/libopus0_1.3.1-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/opus/libopus0_1.3.1-3_amd64.deb
     digest: 5ac61126fb5114217854990fdf86796f2b8a4c8fb11a29f369e76dd865a42936
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/p11-kit/libp11-kit0_0.25.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_amd64.deb
     digest: 3aae0a4770a313f4092d89d9603472fe9dbc0bfc9e69230868c168b3b30f860a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_amd64.deb
     digest: 578da94d3d5cdecfa7206866fa668e3d34ab338366395dc4665501e61d1b7a23
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpangocairo-1.0-0_1.52.2+ds-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pango1.0/libpangocairo-1.0-0_1.52.2+ds-1_amd64.deb
     digest: 79abcf83edc6c1a9dc59f987374c9e980cf2ac8d99ef2cc5f0905b481ef7e113
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpangoft2-1.0-0_1.52.2+ds-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pango1.0/libpangoft2-1.0-0_1.52.2+ds-1_amd64.deb
     digest: 2102f48725fd401cf12395a26f261386483bb5516b280f8ab35e34da3df5b107
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpciaccess/libpciaccess0_0.16-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpciaccess/libpciaccess0_0.16-1_amd64.deb
     digest: 549736858b99dc151e23c249ff54a69d6c03c03784af6cf8af0b71094df33a69
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-16-0_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-16-0_10.39-2_amd64.deb
     digest: 1219e0d46f5c584323ad7e41c6fb39cdb8c6ed242a64913b7dadf0c557d84b6b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-32-0_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-32-0_10.39-2_amd64.deb
     digest: 313cb3eed5be9793ce6db51292ca3d08334e9799856d88c085d268a4a264a586
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-8-0_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-8-0_10.39-2_amd64.deb
     digest: 26ba66e349a9d46978d24e5b165c327e1ef51007770c43a3a49eb35b5fe0310e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-dev_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-dev_10.39-2_amd64.deb
     digest: b2a505ec6ef461644bf946949dc7def6a22ae8627c59ede2a82e9f77500eb856
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-posix3_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-posix3_10.39-2_amd64.deb
     digest: f1d82802bdf71d13b7fe0b95aa0efbef3d4c661920629686170eabaeb8f4ecff
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/libperl5.36_5.36.0-10_amd64.deb
-    digest: 1cca8c85872210489e92326ca7fda2fcc8d9b37a085cd1a0c87d54aa685118e8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_amd64.deb
+    digest: 6338341b375c166ec39e466ef0282642c338d30d028a99414aac2b44a7efc3ce
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
     digest: b8f9b921c681e6c08abd8d452489762dc8ec3234e058407757f4f383ba2a01c5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pixman/libpixman-1-0_0.42.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pixman/libpixman-1-0_0.42.2-1_amd64.deb
     digest: 61dfa0134fe4038b88e3e64081f7340277297771d3a7c1667277cb9b992d2d0a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb
     digest: e4677f42eb04cd63106e75ef1c008595a5b306129d6fdd58171a4b3732f2aca3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libplacebo/libplacebo338_6.338.2-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libplacebo/libplacebo338_6.338.2-2deepin0_amd64.deb
     digest: 4d18786f4da6671935483f18af8e36df7bb7a56b2d229f2b744b8d5d2c0e0191
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng-dev_1.6.40-2_amd64.deb
-    digest: cf53c0792230a4db2be1859a350683fe3831e58986622c8131e67ddd875fa93a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_amd64.deb
+    digest: 8d86e3bef4bb2aa5b9a98eab26d7bfc4929e2596808018ab4dcd905d7b045961
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng16-16_1.6.40-2_amd64.deb
-    digest: 3327085ceef26f45c52af3462d6e506721371991a983b398e2fb741c2c48ab29
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_amd64.deb
+    digest: 29d46c1159c18e4c17c103b7e830d5044731d81b0d54c0f346c9ad1b9147e990
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_amd64.deb
     digest: 300815c25c3d2b8aec8dfd4a03fe74da7d6bab832deb21fe5aa24a3a7e390885
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin0_amd64.deb
-    digest: dbfdde5ab37b0d154efbf5dc331f8e993f320f8cb31a2ae688ae3f0ef154e882
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin2_amd64.deb
+    digest: 48c14ad01844820e5d2d37b4ec3353529ab7e0eddd277c0d64c863d1258d3e08
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_amd64.deb
-    digest: 01182c680d643f335f63ae38016fef3d5f097ab718789f9aef79de42f00517d9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_amd64.deb
+    digest: 4ad4360252e008b89ea7885a7c27e2df5af4a45e0aede319e08b17db3c3af932
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_amd64.deb
+    digest: 7a00b4f3ca191e7a887cbfc6b0ed619493bf5344b85c8e823577b115ec34f738
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
     digest: 8be922fba920a96d098288da4fa5f1d5dfb778b362d7a26ed738014305aa3787
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pulseaudio/libpulse0_16.1+dfsg1-5.1deepin1_amd64.deb
-    digest: ad40b445b798ba098f7191b90a5e949f091b039bcb5961d271fc9715f3f2053d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pulseaudio/libpulse0_17.0+dfsg1-2deepin1_amd64.deb
+    digest: ae0d0ea5f41475d7382d2192eb99b606257b857a44e9d4287302c4ac39732052
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_amd64.deb
     digest: 7611dfe764b5a109e1fa516270c304d451aa2980190c480a83b90207a6b84158
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_amd64.deb
-    digest: fef2ce003db442a002e3c874de33656cae3ef4a6d00a2a72e267b386df647945
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_amd64.deb
+    digest: 452e6e2a18330944a7ab46303050baae3385ce7ad2f509a6526c211b077836d3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_amd64.deb
-    digest: 192a53ec08eb4b356fcc157b8ba97a4d2e1e4a2d8e8d32e37a9d70ce5ff2ea22
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_amd64.deb
+    digest: fc43de68d925c6bfdf632afeeb053f1b28f4050b197ade1c93b701cfea5aaba7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 3c7b32f481b4d44bc017945a73a0f92377ab0a11ffab36e162c768280fa4df5b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin10_amd64.deb
+    digest: 9c271d6dd6f7a6596ed2b700d513c7e0b1171c10190a0e052dfca40878b314b7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5dbus5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 7da15afc4adac19078605f402e6af56583e4df322a92bc2bf0ec08a203f9eed8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5dbus5_5.15.8-1+deepin10_amd64.deb
+    digest: 548ff230b9dea102165cd00be7fa4ebb1facc7aaaa660cb89e150a069b25b0aa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5gui5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 502105aca897cdf0afa5c95dc143a505df44388043a2e6098528955b81cb36de
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5gui5_5.15.8-1+deepin10_amd64.deb
+    digest: cd9608cfedddf7d2ef2783c10152cde18cfe71546a09be1c3cf41045046452c3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5network5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 6d53b85e09f43ab9d6cfaf9c52efc5957b708d5b4cdbb1efe39864241dba076c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5network5_5.15.8-1+deepin10_amd64.deb
+    digest: 4a3f5bbff71bd143b94b0f5d3a5da959bf588bc68db4ff6d3e374661d5df9a91
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5widgets5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: c7ae639e299e34d6d7ada2f0ad797c18237f5ce1be33ae674fd3bf9b8b01ff19
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5widgets5_5.15.8-1+deepin10_amd64.deb
+    digest: 749fc2c12ce2621ad8ef40cb7da61fdaebb785354b09129a90819f6d64249f9c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 2b27dda887d891e316750fb1b7bd56fafb097c1bcb0f03e7ae0062561da40a6f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 827f947abe65c18f979255506073b5d223d2c81e65a2528da21fefa11c9d1af8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: ebd40ac7c53cd6b669568467e3b9b010abbc030ea1201662a74e0cb95a49698c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: b6e687e6926547c0945ff5138495d025ca190f7991b42ea98193c29ef13ec08c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 54dc26fe98838334213678668a1cfd3c020f2f050ed8378c0b8924ec1af8cc31
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 9f7c4a6b688a3c61fd526f22a54959be1a9a5b550ef981a94bf06d7a91e1e4a0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
     digest: a6864707b38a192dc89ad51546e958fc2095ca3b45e6ee99e190d48ef54793ea
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
     digest: 033f970ed9f2486fa265bf3a10332fc18fec0b9d0a83d74ba999007c4d647fc9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 41dd12c029ef2a97fc9524b773c007642948bb0968f71f6dd08538dd03f8d375
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 33eabd5595bcceca83cfd7747d0cf72a6a9fc6555e2ce3e2ee9c5f1abd23456c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
     digest: 18db346cbe4e81620934c3b232222482f5c1251725516d3fb620c10ef2bb2611
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: d8d2854d73ebeb2607bc90ba83cfa55b67cee62ac055bb1b6228bd426fea4363
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: ad1be661bc76e8c62bf7c5a89dedffc7e5e3203119d86e2fb9d5747eb93fe9db
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 7e1f0b187c5e82d45c06a8b3849fcb4e2a6cb6a31b950f7622ead3747009c54f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 093d158b5adf7efa268a719648907c412927df1ad770c15987bc8c0b48a8515c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: f87c83461bc1806acf203a7e52a8c47e32aa5e42ede0d26f0ecf8a26bc914576
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 9104c64aa25ec85a9f10a650ffdf1b03aae2321693ad4485d39b67c7bf68ea0a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 4c1a62bbfb23764fbfc250027bab219087940ba16fa680b1e7348dcf418906f4
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: b91d897b49c277334fb8a68dd554e749c24e01b3d989b7e85d4c08eec327001c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 4f9d66873e7e085fb6909fd47be1fd50a41a8dd4b15b38bc77ab2dff42e43cf8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 2fa585bcff6d8630d2e321e265b7cc592172a3676d6d2adf9ed2ff8ea1854c7d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: d37c7d36dbe7ec33a2f8693f66505262e8f6b9911acc61e0f0d272f479913ba7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 21cd8eda13f476ec71438f56f43ed8933cc0b625302fff4c6f23baacbfb3b5b1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 528e27bb9f946d602265cd8a43853f56b2754f3c945ac7bd64a099d7cc589f34
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 1bfbb5f6771c285ef838eaaf429106eecbdd305baf365766ed05cfb7ac78ff3a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 105370dae395895df950cca059ee1d11aa5f6677a554c7331a83bc0da959ba52
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 7af38213ff2d557481dfe8ef0073da0fdc1ad1f70b22116ebd02f4d39bfb4292
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_amd64.deb
     digest: 0e43640fc49faf57d8454012338aac69b638356417a4a2361f3c0e47271ffbf1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_amd64.deb
     digest: ba29752fae4494fe62f5a4d3f139386078d8beb74e53eee1d7c673028a8adb97
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: ae45f73efa9232cbb98621c9ecc12488a7ebf687eaf9866c2e171aa37efd96c1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 9cc8d7cc8d4290b937bcdcf36c18e63293cbc32821a14bf78d69d336dde918e0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
     digest: 5a2a509181e35a92f6effe0f2ef107c7dfadccefde35548bb1ae568aea003fb3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin4_amd64.deb
-    digest: 88d55f6992afd8662d7050d82d0f23db38f74907b8f21e2d4ab8a5ca51d4eefb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_amd64.deb
+    digest: 70486bbc5555f857aff3ca539dea86df4f800d20ad4e20b3cc5b62b9a6d75b21
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 4ba7721998329f33d49cc6f82add0a1a6819b59c4c8ba1e82dd084bfa3235ca6
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 3ee17d593ce177df59677046e7f5a8b62e5f30143a824d6b7dadf327da631d24
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: d311d6a7a8cf93949f715bbbb271149e3396966a60611a086b05b125dd17c77d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 7ee33cd4857e0c72a6765d62d14d575ad3abe1e74436ff8615f0659c46e60d71
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
     digest: 4b74d4425bcb1d23d7763e62cb1c9f2be712d9f92e46542151125ba96d623164
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rust-rav1e/librav1e0_0.6.6-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rust-rav1e/librav1e0_0.6.6-3_amd64.deb
     digest: 59a08ca19c702ae237a780f353ca83fe082a117b7fa4d2fa3678c32e2459c594
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/libreadline8_8.2-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/libraw/libraw23_0.21.1-7deepin1_amd64.deb
+    digest: f35f81423070586a3589e069a4163b1827c9ba9cf2ceeaac08f1653faf78dc6f
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/libreadline8_8.2-3_amd64.deb
     digest: d7d4a492aa183701aad09f9ae4e156df8d4d5e336f40502f51c72cb5135cc296
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/librist/librist4_0.2.7+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/librist/librist4_0.2.7+dfsg-1_amd64.deb
     digest: a1b97e9333948a2fe8001e60d882e7decc9fabb83d5532305f3ae9a2f0473c69
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_amd64.deb
     digest: 2fbec23eb0a08c54ee112b5c11652ac78bdfd3391605882604c2a6003ca75c46
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rubberband/librubberband2_2.0.0-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_amd64.deb
+    digest: 9743d579d479e0e2ef99f984986b2d9d40d7e0a43b6f0f74b935f3fd2d5b6caa
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rubberband/librubberband2_2.0.0-2deepin0_amd64.deb
     digest: 06dfb10d8fc7b8ac4bb6c418d7e1c331de9cb737c4d4802aedf2834474ca8012
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_amd64.deb
     digest: 8ba9b50925d6722aad9a86f36483cc5cbf169c6199b21edd84f43bf142608cf5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/libsecret-1-0_0.21.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_amd64.deb
+    digest: 9ff9bfa155660e99d78ab3501392fd17381adcb90bdf2457bac8c3af296b3815
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_amd64.deb
+    digest: f02625e8d695be6bc1aa9531c5177097ec906333b60a0fa15861a82ade617762
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/libsecret-1-0_0.21.4-1_amd64.deb
     digest: 3f0d57a746a87803d4ac369c23f451cfd3dea8fb2d90890486d7bbb33d8e747e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/libsecret-1-dev_0.21.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/libsecret-1-dev_0.21.4-1_amd64.deb
     digest: 65230d1419dece374bfa6a4b9808ddad7a97cd7d2ed30b842b1b5fb6c02bb6a5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/libsecret-common_0.21.4-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/libsecret-common_0.21.4-1_all.deb
     digest: 2c12c067604e4872a281ddd17347c2a8bfa35ec65c086d46aed37414786205ab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_amd64.deb
-    digest: ccc4c248f64dbef5e3b9711491fc93a903e4fa15d1616f5ee1bfa0a5cd82c73b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
+    digest: f7dfdd9e463828cff8e624ceda7f13cc68f2c9d2e72b27dc7e7315e1193b7d92
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1_3.5-1deepin2_amd64.deb
-    digest: 6702f261991679f2b5fb4643acf010396a12d3994e26dd568628f433e6f0f129
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_amd64.deb
+    digest: b402ade709a2820f2562dfae7acabdb41e59916ef931e5b9d270812cf2b7fc20
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
     digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors5_3.6.0-7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors5_3.6.0-7_amd64.deb
     digest: 5a730040a0326f0124822fb9ffd632d4891c5451873049d630d0f9da63f0db10
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
     digest: 4a1b7141086a540294dfc0df7eb707f2ef1e57d2a2f4b30f80821164d0f97b7b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol2_3.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol2_3.5-2_amd64.deb
     digest: 47738eed5444661ac0a8a8f2ce6fee7bcd448cfab2701340c51464cf532ccbc9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/serd/libserd-0-0_0.30.10-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/serd/libserd-0-0_0.30.10-2_amd64.deb
     digest: 3fa4be028ff744b1440c8663795323c01e29f109d3c3f42f61394b917778ac97
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libsframe1_2.41-6deepin5_amd64.deb
-    digest: ba80a62cedf20c1aacd7d5f5d4d4b9b8ad03ad3ead1487b3ac4bd213f9105bab
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libsframe1_2.41-6deepin7_amd64.deb
+    digest: 5e5d2c0bf008d65000ea3447906c80423d4f6f2053cf050f45804514c17d0db2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
     digest: 7af3357f80d57fdc31a26596f9e93f0218a625929822228d312498cabdcea72e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_amd64.deb
     digest: 9da48196bd083c4749d1b4814a15780fdfa5a962ce3c19c5abfe0fa98e4e870e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shine/libshine3_3.1.1-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/shine/libshine3_3.1.1-2_amd64.deb
     digest: 6b983449633db36212a3484471299d546ef79dca6bfea56866da050aaf260b5e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsm/libsm6_1.2.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsm/libsm6_1.2.3-1_amd64.deb
     digest: d8a6d0abf65a6fe4c5edcb5fa37b115477736e60c31118df74b701a468b49cab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/snappy/libsnappy1v5_1.2.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/snappy/libsnappy1v5_1.2.1-1_amd64.deb
     digest: f125795c50fefab5431647aad7d9de630554c254af61837893feb3fe0960efd5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsndfile/libsndfile1_1.0.31-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsndfile/libsndfile1_1.0.31-2_amd64.deb
     digest: 91c58af0419a33af2baa57684a5a85ca6c0106cf6f5d80f62341b0280e6284cd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsodium/libsodium23_1.0.18-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsodium/libsodium23_1.0.18-1_amd64.deb
     digest: b16ee914acaaad0cb1c062370f30934b76e401350bd531d169e5838927c4da30
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_amd64.deb
     digest: 10dcd94952de8e379983b3ac597802fccf58aa0f11b23dbe03f406a71e08135e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoxr/libsoxr0_0.1.3-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_amd64.deb
     digest: 9736df9018121b8368b482278a533284a82da09650baa3cb3541fa58cfbc09cd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
     digest: 44381cd9ad35fa6ffa7a0b3e27611011602bb32093efaf0c80117dc9f97a371b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/speex/libspeex1_1.2.1-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/speex/libspeex1_1.2.1-2_amd64.deb
     digest: d550e0dca380616b0d3f2ee0731235fb2e8d5ae6896d2f1d90b7d8e419ed8f33
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sphinxbase/libsphinxbase3_0.8+5prealpha+1-13deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sphinxbase/libsphinxbase3_0.8+5prealpha+1-13deepin1_amd64.deb
     digest: 286774e8597a0d0cb174ee4516fdfeb622077e4e5b26d1a38c7dc33c8239ad54
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_amd64.deb
     digest: 73029e73a746e8723afe8e98469774dc3de39cc7ee59a5ad1e9dc4745c11f55a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sratom/libsratom-0-0_0.6.8-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sratom/libsratom-0-0_0.6.8-1_amd64.deb
     digest: 0c389661679c23548729898096cef966a575929c9a8630d2da565169345c215e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
     digest: cda4bbbcedb3ddd9b6722acabb811b95d1a6573a60ad7e6fedfbccac843bf8f2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_amd64.deb
     digest: d24f878a3059bc9cfa70dc1053cb1a2aad772c63b8bc528d4ad47b089519c017
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openssl/libssl3_3.2.0-2deepin2_amd64.deb
-    digest: 8b86b65fd2480dc342d16a1dd62da1cdb955ba34d830d245c67ed3857680dbec
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_amd64.deb
+    digest: 90258a13940712eca57406b2bb0d274fbdaaa2d62a45c1e60c5b123c4080d663
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/startup-notification/libstartup-notification0-dev_0.12-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openssl/libssl3_3.2.4-0deepin2_amd64.deb
+    digest: efe5ea0c1f74ce2ee8c760ba534276c01c0b347fb7eac4285f79b935bea8274c
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/startup-notification/libstartup-notification0-dev_0.12-deepin1_amd64.deb
     digest: d36752d62a6a63407eb76befea31cdbc678aa3cc06b4184a54064d6e83ac62fa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
     digest: b0e9783da04f53ba8da97660523021322c4477059c63d3684fab283b7f9aef9c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin3_amd64.deb
-    digest: b58b4f44e2a475c39749808c5b7f6bafbdd50e25e6b59dff28ac68ed1603234b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_amd64.deb
+    digest: e2c664c12b609801da2f8cdba3ad5b19ba7bd3fcfe3d47dab5b14f5a67919f57
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_amd64.deb
     digest: fbdb57f1b3b245ef8d92d7a29bd0b054fec010ffd245b1d633172674acbdd7cd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin0_amd64.deb
-    digest: 5433808e381ce031841801dbad1f5dbf31e7fb66e44c6b47b1e3d782d6577db9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin2_amd64.deb
+    digest: 9586d0d1d63a4140827a2a2c6b63bbb4c74ca6c3e211dcd007da10f71330e38c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin0_amd64.deb
-    digest: dce0e6c6a5b69fedacb842be249acad0eef03fc1f76c97ded590dbe31cdacd45
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin2_amd64.deb
+    digest: 6dd0610dc30fe5bb3a72788b563a8c6b77aa2ff482f3394d9f7e4bbe8f8ec74a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin0_amd64.deb
-    digest: 2f6e7a4c570e99b590b1d3a78c2cfd96bc4a665de3e631b292180336af31440a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin2_amd64.deb
+    digest: 9889c27469bacd09cbaf06ceb3f8c7b0f3210248e79d120e68b434e2adfbcb28
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
     digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd0_255.2-4deepin3_amd64.deb
-    digest: 2d65df5f46dba24e2cd25605b715ea7bf4b1a23ccf2fb789f50e4a1d9c0586f4
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libsystemd0_255.2-4deepin11_amd64.deb
+    digest: 75f4b1c1d7e0caf4127313225fb3be35243b09df4cf93e0225f5fb27e6c4074d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_amd64.deb
     digest: 3f24f7a181f374bd6623bfdc7781e2cee5d948361a456d2f6216aa4ba5c44a2e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
     digest: 3a87af58b0b3becac7062da11264d083cd68190e7dd421c2cbd00da8841cfa25
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libthai/libthai0_0.1.29-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libthai/libthai0_0.1.29-1_amd64.deb
     digest: f0bd45223660d1b5b5a0d8e34637cda429f1600a407c8f7970293cbb27c4e165
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtheora/libtheora0_1.1.1+dfsg.1-15_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtheora/libtheora0_1.1.1+dfsg.1-15_amd64.deb
     digest: 6cdc119b8a9f7a413a239e026378793bfc6b6487295db146fbe992994e420097
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff-dev_4.5.1+git230720-1deepin0_amd64.deb
-    digest: 5040a118bf35582b0a96581b1652a2f97b83a936d8f9ec90bfdcd39ca63b6341
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_amd64.deb
+    digest: a181a6d9d9fc0e75973f750168a540a2f25719d27e0e7a981a608ed049496f66
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff6_4.5.1+git230720-1deepin0_amd64.deb
-    digest: 5d0206a7996e6eca94109bc0c78fc968a5dbc8c46050e43f82cadcff0331823f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_amd64.deb
+    digest: dc2eb00fa11dcd6b3cd5ba61474d863b504d5266b1340ffd7e97ad389b0d2f87
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiffxx6_4.5.1+git230720-1deepin0_amd64.deb
-    digest: 88293e02a12cfeed11a657116b795318a07abf69b80599f8270a2d1148c15978
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiffxx6_4.5.1+git230720-5_amd64.deb
+    digest: 7da1a52c67cecd4aa048a35c7d1fedab8205b36ca59adf654b518c1604032119
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libtinfo6_6.4-4_amd64.deb
-    digest: bb49775a3e3df73dbef25027937ddb2f714f262e8cb859ef228d26b3c146b6eb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libtinfo6_6.4-4deepin2_amd64.deb
+    digest: 7d248232bd021f95756060036d571d809b1701c670d0e47e2e1f6caabebbf517
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
     digest: 74bddc18e3289947b20653433e82025873f5679ccba52f258ca4912e435a09ee
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_amd64.deb
     digest: 801b243dc8b3ebecf2be9efc9ca69cd987f26830accede2e7142210c5640ee91
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc3_1.3.2-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc3_1.3.2-2_amd64.deb
     digest: 4ded57b843774f3c65449d6ad7bed6efb97bf94cdb4aadb8554fe5cc12210291
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
     digest: d7c7fffd808cd0b765d2287b98bea752d740994788dbf90de6db4f9710e41162
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/twolame/libtwolame0_0.4.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/twolame/libtwolame0_0.4.0-2_amd64.deb
     digest: fdc576e8da6c75367f25d569902e6217db30f61d7865f35d43a53d824856c974
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev-dev_255.2-4deepin3_amd64.deb
-    digest: 70e6473b554cedbd161ce7f55223f5fc921ae173025f92ee71d77df4afccd314
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev-dev_255.2-4deepin11_amd64.deb
+    digest: 248c864cdbddc655b53eaf7a8b3f930d888daf62b279da8506715fbed6e1129f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev1_255.2-4deepin3_amd64.deb
-    digest: 540b14570f244649ac7cc75094b0bb9ad8a16287747bc53b53cb85cf4404aedd
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev1_255.2-4deepin11_amd64.deb
+    digest: c7acf7afccba7ded43d8cbd42971a6277a597e1dc1190726cf38667369acad35
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
     digest: 5ebb4a61642a553212842e52f9bcca0bcdf2fa47f95d8d1a4b30d6096dbda8e9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin2_amd64.deb
-    digest: 097f3b74d6483cc3ed26a4b8c9775a2cf4da3f98a2c1b30c2c7040e40da42a6a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin10_amd64.deb
+    digest: ec3e61f20da5ed81b4a1c455b690eae010801c7a5f797fdc581fcd98da0b7888
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin2_amd64.deb
-    digest: ff85f83750473640cbf62fbaebc09279521492117bc6393affc19d45e63e1265
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin10_amd64.deb
+    digest: 9540c14a3cb8fc2edddb6a95d0383e2b0dc1d61f275a81fc57ea1d7e9edebec0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libu/libunistring/libunistring2_0.9.10-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libu/libunistring/libunistring2_0.9.10-6_amd64.deb
     digest: dfa507aa9982a3ba8cca86bc571d47e0c30d8adadc833e16cba4edd6e4c68155
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_amd64.deb
-    digest: 8cc7e43d37649c4ee3595f33589716d7eea70ea4ccde666039b2b1d01a4f8413
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_amd64.deb
+    digest: 5ff4edf566b7bbb9d4e6c175a5d58c26aaaf201472f12433f1de46f546945d03
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva-drm2_2.20.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libva/libva-drm2_2.20.0-2_amd64.deb
     digest: 3c519c4dafb6a654f92945151f133ecc09263a62a030ceef6c5357e0dd3dc731
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva-x11-2_2.20.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libva/libva-x11-2_2.20.0-2_amd64.deb
     digest: 62dd0f5dc9df1a6ced3394b9ee5276fdebc951e02d1d97cfa3ab378159f2f42b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva2_2.20.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libva/libva2_2.20.0-2_amd64.deb
     digest: f29d80ea76016a56fc7278736a8c38e26351599e35c459014ebf34be33081bf1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvdpau/libvdpau1_1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvdpau/libvdpau1_1.5-2_amd64.deb
     digest: 5eb63aa298bf34d70a561dee7b8d9f2e7cdb80c3d1193e05a7775f9fc0739b9d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvidstab/libvidstab1.1_1.1.0-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvidstab/libvidstab1.1_1.1.0-deepin1_amd64.deb
     digest: 1e15072d6b706e885046073d7acc1e2d792c16df0957f08d8dc1f2ae15955700
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvorbis/libvorbis0a_1.3.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvorbis/libvorbis0a_1.3.7-1_amd64.deb
     digest: 9a3210b3d90c53ad6b726813d03dee23f08fdfb6d6be3a7b196f8a08106fa729
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvorbis/libvorbisenc2_1.3.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvorbis/libvorbisenc2_1.3.7-1_amd64.deb
     digest: 64ce2a476cd54927f711b9947ed1f49944e2960cad96be386d139495d8da2304
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_amd64.deb
     digest: 50a8cfed14d73f5e15fe13de7faae7d05b5e3a5afa79bac1ed373cf8487213a1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/onevpl/libvpl2_2023.3.0-1deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/onevpl/libvpl2_2023.3.0-1deepin0_amd64.deb
     digest: eed4a33395e33aeb3de75337547f745e7b0a131547ac2c88483aa1f7cbb6fbe6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvpx/libvpx7_1.11.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvpx/libvpx7_1.11.0-2_amd64.deb
     digest: 2f51812db0c74d577fc30293fd86ab40be513a457c754a491512bca9b140715e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_amd64.deb
     digest: b3a78dde8283c64a2dbfe25320506a89b8dff77169e6e195129088047a272d4c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_amd64.deb
     digest: ea988ba1798a25fa13e1a6b852f1f8f8550293daead86a931846e4131a9e6c2e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
     digest: 2e107e0a55003a2c223c792b5d505e566c553c42b0f6acc98f927f1a88bf4c2d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
     digest: 2e0eb22e108ff3de178a570dcd21ab3d6cc16f6baf94bec37595008786789280
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-client0_1.23.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-client0_1.23.0-1_amd64.deb
     digest: b5f2ac4f0acf93a0df4efefe38f34ebdc0e1724639c864e5777447bb5f9b7c2e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-cursor0_1.23.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_amd64.deb
     digest: e0acb5c50acbe13b427f9aa0ef9dd662d6e824b2f1d17e1a170bdf20422fcc36
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-server0_1.23.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-server0_1.23.0-1_amd64.deb
     digest: a63916b242532f6c621674b8dea3fc9e0c55f6592409edeb9146f8b978ec5a6e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
     digest: 0c60cd19f18fbd0cf299480c7e7cfcb7451e6b1b05dc8f2d5cae1cd248e4bc5f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp7_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_amd64.deb
     digest: f2271cabfa4d4847bef8a522e2775d4f9c09a2560911df4779a7cc06d650eec6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
     digest: 26d6ff4ed6bf1da7fe3eafe2514ef5c04a8792381b35e3bd3745fab1b6347246
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_amd64.deb
     digest: bf245a91bfd56f199fc182030a8b9091c77ee4b3fa99754328ef6e4c31b9eafa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_amd64.deb
     digest: 4732ad39b0b2d4504983466503fa0ea1ba286c42aca07feeca8055d91e17aede
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-6_1.8.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-6_1.8.7-1_amd64.deb
     digest: e21e2b12e455664dd8b6ceb201d853c120dea77e0703c95545a3176708ae699f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
     digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
     digest: 93ec6c1345900f791549c12440757ba08e756379278bd6fe5133e6690c544621
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-xcb1_1.8.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_amd64.deb
     digest: 68341e587a81b03655ff00f0cc9ba543181285504475e66b422308b1bdd30e5f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/x264/libx264-160_0.160.3011.1+dde-deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/x264/libx264-160_0.160.3011.1+dde-deepin_amd64.deb
     digest: 4e6bfa84f6f72256f4afc8b5dc0978368998cc1857f1ea5e71eb6eaba10cdfaf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/x265/libx265-199_3.5-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/x265/libx265-199_3.5-deepin1_amd64.deb
     digest: 370e93a48bfe9a0a64f8d21ff3656bc3e697590935b0ddafdb4fff6a517b71d2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
     digest: 784b6358825482c6b8e0a5515c1ea33a84e1ae70999df930a75c344a476dbafa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb
     digest: 0d55ab9b5634a7b635ebe263526719f3c5c925d847c0f4cb927bc61584cf269b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xavs2/libxavs2-13_1.4.1-1+dde_amd64.deb
+    digest: 09d132f43d700ef33f16c03354ae02d28a79755e92d3701f8e5bf15df0fa4ff1
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_amd64.deb
     digest: f3575052a14a5ec2d016bc667d466fc5bceec389db5b6ad9ab03ca53b50411f6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri2-0_1.15-1_amd64.deb
-    digest: 691906c89f7d59cf4e8a244c333cd1e9a91b00241bd44e6d8f5b975905ac1a32
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_amd64.deb
     digest: a55805048ef2bcbc16d6ed58879d173012291066e7e94f8ede8eb456d01c3079
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-glx0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-glx0_1.15-1_amd64.deb
     digest: b049c57d28e8785786edba1d9ff6139fb8e85f17dbeb921aa4437a160f28ecd9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_amd64.deb
     digest: be2ad80833f41279cad9ff66445251ea6ad3eec32cc9d2b9400ff8ad75ae255c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_amd64.deb
     digest: f41b73e88b0dfb9a8b1cf7dc6b7717cdbf19b3eb0c4b9a395323b70cb3f22daf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_amd64.deb
     digest: f240c2c0304a253f65767ab856f995ceea9d999fca674f71e210704210218e65
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-present0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-present0_1.15-1_amd64.deb
     digest: 548641b3568cf21f4359bed39375c1c8e873f92fa38955e310a27c3d0a0bd63c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-randr0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-randr0_1.15-1_amd64.deb
     digest: 20d03b2822771bfeaf4ba3ae40faa96cf48e3a7c9bdf1d8ec37de6064a0ee02b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_amd64.deb
     digest: c7bee3954ed81690c89b297ad68e14b95a634dc57ec1a235348efbf63de095b5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-render0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-render0_1.15-1_amd64.deb
     digest: ee032e334e48cdd15385fccde4b4baa399775d3a53aafa3a86e621012a47dae5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shape0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shape0_1.15-1_amd64.deb
     digest: 135268523d9957b26d436eee5cbb699815e52d98077b4e99516a9078444c9fa9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shm0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shm0_1.15-1_amd64.deb
     digest: 764d8a7b72cfcd3a4e3f1abb7b19c0af24e307a5595be04f06184b3817df8b44
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-sync1_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-sync1_1.15-1_amd64.deb
     digest: 8e5d1b2a5e1bfca4c9408bc7b62c161359f4ef7c2f35a25ef1734fd857c08654
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_amd64.deb
     digest: f0b0176f922757c116b36801584068ab4e0411c6d97a6ed9acb578a4ef56a7c7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_amd64.deb
     digest: c32ee9a285da0ddb94ab374cece23c5403e691539b5d604a1450f5120485d18a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xinerama0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xinerama0_1.15-1_amd64.deb
     digest: 10b5cf4aa80e70de0a4a8f1652b8c43c8bcaefe8e1d2fe2856ab0731fbfc4e41
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xinput0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xinput0_1.15-1_amd64.deb
     digest: e71f83ce673cc5b84531b5c84d2ff7b1616967971f859d7724ae0130d0291eb4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xkb1_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_amd64.deb
     digest: d25d2db11b35fb8d8f7122805028094a0df945c59941f9b726b64dc48d0bf515
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
     digest: 981d5049c153139995fa5d28ca1da252bbd5239a25111dc7bc28ab8c556d1b0b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1_1.15-1_amd64.deb
     digest: 7472219060504d69f13cea545dde78da4b42455c3018f211d161315c7d8aa9f1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_amd64.deb
     digest: d0b1950a8dfb16ff2f3c6aac1296b508da0f25eef3bc636feed2116f7ba664bb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb
     digest: ebcc2294de7d5fb853478096435000c2c262f0cc27bb6e9cbd1455984e58a72f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxext/libxext6_1.3.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxext/libxext6_1.3.4-1_amd64.deb
     digest: 59a91d747d250b40897b850d0aa7477a92aa671991287137875b1475a7708a85
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxfixes/libxfixes3_6.0.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxfixes/libxfixes3_6.0.0-1_amd64.deb
     digest: e4234708c3f3631d7f361a1429d8b9de9b8acc81244f23b8df64d599b62fcecd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxi/libxi6_1.8.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxi/libxi6_1.8.1-1_amd64.deb
     digest: d8a2f9bd5ee841567db6b5aae74edb48c2fc11be2fd6354dc83cfca423905aa7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
     digest: fd7cb0bb0dc64c7417a6418bdf4d67145947902d5dd668eab4949811b170ee51
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_amd64.deb
     digest: d763060cdbffd1ed849ae63e091ca47b8b75c8777ccc2d0ee968fcbe66aa9b51
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_amd64.deb
     digest: c44ac854dbbe987c4a0ee11ddf526b8fff1b701edaa5d85b7495a81aeacc3686
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_amd64.deb
     digest: 36b25f4121dd6765f49a5249a94f675139c4fbaae04be5ccc1ac3ae59f1e40c2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxrender/libxrender-dev_0.9.10-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxrender/libxrender-dev_0.9.10-1_amd64.deb
     digest: b5ddff8288599aa056803e26e4a230c67c6eb14360705a6bab2cf9037d5303f5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxrender/libxrender1_0.9.10-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxrender/libxrender1_0.9.10-1_amd64.deb
     digest: 3fe11eeffd33fee74287c85002204c97b9c624d84a79862e4ca5d37c7307253a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxshmfence/libxshmfence1_1.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_amd64.deb
     digest: d112a8a931b29eed0b2c058cc53f03be11dcf4fe2dc28a570c38cec52f687c92
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xvidcore/libxvidcore4_1.3.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xvidcore/libxvidcore4_1.3.7-1_amd64.deb
     digest: 522c1fb8a87a89a01ec4501f7ff0156cec33b0ad9ad4180daeefb942d116f3f2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_amd64.deb
     digest: 6ab24dd183238d561320ff6ab17df620297d4058d82e02606354740c0b8180f8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_amd64.deb
+    digest: ee79d2e37a74fff74155751702fc35a4623f23093950fecb5cadb80dc23b9f6c
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_amd64.deb
     digest: 73dced8cb5640743208e7a7cf2d4ae7072610d14314584c21992e84c31179907
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zimg/libzimg2_3.0.3+ds1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zimg/libzimg2_3.0.3+ds1-deepin1_amd64.deb
     digest: 2a7e6a214b981289de1b7a419d9f91a40ebb6ecec1e9eb9254bba27c15892e64
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zeromq3/libzmq5_4.3.5-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zeromq3/libzmq5_4.3.5-1_amd64.deb
     digest: 6374362f4defd2e6a454b31a8fe8e407aeb5558c4cacebc6a97a3c9d7f639e18
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
     digest: 92ec406d537e08271b66dbcf10d5730fff8eee067379c9fce7e74e4c53c6b4c3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_amd64.deb
     digest: 2ea949de45dfe27832a6e7816a03103dae4ed45ba2b380669de5d5c89c361cc5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zvbi/libzvbi-common_0.2.35-18_all.deb
-    digest: 1fc738c696936a298eab3f5a6061ae0189078abddbdf7ef3da2b39537d47aa85
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zvbi/libzvbi-common_0.2.43-2deepin1_all.deb
+    digest: 8c4f70100c1fcb2755b08644f2326f0c42cf037e89c22cb69e4d0dd0798cae8f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zvbi/libzvbi0_0.2.35-18_amd64.deb
-    digest: ccd6ac9289590f2fe84adb7cbe5f4aa0b6da77a316dc818c3244488daf098f48
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zvbi/libzvbi0_0.2.43-2deepin1_amd64.deb
+    digest: da30868c3032f3dfb1f028b73f0613b781c331741fbba8938f9d1a52dbbb1677
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
     digest: 68fe4a526d73dd2ff6b75c593a5a4059486d1ec2535ec5e42cc52057a52744d2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/linux-upstream/linux-libc-dev_23.01.01.14+STE_amd64.deb
-    digest: 6bdeb3308841d5a40930eeea4214170dcd222ff0394cda1e4d27aff5c212ba18
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_amd64.deb
+    digest: 46774d4ce9af0864f44fd0aed7cac874abe926c2ecda9845657acd3e68d1fe66
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
     digest: d184d5fd7e340055beee8115e1f28663e539c024ede10773ac03f4ca3f86e343
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/make-dfsg/make_4.3-4.1_amd64.deb
-    digest: faf91f05aec3d6779a1b53f28cc27ceeb6a173f9e395851c9c29090dcf2e3705
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb
+    digest: fc03b0233080c11aadc3ef81283bcba5ff4904e0591ecf2beda7a4e7157e9975
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/media-types/media-types_4.0.0_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_amd64.deb
+    digest: 9f832c60e3739ceecc42e8d2609e6b0304060479a11d8a4703396b52081e7073
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/netbase/netbase_6.4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_amd64.deb
-    digest: 752849bcf3692f005746425ed4307477b665ce980135c7815538a2053e4cbfdf
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.3.3-1_amd64.deb
+    digest: c67aae5d49b31463ae5dd06443a83de69a926bc4b8090c875c25c34f4bec5f17
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/patch/patch_2.7.6-7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/patch/patch_2.7.6-7_amd64.deb
     digest: 4bf340095bbde164d3ca33360e3b9d89a2f92bb1912cf2b4fb21a266c2ca250c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-base_5.36.0-10_amd64.deb
-    digest: 50fa4a0bbefde86abf9ffd1fa092ee82af23ccc8f65b5b952526dc885c943169
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-base_5.36.0-10deepin1_amd64.deb
+    digest: 7b56a354906c81ebfb301c74af9558ec15da38f82963b9002b157d788c1e55f4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
-    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
+    digest: b79ccae8397e919ee917cd187b8be2d3b10eb598f43cf72a9d9a50c3d81ec288
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl_5.36.0-10_amd64.deb
-    digest: 59d13b610350339f3b273097011a3db6db60a99d587bf04eeb881c1a34168390
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl_5.36.0-10deepin1_amd64.deb
+    digest: 1f28deb9739ccd0b2569990ea9fe58bdb5c363c8bd2b60a1dd8721da9d33f655
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb
     digest: e9751c5efad4e9fb2150686bfb82ad13ff8b8f7d00592d3571f70f17a61ba884
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb
     digest: 6d6e880665acf6c1600e779d00259242e7f58e957dda43d760b65df472ddbfbd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb
     digest: 3e8dd26853b621b7b1ef82533bfb3bfa0c9ba07f581df727cb3271e7a35edf33
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_amd64.deb
     digest: 44712ddb4dd007c7916d3bb3e2539d0853251b4672e6b76d057733fcfb26fe03
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_amd64.deb
-    digest: ad3ff722bfadedaeea33599b5ee43e88f7cb0c3a5f9185348058d0ddb7c9830e
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_amd64.deb
+    digest: 052de179f77f52e03dc62849e569130457275528003f3c66b1633aa46750a995
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12_3.12.4-0deepin1_amd64.deb
-    digest: 5cf3eca309d9562d2c4b3102dc4fe89db6f670e634066d70f1d3c0af2843c852
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_amd64.deb
+    digest: a0ffedb8e24dfed01e29acc8a207b6e90d40a0b1b1ba39dc5c9c2c51ec7da796
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3_3.12.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_amd64.deb
     digest: 3e3840ef15b198763d57c130ef9675a46fbdf534f2d5d721f8ddf91b6d743c1c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
     digest: 1ddd2f46a8e6b858e589bb011fcafb498ea673c78dd248283284b8a188cf996d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin8_amd64.deb
-    digest: ff4dbe59e1fe5063f9b75fa5bebdb2fe143b6b0f945771a847ea1d7a3aed4c44
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin15_amd64.deb
+    digest: a8e9ed497c034b25e1495a55c0bd81d275285e69db6955afc6d2c5dc7397fa20
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin8_amd64.deb
-    digest: efde03e80ec9484fca557ed25b4d1e22b4a92068e9e056b60da7108fc5b0ef05
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin15_amd64.deb
+    digest: 6f48417c4d65758f31385f5f5f56e3b58e3b366b3a35565a7ddb21a40067c858
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 2bd4061502b590e7e78fd5cfe089eb7e7fb173a15fed2ced98b50737549b8208
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 32c3245be7c5c0a778f7d6923c6d0f244fa4a297923d96d0583742477e61a540
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 17025348f2c9c6a1dd0742d8559771261dd4d297c9e3fc856ae8ba91a0ddb6bd
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: c7bee095c8c3d51a32db1369e90aad0c63339217557b13e494c1ffec0a962abc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 359f5fd7d83789deee753300437ea35ef2004a4ac03c5367249246addcafc210
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_amd64.deb
     digest: dcef2b6339bb7f19c33a710f6817b5f0512824a6139ac038a1626f766c2d3b91
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 216615817367297df6cf55a42109f53ecedebdf973ad3ee5aca0a8335774c65a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 8b33f401a988b6afda0ffd807fcbdad2a4ed487aa3d81e66e62d499b1b7a4510
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 655b85be8e6045818776113a226aa32bd3b5aee2edd6db07ad86ea65e565b490
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 30382213970c6d9ef9d09b54dd5d3f6088e7e740382edaa457fa2915e8e527c1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 3fcdda184d430545018216f81c03df54de1f1a07d096cc6597b94e89d407441f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 5f61b34f7a74b35588afcdd2b362223b8bbb4696d29ae217b087b480158c3bf0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
     digest: b9e766a60ff54dc40cdd1307aead4f3c2c1997388e21fe36ec37650bcf650384
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_amd64.deb
     digest: 820f8a30e3cd001eca5a21403b060ea5f047017fc9450423717ee7a59461a8f5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
     digest: 9ebce5aacbc3bd447f6fa109d03647369ec93d054f45a4b6f332b2643ebf9c0e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 5264d118de60afa8f15122126da05a7663ed8cfe0b592bd9de18bf290f26d92b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 1e7728aaa16cb4ce8b9baad38f9dba7d047b54a87d3d3c130b3f76bb54ea4212
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_amd64.deb
     digest: 0acef551ad9074060268eabb8d0b2b4703b005b00672a23406346e19d7346de7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
     digest: d2521c7f6a5efb286c34d765cf0cdfc2dda504204acb81ed39657315602350dc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
     digest: e2b8c1f31715901d773e714ab0105534aa17ed64ce9e5065900e4fc8fa17ed58
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/readline-common_8.2-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/readline-common_8.2-3_all.deb
     digest: 35fe59faceb8d9def8b6aa664e091eac8444887bc1f33ba2cf22099c3646e7bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_amd64.deb
     digest: 76a363bd052b40394f829486c820967c1386539c2fbdd7aa2e77430132fccab0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shared-mime-info/shared-mime-info_2.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_amd64.deb
     digest: 545413a218d5cd7e3103b5e277419a7e67044c95f83ed7fb700c6c99ba523c02
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb
     digest: ee27ac0010bb1525067edda7b6b86110a00550232fb154f87491dbc3a3a2c8ff
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/uuid-dev_2.39.3-6deepin1_amd64.deb
-    digest: 0ab4e3eb8b8b386bfb3718ba57f67acd57f07ee2f1ceade1beda197c0ab4af03
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_amd64.deb
+    digest: 15c9b33ab745cce30a6d51d8af8f0d3ab80e68af8dd21a416e16e60c2af359fe
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
     digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
     digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-render-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-render-dev_2024.1-1_all.deb
     digest: 7fb5329b624a9bcf86b4c6f4a3df92650c1c6a2041f0a75f4ae5c6f819915eba
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
     digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_amd64.deb
     digest: 5a83d9ea46a19255d820eebcf8c6a8a08339e1e37ad11ac3b8d89d1dcb719e13
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
     digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/xz-utils_5.4.5-0.3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/xz-utils_5.4.5-0.3_amd64.deb
     digest: 6144e64526111988775c0c78db08e9afded0f1f760fe924895017ac338f87553
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
     digest: 6d5bf0445a25257bc75a612224498ecddda2fa56edc8d17af5c4bdd2713edd4b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
     digest: d0bab03ed3981fbe2bae8799a3c45d9a3b1561ae3d7bcffe37f235d573ae24c6

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.36.1
+  version: 6.0.37.1
   kind: app
   description: |
     album for deepin os.
@@ -23,7 +23,11 @@ build: |
   # 查找并移动目录下的所有文件（包括符号链接）到它的上一层目录
   find ${PREFIX}/lib/${TRIPLET}/blas -mindepth 1 -maxdepth 1 -exec mv {} ${PREFIX}/lib/${TRIPLET} \;
   find ${PREFIX}/lib/${TRIPLET}/lapack -mindepth 1 -maxdepth 1 -exec mv {} ${PREFIX}/lib/${TRIPLET} \;
-  
+
+  # 准备插件
+  mkdir -p $PREFIX/bin/imageformats
+  cp ${PREFIX}/lib/${TRIPLET}/qt6/plugins/imageformats/*.so $PREFIX/bin/imageformats
+
   # 更新ld.so.cache
   if [ -n "$LINGLONG_LD_SO_CACHE" ]; then
       ldconfig -C "$LINGLONG_LD_SO_CACHE"
@@ -47,1377 +51,1496 @@ build: |
     libffmpegthumbnailer.so
     libblas.so
     liblapack.so
+    ../../bin/imageformats/kimg_avif.so
+    ../../bin/imageformats/kimg_heif.so
+    # plugins for libheif.so.1
+    libheif/plugins/libheif-aomdec.so
+    libheif/plugins/libheif-dav1d.so
+    libheif/plugins/libheif-j2kdec.so
+    libheif/plugins/libheif-libde265.so
+    libheif/plugins/libheif-x265.so
   )
 
   # 生成.install 文件
   bash ./deploy_dep "${LDD_FILES[@]}"
 
+  ID_VALUE=$(awk -F ': ' '/^  id: / {print $2}' linglong.yaml)
+  # set LIBHEIF_PLUGIN_PATH for libheif.so.1 to load plugins
+  mkdir -p $PREFIX/etc
+  echo export LIBHEIF_PLUGIN_PATH=$PREFIX/lib/${TRIPLET}/libheif/plugins > $PREFIX/etc/profile
+  echo $PREFIX/etc/profile >> "${ID_VALUE}.install"
+
 sources:
-  # linglong:gen_deb_source sources loong64 https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release/ beige main community
+  # linglong:gen_deb_source sources loong64 http://10.20.64.92:8080/crimson_25.0 stable main
   # linglong:gen_deb_source install libdtk6gui-dev, libdtk6widget-dev, qt6-svg-dev, qt6-tools-dev, qt6-tools-dev-tools, qt6-base-dev, qt6-base-dev-tools, qt6-base-private-dev, qt6-l10n-tools
-  # linglong:gen_deb_source install libexif-dev, libstartup-notification0-dev, libudev-dev, libfontconfig1-dev, libglib2.0-dev, libxrender-dev, libdfm6-mount-dev, libdfm-mount-dev, libavcodec-dev, libavformat-dev, libavutil-dev, libffmpegthumbnailer-dev
+  # linglong:gen_deb_source install libexif-dev, libstartup-notification0-dev, libudev-dev, libfontconfig1-dev, libglib2.0-dev, libxrender-dev, libdfm6-mount-dev, libdfm-mount-dev, libavcodec-dev, libavformat-dev, libavutil-dev, libffmpegthumbnailer-dev, kimageformat6-plugins
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
     digest: f6ff5fd88f299cfe07c0c808da8795d6ba4a6add35435dde5be1a64a4403de0d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-common_2.41-6deepin4_loong64.deb
-    digest: fe840ed00fd544ea41df879fc2c46809674b622dabdec981998cd0fc28c8b870
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-common_2.41-6deepin7_loong64.deb
+    digest: 6ff45e7708ee8470b2c50a09c2b4a1077b1ffbf53cffe660ad8dc386678eff87
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin4_loong64.deb
-    digest: e60fa11631dd3043e03e9677b2e2c203e4106a280603695f6fbdc664c7674918
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin7_loong64.deb
+    digest: e0b9f5abe0d37451ce205c8a58f946ccaeca97ecd53816c3a1050775ba0459b2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils_2.41-6deepin4_loong64.deb
-    digest: 565d6d2d33833a647520eb4129bef71f550982efa96a2af6cf2f566b4a3888e6
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils_2.41-6deepin7_loong64.deb
+    digest: 6f2af278a75b4eca34ca84b6e3a527cfa423927243fa2381d8e499d011f9b0ec
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/bzip2_1.0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/bzip2_1.0.8-deepin1_loong64.deb
     digest: 08d9f48f571bc206fe4e30a27e535a3a086b9dedba4a5f5055e898ff0dbea7a6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
     digest: eab43bf5b5365d2839d6c319aa489eb239a581d8fadc3132920645bf20948a70
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
-    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg_1.22.6deepin3_loong64.deb
-    digest: eea7a8587865789ec9f40ae9c3e5310f82a5c8c295b27d65e91627c86c107951
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg_1.22.6deepin4_loong64.deb
+    digest: ed2c4a87410d3beea4622bbe835dab07b458a8e286be591ca34e97f2a6f6d730
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig-config_2.14.2-6_loong64.deb
-    digest: 17c510572e0a51ecc5a4eba486a1cfcb55d2ac297c84f35bc7c58cbc31e6471b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_loong64.deb
+    digest: 06fd1e3b51d4e56571e9e974fd7936aa7010220f954b9a78b239b42bbf6e94fc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig_2.14.2-6_loong64.deb
-    digest: 85fed3d569a4fc895efd890e842e276016aa92848ddc3419c6fdaabc02280c7f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_loong64.deb
+    digest: 383b6417f02a2850dc8dc08613ba4f188f63943deef4f707fb03b50e34627c30
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
     digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
     digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
     digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin3_loong64.deb
-    digest: d633244b99267cb17e5591c3b221f74f65f1b31bb9f290acc8c255469e01fc63
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin4_loong64.deb
+    digest: 8603fe4ed1cd650d10366be27c0f5920c97379955c5a9d628af03d6146411422
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_loong64.deb
     digest: 9adbd030273cfacb0eb6223bfdce65e0106f5c811d96caa66978598bb40f3309
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_loong64.deb
     digest: df1346b7d3f97770fe21c1d05024d3d9583cfd1d4dd3da3036f8a306419eb1a1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_loong64.deb
     digest: 5770bc5dcc6da72cad3770a54023a87e2e1af8f5fc179def0a33ab3d0a79866b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin2_loong64.deb
-    digest: fc700ffb347d45ffae79229bb8b5d65052e24799e450c6cab624fc3cf7531f2b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin10_loong64.deb
+    digest: e7238243dd4fef2be5c4430f140546a8b7fa7f60cab873e6c3b75bedf2da780e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/acl/libacl1_2.3.1-1_loong64.deb
-    digest: 6a5d883c7ca1fb96e88290e5f80f2310b83e190d02133676ef19fcce44b5fc39
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kimageformats/kimageformat6-plugins_6.10.0-2_loong64.deb
+    digest: 9ca999cb9f741e7613ceecc1d29e2cfe28c7784f6656ce9130884c2c47fb0a1b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/aom/libaom3_3.9.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/abseil/libabsl20220623_20220623.1-3_loong64.deb
+    digest: 7b3e14e54d88c90cfd4ff6d206361aa991c6a14ea90924d901784f7be7c99445
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/acl/libacl1_2.3.1-3_loong64.deb
+    digest: 7388773fe6ec2b0439e0383023e06d26dee49dc9a2adc9b0969c3e24a51f09e7
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/aom/libaom3_3.9.1-1_loong64.deb
     digest: 22bc30a8ead069539d5cad4100b0141198b3871fdcd5253189c5bfcffd14cced
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/alsa-lib/libasound2-data_1.2.12-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/alsa-lib/libasound2-data_1.2.12-1deepin1_all.deb
     digest: 4990cab9125078d6b8ef1caaeabb597ecda80949d02d251903fd496272f59fbf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/alsa-lib/libasound2_1.2.12-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/alsa-lib/libasound2_1.2.12-1deepin1_loong64.deb
     digest: a281d653785825cd9591ca4d1153be142ed006c6ebd129865fed4f0f6e044698
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libass/libass9_0.15.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liba/libass/libass9_0.15.2-1_loong64.deb
     digest: 624f8c20c7f75e516baff9d91b7039f5f0fd60627bf97f7a3d3be980bca05fa5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liba/libasyncns/libasyncns0_0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liba/libasyncns/libasyncns0_0.8-deepin1_loong64.deb
     digest: c03afc00dd771536dbd99801a6745de20f479304b3a81367e3056e1db43e0ba2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/attr/libattr1_2.5.1-1_loong64.deb
-    digest: 405e34b981984b1e6d04b5093fdaa36013459af4687c62c3a7dbdd0b42766ecb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libatomic1_13.2.0-3deepin4_loong64.deb
+    digest: 1ed85dc548b54f63267a5fb8c81b8d90638df81de8bcca7448e087f994b31bc5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-client3_0.8-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/attr/libattr1_2.5.1-4_loong64.deb
+    digest: f9965bc423eee241336a5edf4851ebe8058fd76c5ef227d59d57a4e7accd55bf
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-client3_0.8-5_loong64.deb
     digest: 9ccbd93fc9d06c9ddf2b4fa7a399f4695576f80624ce1742ecce86de1b31006e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common-data_0.8-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common-data_0.8-5_loong64.deb
     digest: 24752d796aa2f23c09e8bff308bffea8e605b818e77cd6af06e6fc2678e80396
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common3_0.8-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common3_0.8-5_loong64.deb
     digest: 38d7141a270890e7a5e6dbbf668436061d17b6ec81abae9277b5171cc0677698
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin0_loong64.deb
-    digest: be33b7eab08ea435c5858d47956aada390c573d31b69a5915894ce2bcc9a4086
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin2_loong64.deb
+    digest: 920d3ec849e71760f05fc0cf7f057bc5d6a9fb5ff224ade98e4da2769b41ce52
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin0_loong64.deb
-    digest: 543e50cdead7c87bf1894f52be1b388336ee850095338db882d96f12b2c8ad44
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin2_loong64.deb
+    digest: 7a20afa0f9aacb210e8aedb636f8ec29905d19c8862664a4bc898e89c4a4ccc0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin0_loong64.deb
-    digest: 8e8d2728c6445862f54cabd52a37d0236d9dfb999ff92a893fa2da685bc4e051
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin2_loong64.deb
+    digest: 36b58f1381c4204e13ea236c977c367d16e57c3aa29985c186979e8a38711b75
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin0_loong64.deb
-    digest: 5fb5ae5404150c1d36ab0edb468d870e7f2f002432a8dc770b0ec1579987aad8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin2_loong64.deb
+    digest: efcfaafc0b770753c5b0465199d8f81de739aa591f5e1ee521835fbb1de474b5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin0_loong64.deb
-    digest: d0c1b238e2fa1703331cacbbe76d2fcc68cb5b8c697954b955bb33c9479c7f92
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin2_loong64.deb
+    digest: 2423da906a4fb65e9abf19a59910c614e58899ac2e4aaa522850cad7bb9576f6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin0_loong64.deb
-    digest: 7602c4d70d8ac3adf7d58770198d38378467ac9e4ea51c53002439b0ddb8ed4c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liba/libavif/libavif16_1.1.1-1_loong64.deb
+    digest: af6b9aa1b2537578c666242faeaf84e33eded9bbcb715cd2bb55a406382c8d3e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin0_loong64.deb
-    digest: bb0f82a4c1e3c890b82eb3b0333ad5c23ab91eb92b4b603aedf50693642b631d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin2_loong64.deb
+    digest: 0a1a51e680e29dd5240728088846f31704524f393f66833c2f1bc46a875ceff7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin2_loong64.deb
+    digest: 356dfdd307a6a564c2f253378fd07f5925d481d84ea650d5aaa922009dffdb8f
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
     digest: 43c9bedf808d5c2b85351f73dab25e81c5674c499c293be875ac5250c4b8cca0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libbinutils_2.41-6deepin4_loong64.deb
-    digest: 7aa139173a2527c2091b86730b83cf4f8ab922b18a89b4e11bc7047438712410
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libbinutils_2.41-6deepin7_loong64.deb
+    digest: 0072ce1b04c7bc89f5a4a9e0bc9345ea6b7bec1c7469e2ddf3ef5ae1ca955853
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lapack/libblas3_3.11.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lapack/libblas3_3.11.0-2_loong64.deb
     digest: 8c97d1fa2094a1eb83ea35ae5dab39982c5e1f08267d20dc8ffb162d0d4cf601
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid-dev_2.39.3-6deepin1_loong64.deb
-    digest: 1ae31bcf267da44344974386315edea5a613a9fe7242cba4b1749e90e18c50e7
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_loong64.deb
+    digest: b8c86c20ac3f591b298fafc9d94b91f81df48f1b59a65493933e79dce235ce07
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid1_2.39.3-6deepin1_loong64.deb
-    digest: 461e40f1f9e1aac09b577de585d654725476ee1d355d0ef508fb4ec0ee5e21c1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_loong64.deb
+    digest: 9997f65a9ee404fcfab2ffb048a597d3b44bfd985495375b9b35a4b0b4c8dad2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_loong64.deb
     digest: b28910a92aece870792abb3b969c20947e0a9dfeed0957b8207c49ef97766b8e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
     digest: c2388059363813c7ad5e42d91f514b1e93e3dd07432634eca0a6814e2d7edc10
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli1_1.1.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli1_1.1.0-2_loong64.deb
     digest: fa0a0735177fd06de4701acc3ccc180b7b45da0e3573cb82cdcda56dea9ded62
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbs2b/libbs2b0_3.1.0+dfsg-2.2-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbs2b/libbs2b0_3.1.0+dfsg-2.2-deepin1_loong64.deb
     digest: 5f0041e11d00e85632d9e22f90f9ecabbbb4937750a4a7bb7c0a0c80b9391d94
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbsd/libbsd0_0.11.7-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbsd/libbsd0_0.11.7-4_loong64.deb
     digest: 1a2e574f4385b39b0e1597f0220fb743d8f2cc4ed0a19047e97d361151d30c6b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_loong64.deb
     digest: a29abfb786ff0410774a943b1835520b9184b7bfeb4bbe24e1c1e244aec2cbfb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
     digest: b073876e60d9f9ba41ff9f984d0895c37684272da7ea5389b2ceb85598e3154a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc-dev-bin_2.38-6deepin7_loong64.deb
-    digest: 20388887631a10f107829e8b8bb7a2079adc25a243acd5a778781587491ecc7b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_loong64.deb
+    digest: 9fa3bcc93dab003763d83db50c25081e29ded90e14d44fe404f6d5b052f1e006
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6-dev_2.38-6deepin7_loong64.deb
-    digest: 7b5a4acec8ae11ed60eb1fda0e2408056414335c2360796956a73eb3dd260c77
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_loong64.deb
+    digest: b50b71c9c338a8b778c53d3263b155a04f5abae803827cad1f698b015826d2b6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6_2.38-6deepin7_loong64.deb
-    digest: 94e71f05ba2c63b39dd4b5ed2446d052e231795c058730c00cdf9beef4b8c53d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_loong64.deb
+    digest: 4d25699d2b3054ff228cf4e83822adecfdbfebb848f2a9bd0786704ff915b6a1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cairo/libcairo-gobject2_1.18.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cairo/libcairo-gobject2_1.18.0-1_loong64.deb
     digest: 0fd460a975ddc4f87d1704597adcd603ec099f338306d4ee1428e48b03ab7093
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cairo/libcairo2_1.18.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cairo/libcairo2_1.18.0-1_loong64.deb
     digest: 79927555f9e79d6b0f2e4b533853b67fea7cabb9f3fece9ff7a87684508222f1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap2/libcap2_2.66-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libcap2/libcap2_2.66-5_loong64.deb
     digest: d4cbe29713f415bd8679e79b2d4558a790c0749b1ee8f829ffa77cfc29695377
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/capstone/libcapstone5_5.0.3-1_loong64.deb
+    digest: 9fc4dad13f7d8cd45e037e5f4bbc7aaf446e76cb583ef9fcab6c5618c4e5d6c9
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
     digest: 23c1612c4842c5ea3315b25e15d859301a5f925f439fc377b3b989d1473d142c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cjson/libcjson1_1.7.15-1_loong64.deb
-    digest: a705b9b61cea069c289dde00f333e9ba88370aa2d770c2bda04c38f53f483cf0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cjson/libcjson1_1.7.18-3_loong64.deb
+    digest: 441206537dac908379f2e3512056745933ab830aadeccb3185a7349a3679f02a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_loong64.deb
     digest: 8a7e85de84804dd73ec433de1ad3fb61905c8c8a943365620cea7cedd44a6967
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_loong64.deb
     digest: ee391e47845900e8362b9cc01aa298a4bf662e354f17a91d2cada946f72fbce3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/codec2/libcodec2-0.9_0.9.2-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/codec2/libcodec2-0.9_0.9.2-4_loong64.deb
     digest: ac3e8cf51f259f54509e48af947004af2066205eba950b11ef4eb1ffd898174d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_loong64.deb
     digest: 47f0cbde458a5b5998a470c7ccb6d7d299edda99007d79eede46b23ee2b26401
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_loong64.deb
     digest: b613149b2665f0c26951cf78b70777ae30ed60feecbd2c86a65233ffffdbebb5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_loong64.deb
     digest: a9dcd576d5cd80ada64381a1727a3116545e93cf447f59c7414d1777e2993fec
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf-nobfd0_2.41-6deepin4_loong64.deb
-    digest: 2865f6e5b84a2b879e3a28a2a9596658be420fe428903b5a99426a299d5d75f3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_loong64.deb
+    digest: c06121aeae9359ded8ff84c74ade5b03d1325b77c4a938fbd9931c8fe2caa84b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf0_2.41-6deepin4_loong64.deb
-    digest: d7f1a09ddd15c431f09a4f35f86e28f463821654a41902a02b9e74a617f0e4c2
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf0_2.41-6deepin7_loong64.deb
+    digest: a594bca37501a18b322a46118883ed18bd99ef7d31eb5e5220a2d7c1adc4935d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_loong64.deb
-    digest: a6bcb173e61ad5273becf725933fff6bb10cfbe068d4a9a23af53b542b47cb78
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_loong64.deb
+    digest: 7452bfb8da2bf510f5095db334f7730c914a087571d313172392b1a2b12b986e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2_2.4.2-5deepin1_loong64.deb
-    digest: f81c3066868743ee4c5cbf09088c1b7f8dfc38832b358012ebbeab92a1428051
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2_2.4.2-5deepin2_loong64.deb
+    digest: 2215b8b403b997e7ce667895f92cafeb22ceafcec9dd468c6583aa2dbe83393c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_loong64.deb
-    digest: 51248257d36d6528d3cf0cd7f038c6da2cf929267029b18a13ecdde2213cfb25
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_loong64.deb
+    digest: 07c0d38b655ad9e1dc4d93ca4a858255adb25dc7b131ae1509781b83f1d2d133
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_loong64.deb
-    digest: 3c9ca124f4de35b207d02b042d1d25bacff0d4a642e0c34ace340d4667e7c037
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_loong64.deb
+    digest: 054a65c1507942291091fe19cbb3ca046ab48e734b4e8a2a77939fa427a89363
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdatrie/libdatrie1_0.2.13-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_loong64.deb
+    digest: 1e92b0e84256009fa0d4afa40bc765076fb97a45ab25e4f27b29a18a8b3445d6
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdatrie/libdatrie1_0.2.13-2_loong64.deb
     digest: 2babee650b0a341ed5e23cb131ae40d3c21ee46ecaad54fba79b764111628591
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_loong64.deb
     digest: 2aee3841500c6021eafb9bd0f6231ff1e814e73376d44b4a01d66b3cb6a1e358
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/davs2/libdavs2-16_1.7.1-1+dde_loong64.deb
+    digest: b5eb7f8d4bca07748ca52452a01a09aeb89013c49a6c8f72227aa4cf37f43195
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_loong64.deb
     digest: 976e0ae132630258702d76bc235bec36ea5820e506bc110585aee657fb487472
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/libdbus-1-3_1.14.10-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dbus/libdbus-1-3_1.14.10-3_loong64.deb
     digest: 78833b3973000dd505cd32d2301a8d5a9bdc5070360c2de5bebc9e9cc5289b17
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate-dev_1.18-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libde265/libde265-0_1.0.15-1_loong64.deb
+    digest: b074379f8e7ec81a299a83f504e0638be77e7d155d0141feeb31f4f5879042d1
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_loong64.deb
     digest: 6d218959ede7fd5ad4fde3c25dc2c26f113d1e07c487d344a7678c29b9ce0dfa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate0_1.18-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate0_1.18-1_loong64.deb
     digest: 1b60dc1dbbef61987759b5254d408edbd7d653e28b94f857de22578b0ca62dae
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm-mount-dev_1.3.4_loong64.deb
-    digest: 0072251c611774a48852e0de97c2ebfc9323fbefbc18d6a26e9b2c6611aa3610
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm-mount-dev_1.3.9_loong64.deb
+    digest: 52642ded9372b4048a87efa0515d8f84dcb794a57879c909792989e8ad609523
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm-mount_1.3.4_loong64.deb
-    digest: f21d91e9b1d2c1ac953b44bd9618fd3a5d2ce0e733d1b3c02c03f82b5a625b3f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm-mount_1.3.9_loong64.deb
+    digest: e5079981173cecf502c58538ee4b48d4bd6135569bdd872c7c6e1e1e396bb89d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm6-mount-dev_1.3.4_loong64.deb
-    digest: 9621bd14e83be95d29063d2911a18a01fa7faac5c8d62bf03731cc714902d8cf
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.32_loong64.deb
+    digest: 27e3a66194bcd1ebf3132c8f387c274c47a374e39a0fb6577cab24281834b200
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-dfm/libdfm6-mount_1.3.4_loong64.deb
-    digest: d4a198bc1f6fd6a26fe45a3ec3df9ede921e1b23a9812f9ae9ac5c8dacec8d23
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-dfm/libdfm6-mount_1.3.32_loong64.deb
+    digest: f5c9cfa166536d0e4e56de83340ee9e157b2043a0418909714a0b1dff7efad8a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
     digest: 1cb1deef108f4163f884f564e9fcfd429adc315e9509c30ff3bcf936824ac543
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
-    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_loong64.deb
     digest: a26ef022dd15349da87ea50e9a8fa2799ab3f5287c93075bbf6c229c2eafd969
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
     digest: b8289eaa6341a8493f4c191a45165fe944248da69f675d09005a29058e7ae5a6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_loong64.deb
     digest: d1ff95314f5b678d51fcbcb5c1adc603db5958e82fef41dfff3431c3274e18bf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm2_2.4.123-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm2_2.4.123-1_loong64.deb
     digest: 9b28e3fcb6cff61e26352d3b426fe25b0c19961120d499fd5cb05f5177b411bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core-dev_6.0.25_loong64.deb
-    digest: 6c61509dbfa71c1bef66b405f76a18e4f68e62aed4d55626fb2fd2e2ac87c8cd
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_loong64.deb
+    digest: 46b262c7a9142265d96ed03c896080b6be4931cd96881ee36d450593c1b23185
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core_6.0.25_loong64.deb
-    digest: d637527e884ee0fdcf6683013c932de3230c7c357afc87a4d2e31e0250c76d84
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core_6.0.38_loong64.deb
+    digest: 2a051f11ab21c3eb73382db4cb96c892e5c25be60b9ec7b1c436645df09237c4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_loong64.deb
-    digest: 7a16c5c6e9f9002a14350ca92bcd645a7b2fa0f1dc2fdf0ccece81628e65e530
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_loong64.deb
+    digest: 5c820da0d98e49b0cafcce328abc7b20f79a57fe8e9955eab7c86232ca4d217c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui_6.0.25_loong64.deb
-    digest: 4ae1e9b1b54e2c23bcb5d1bbe82d9e8914d86c8f6bd849e564a72cf0401d6e47
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui_6.0.38_loong64.deb
+    digest: 204e21dfba6edbcf36a22ffeb1317cfabed65d11eedb04cd53840dca04ba72ef
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log-dev_0.0.2_loong64.deb
-    digest: faecf60fdd232fce51578eee0380bfebfccc84cf7c00ae3d41af9a43572f2c0d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_loong64.deb
+    digest: 85431680f43cb35350110f025ab764f817a87ef8b87f8aaf1221cf92324a22d3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log_0.0.2_loong64.deb
-    digest: 9e03504ae093c9be1bec37e76dd97ef78bf4fe519320828ebb41096cebe47649
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log_0.0.4_loong64.deb
+    digest: 5dd93e358d83fad8b4f44962845e07554f43f36f252c886f694cf165ad67a3d2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_loong64.deb
-    digest: 55fe88c9f524afdbbb25ca361b1bb5d508848d94c9fcf8add1f9559ae717812a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_loong64.deb
+    digest: 17e369876960256cc74b9a89b79f507944aa3f1965f443fc7d6fdbebafb60ea6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget_6.0.25_loong64.deb
-    digest: 81a053ed14e32a37af815860e1a3f77c06c00956dbe840040b25098335b4e1de
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget_6.0.38_loong64.deb
+    digest: 18fdea046e17f28b1ace921d4c27f8eeed9a28841c46824138307c9f47722cbd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_loong64.deb
-    digest: a33416dbd875dda49e387dce675dfbfe364eef8c0237ed869714535deb97987d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_loong64.deb
+    digest: 43b505fd21a6fe0c79ecd5c8140b1619d20bcd243d4d4576fb2c84c1644b85c1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkdata_5.7.5_loong64.deb
-    digest: 7e6f8fa112dcfc39ddd784f68cb20629ac9fdf8a014035c4233fea7d3afeafc1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkdata_5.7.18_loong64.deb
+    digest: fef371d4b3e03bf0e9ceb368698a63ac51243fe823d5d7bc19f1654836e5d81a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libedit/libedit2_3.1-20230828-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/duktape/libduktape207_2.7.0-2_loong64.deb
+    digest: c46919dfca686178998927311123320eca3c995576736b5b4a0174f567289f13
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libedit/libedit2_3.1-20230828-1_loong64.deb
     digest: 851c5523af03e9dc081aa14afbeade7eeb1a21de5597226f13e0dcbed4a6ade7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libegl-mesa0_24.1.5-1deepin2_loong64.deb
-    digest: a44f7b45ca577b0d50ac305f25800316bd8beb63bee523dffd6c5bfa1206fcf1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_loong64.deb
+    digest: 7877f5ac8d6ca3d585de64047278d3f6983e9213b31a3e2d4d8b03218474f4da
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libegl1_1.7.0-1_loong64.deb
-    digest: bbc7f8773ad9b2cfa4a27a26d6ad4c276eada2db9b680d54bdf7eb59ee9e5012
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_loong64.deb
+    digest: e20c3e83c2e1e4d5787efcc5036312ebedbc4c0fedf0c2578ebb53041042e2e3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/elfutils/libelf1_0.191-1deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/elfutils/libelf1_0.191-1deepin2_loong64.deb
     digest: 16e47795eed490234214777685afc5c411a8ad0fdaf3508469e3105fb2b364df
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_loong64.deb
     digest: 1bb14f1d3b2a10316e1db8b888585b1486789cf2b060861e0281178dcd75b828
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_loong64.deb
     digest: f2f047f2363dda33826f748756c5b1c8a2bf809c981a66509876eb150583b278
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif-dev_0.6.23-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libexif/libexif-dev_0.6.23-1_loong64.deb
     digest: 9de1e8e206fafff8cada2ce815ba093a01296b22330450da2d21a2002735c343
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif12_0.6.23-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libexif/libexif12_0.6.23-1_loong64.deb
     digest: f5365c63e491f48204faef20665b2b513c10338425d3e9b68c88ca999c087f24
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1-dev_2.5.0-2_loong64.deb
-    digest: 0e5c956c6ba2967eb8e61479c2bf56189c8bee0077ded44015b9240ab11ae4f6
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1-dev_2.7.1-1_loong64.deb
+    digest: b766ee38f67bcbe9afec078d8fb2f5fb273e35b506a1d1a3c135c5ff4482121c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1_2.5.0-2_loong64.deb
-    digest: 845317fb7d0fdc029f3aa98c870826391b9bdb530c6aee296fd1671ed5dd8429
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1_2.7.1-1_loong64.deb
+    digest: 4b842b02c3c84ff64ef932b999fdc20e776a4f410cae4c065deed16e9ea5e99a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
     digest: 864ef36cd80bc0a9fadbdafca5a5ef05ff92458f945bc1c20753d7635d8f17b7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi8_3.4.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi8_3.4.6-1_loong64.deb
     digest: e1d9a61065aea68e96e14f496d7bfd63e024f8874e1d320cb607efd82dd96910
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer-dev_2.2.2+git20220218+dfsg-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer-dev_2.2.2+git20220218+dfsg-2deepin0_loong64.deb
     digest: 9d8a71ea270cd977632662c979ebfb932228dc31b65bddd59acb659d0ca06e28
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_loong64.deb
     digest: a7db6ba0bdb19eba45a01ffee174164abf3daeb95b51ab4d800f1128e9f88782
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/flac/libflac8_1.3.3-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/flac/libflac8_1.3.3-2_loong64.deb
     digest: 88b83d3414a7170f0e4ed2ba671b9cc45e5b376f3481a8154b094148a75f2fb3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/flite/libflite1_2.2-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/flite/libflite1_2.2-6_loong64.deb
     digest: 89927d11c271631ca816010e3825c066645c90621bc386f4dea59fbcc10fa51f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_loong64.deb
-    digest: d1a3b1236183019b2d22d04f45e772ecf88e6d4bf36a4820eac7133be614c4f1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin0+rb1_loong64.deb
+    digest: afa51b193209a8d67f9f610e43bc9dffadd90f61fd77112ca1f0cfb87a7bd269
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_loong64.deb
-    digest: 353ec48905f9c8553b1e46a60124deb598ff3a1c07ca6a0aff62b0c5ba5bae77
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_loong64.deb
+    digest: ae8860a596b6ef0831f0c600efca87de921427e30b2b706c6ba682ddbaa624b1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig1-dev_2.14.2-6_loong64.deb
-    digest: fb7dc50d5c6f70b425b95cad47a9b57633b41fb814d06fb42c9a9022c2bf0ee2
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig1-dev_2.15.0-2.3deepin1_loong64.deb
+    digest: 2dab50fc7571096b965106cc36feaeeecfef3eb1d766a3bfc7456d8d559670d4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig1_2.14.2-6_loong64.deb
-    digest: db05b74e370f34d39ff896e5070fee3351a4cb938e86bc6dc852c624cc9534cb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_loong64.deb
+    digest: e4faee509dbabd22ea70b8d59aedef53701693356ca681d32eeb855026312c03
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libfontenc/libfontenc1_1.1.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_loong64.deb
     digest: 36450772f287a243ed0ff6c3b5e491021c7d63f6f68a9e71711fbb6e5884c868
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1_loong64.deb
     digest: acb0c01cf1db9cd8abf2ba2fb1deea3f6c52e90a471d0cba26e403d9fca7c292
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1_loong64.deb
     digest: ad56d47b6131633a5cd1f2a0e651c4bad65c92c35faf41e664ff79d9ca0df2c4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fribidi/libfribidi0_1.0.8-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fribidi/libfribidi0_1.0.8-2_loong64.deb
     digest: 16a5f333df8d58b5b343a3ae40067a9b1132eb7f3cdf1517b8cb88da6d5b0463
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgbm1_24.1.5-1deepin2_loong64.deb
-    digest: 404e80e480804be07bbf59631365f4cf6dc9ec57c49fd6a0f07bf0cf4f940aee
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgav1/libgav1-0_0.17.0-1_loong64.deb
+    digest: 9394a422067c77c6e652270eca0a02a6bc226fd0d708ba6b0c9288dd99532fb3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin3_loong64.deb
-    digest: fe12d56b3510d451c1c494eef3fcc29b7cd05b847eddd533510c7645448a8b7c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_loong64.deb
+    digest: cc93c2d61fc3c6a93ba49cd4c6fac1caa03a6c330dc1900a43bbe4e747fc7eda
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgcrypt20/libgcrypt20-dev_1.10.3-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_loong64.deb
+    digest: 05d11e942b30ee6974be843ef2b8539426f3891c20bceb2e5bfc823e4c25b673
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgcrypt20/libgcrypt20-dev_1.10.3-2_loong64.deb
     digest: 3efc53ad7562df53beeaf914ea4c07a7f7ce29ff5867ec4e48cce58fb59f3a85
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_loong64.deb
     digest: 5bdd589218c3c04dd4c23f14e1815e007f56c84bd45cd497a1bf4e720bdbb6cb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm-compat4_1.22-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm-compat4_1.22-1_loong64.deb
     digest: bc7c3017145d403f6935e564bbcf6ee8904dbff103b96ecd876a3a66cebb6ae1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm6_1.22-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm6_1.22-1_loong64.deb
     digest: 2d965b1e2624d262111a5a767278f4f4ad51eb1c073096ce2dbc42e0c02f3fcf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdk-pixbuf/libgdk-pixbuf-2.0-0_2.42.10+dfsg-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdk-pixbuf/libgdk-pixbuf-2.0-0_2.42.10+dfsg-3_loong64.deb
     digest: 69e080182493af879fc8ea17ee6637a962e93a90bf26edbcb72ed4910d32e40e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdk-pixbuf/libgdk-pixbuf2.0-common_2.42.10+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdk-pixbuf/libgdk-pixbuf2.0-common_2.42.10+dfsg-3_all.deb
     digest: bcf7a388b33a76d765b3db4dc10fc0a946086bc7409228898ffbcc522e9dffc9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgfortran5_13.2.0-3deepin3_loong64.deb
-    digest: 3b9dcf7c22315463c2436f0895d1ffb5f9d709bcbcae308261c1eff20f8fd8c5
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgfortran5_13.2.0-3deepin4_loong64.deb
+    digest: 492cb11aad340d82bda1ae6791f96a3ed18185d1925b131879d285f06da4dd2c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_loong64.deb
     digest: 02f892b6d38643410cd753637657b9803eb718268927eec5232e68045e81d13c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl-dev_1.7.0-1_loong64.deb
-    digest: 34cc7650a8d538e59d44560580ff7d0819b2607877299a65585cb516d4136c03
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
+    digest: 37a693f96d02d97be01c45d972836cbaaac0b9a5043174a04b2e2eeff251b30d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgl1-mesa-dri_24.1.5-1deepin2_loong64.deb
-    digest: 3308be394c3ffbd105fa29d7df5af2996a74841afb297182be407d05af02463b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_loong64.deb
+    digest: 45cb2d6de8f6e7c898ff76bdbd5255d630d1df174a8cd028d28dcf441bca009e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl1_1.7.0-1_loong64.deb
-    digest: 623a88c159a1e9eafc6316e91d3c55179c692fa950ecdd06f1955144813eb6b6
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_loong64.deb
+    digest: b6dc7a60ae6e3530a6caa3e45d5869603685c43ac8937535062fae0b5c8863ca
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglapi-mesa_24.1.5-1deepin2_loong64.deb
-    digest: 1c7a900b9bd87aa232d2f74ce68fc6925ac3fb6102e244f654ff54aacd23711b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_loong64.deb
+    digest: 0fbe33c65fcd9f8d498846fc628c0fd65f86f0e8664618b83d325bad58b56a10
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_loong64.deb
     digest: 796a8a4bfcc14d204bc23914f524a0dcb3b0545611060b3056547eb281e277f4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_loong64.deb
     digest: eb81bcc49501d0e04514a0fa968beb0a0b81d4d4a35199c0d5c660e7ea6a1575
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
     digest: 4e75a1c9e56c81ed2c1737e3e6fe590163a77ff45179101a4fcfb90b4c0d135d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_loong64.deb
     digest: c7351415720634d89b5ddf7e809d78b458be23d09cf32365e14a72141d6d20c1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_loong64.deb
     digest: 1828aa1e6fe842d0713e1ae545f874d2335ab0c683638eb5bb594dd76037cd87
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglvnd0_1.7.0-1_loong64.deb
-    digest: 4ac20b2ddbc5d3985d95befa3db331ebcf6bf9d8b9c13df462018e2e6fd91218
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_loong64.deb
+    digest: b3763b7b1910d2692fe39f0b76195b639acf92ea656d4ff61da867393422251f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx-dev_1.7.0-1_loong64.deb
-    digest: bdb1eb7fd4e391c38fc5a21da29b1569afb19bf9594e46fef10311bd4d4f0441
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
+    digest: 260b85824035f054f7e25e2b142ee5397c28953f77f463276203b0e5ed8d9bde
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglx-mesa0_24.1.5-1deepin2_loong64.deb
-    digest: 17f2707c6c7f351fff8619c03124985d9b244dd1ba5f7a78ae37b0d9940e2b82
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_loong64.deb
+    digest: b219b07aeb0e70c94dcf3d2161fdbe5478a745b9bf8b660ef6cb8155f1e81e09
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx0_1.7.0-1_loong64.deb
-    digest: 51e7ebb3d6b78cc5f420d864eb898e91a1ab386fea5c51548439231aa66d8232
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_loong64.deb
+    digest: 8b29582e04b7987e1b45b1e7229eb4b772bf6d8ba18b5499b22144108aa2b70a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
     digest: 03512d70fb50bc97266e9f14dd56fc5577d455aed40072f0f2794056bdd6ac28
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_loong64.deb
     digest: c09ccc302996ba01e2f836ad038b25f5039c750fe2e10bbf66154f65b4ab3e5d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gnutls28/libgnutls30_3.7.9-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gnutls28/libgnutls30_3.7.9-2_loong64.deb
     digest: 2b68ea50a264b00dfae6f6b003939b618eb9b4a206e8f3c4e5f6601428d7711a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgomp1_13.2.0-3deepin3_loong64.deb
-    digest: f8d21f6663dc0057e9ace95a9f4ed30d682eef089970ceee9e0027497c2c245b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgomp1_13.2.0-3deepin4_loong64.deb
+    digest: a650bc16697eb1e90218fc6c2b5f6b3b4207c81dd511a07729333ab0410f9d00
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error-dev_1.47-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgpg-error/libgpg-error-dev_1.47-3_loong64.deb
     digest: 8399956284ea0cbb6bef52b2ee4416b0ee477627c6163c71f4a8857408e54434
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error0_1.47-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_loong64.deb
     digest: 432b4819ad1edb46e6d8116596212dbc3a82d0d34c93c3574ded8db352188c8c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/graphite2/libgraphite2-3_1.3.14-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_loong64.deb
     digest: 3fc95b46c6dc87a3991386255c381d00c68a6ae6bfb4390ccb05f8cc61949331
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgsm/libgsm1_1.0.18-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgsm/libgsm1_1.0.18-2_loong64.deb
     digest: 3dc3d3c042ca69e0382907caf9578f0992a109e3e47394ae59359d4183b915e6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_loong64.deb
     digest: a74abdb1e7ddf88624513747e6591d1c799bc8774187470bd05d8d489834d596
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_loong64.deb
     digest: 5930cfa21617d8103fad46534ba6d07b3930e28a3606600755a076d3eb95319b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_loong64.deb
     digest: 1c2e9030c9a558915577dbf8047628b212c9b48c175709b244dfa794feaccfd2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
     digest: eb28d4bec657f7273f965bde361caca747436978ff2b8dfda5bb4ce292c8868c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_loong64.deb
     digest: 23f39df88cbc47f74e5a77408b2cdbc4fc47e41fdae3e5fb319a9cbe552c12a3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libhogweed6_3.7.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-aomdec_1.18.1-1deepin0_loong64.deb
+    digest: 736b44df235293ac013dfb665551c70a43bd0bafff7f4d2544494c3fd88614b4
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-dav1d_1.18.1-1deepin0_loong64.deb
+    digest: 6b448f86579c9439a4f77f1d821b21ae69913128f5d75c71d9e86cb3eaa8d8a0
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-j2kdec_1.18.1-1deepin0_loong64.deb
+    digest: ca5917a0795c399d90f16875b80d0d1291bacc7bf9a602cce4433af7e05a1fe2
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-libde265_1.18.1-1deepin0_loong64.deb
+    digest: 6a73e15d6663ee7ca1c62c5822d93fb7015ba0a4e1bd55e14179b3226c3db184
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif-plugin-x265_1.18.1-1deepin0_loong64.deb
+    digest: 40a7a04c05dd22144b639304b3470279ac670cba27d4c46e0ab27872bcd9ceb6
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libh/libheif/libheif1_1.18.1-1deepin0_loong64.deb
+    digest: 330186df0b59f153887c1763a5a2a873458e268316f1f38cd2cccf1a41d3a943
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libhogweed6_3.7.3-1_loong64.deb
     digest: fca8fa6138c16bfb7f8d8fb78f55799c24b9a01bbac0202816b22624cdd0da6a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/h/highway/libhwy1_1.0.7-8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/h/highway/libhwy1_1.0.7-8_loong64.deb
     digest: 831d45c39ca2bf93b17d7f6631cc4d3b6ef1dde879911a3fb55953fa73719fdf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libice/libice6_1.0.10-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libice/libice6_1.0.10-1_loong64.deb
     digest: 71f07175fac63f8a51f001299a9329a38c4320df6b46e6bdda20768aa90a3456
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/icu/libicu74_74.2-1deepin0_loong64.deb
-    digest: 02c3223e35ca49a4c9c167ccecd7c49590e8fd710a203dff70d476e038632320
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/libicu74_74.2-1deepin4_loong64.deb
+    digest: d60c34f7df7c6c7b8b950d3b2996bd1dda6ea510d77de2869bd13c614a1fe00a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libidn2/libidn2-0_2.3.2-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libidn2/libidn2-0_2.3.2-2_loong64.deb
     digest: b235fca3fd81c2e6918d54b8d71f79757d6b818cf897fde7cb3826dc23ce85b3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/imath/libimath-3-1-29_3.1.9-3+rb3_loong64.deb
+    digest: 40821e1da7b867fe1fa8c475ccad98b241ab98038c7885c039d828cf0249b282
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_loong64.deb
     digest: 0fff2ff2f3f962bcc63f9d7379995197a1727ce30a91f908ea72a3fa662a6b51
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_loong64.deb
     digest: 6d985129e0600d7fe4a411a39bfadf4c73f8563ac1604635d19fda6a9cfc111e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput10_1.26.0-1deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_loong64.deb
     digest: f8251fc25fdbcef6b938b6be532237f63c3dff78dd83b1d3ff665748685f7f4b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jansson/libjansson4_2.14-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jansson/libjansson4_2.14-2_loong64.deb
     digest: 4a8662b90c807a6afaf7ac4d89ae42e33725c60f5a0a26230366cd487425faec
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
     digest: 0c3b4ccc6927abdfddb2d909ca139fbbf1c5e81ccfdba90c1ffcce9f460d4cb7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_loong64.deb
     digest: 8940e6f4dce77f526bc32b5211d850389bc0875cf944520e9f0a4d85a170e9a9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
     digest: 152658aba54e2f163ba19c0fe53aa7666e1c6907eda79433f1ec38240a9670b7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
     digest: 342808c163f19bfdfdb7f36cf51acce6401aa2c0df6fd5695d0b3a9f2731bd9b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_loong64.deb
     digest: 47df0f4474b4722b6a741b7c8b33057f38f58245efa92c176abd489665e92c1f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_loong64.deb
     digest: ff74443d44dd44adb4aba8829d58bb89ad9bc7bcb934b5bd7f7b578fc86b9f73
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libk5crypto3_1.20.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libk5crypto3_1.20.1-5_loong64.deb
     digest: 4a83826bbb0da645b6f48c1de0682bd7ba1d61a2b903fed7738ec7c88f559b8b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_loong64.deb
     digest: 0f7646fd6ba7bcf29756eac9b72ce2b03ad5de6d90e131ce0ab97e51f1da29ab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5-3_1.20.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-karchive/libkf6archive-data_6.10.0-1_all.deb
+    digest: 4ca53184e68be4a5b171d50896da08b26a634ae6f57a14cc9384ce4fb025abfd
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-karchive/libkf6archive6_6.10.0-1_loong64.deb
+    digest: d09822334b6c32696e2347154193a5b216e10de371575442d8a9082ee94b48bf
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5-3_1.20.1-5_loong64.deb
     digest: 071d32ffb73b3feca3d9135ec6109730728b20f40dc194abb24d3f4506c964ef
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5support0_1.20.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5support0_1.20.1-5_loong64.deb
     digest: 7ec7dcba628cbededb02866a71961599d1fc501303c2797f756381ce2026845c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lapack/liblapack3_3.11.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lapack/liblapack3_3.11.0-2_loong64.deb
     digest: dcf626ad114b8c5998b91c1adf1968a83146bae6bbd087ea5ba341780bd0442e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lcms2/liblcms2-2_2.14-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lcms2/liblcms2-2_2.14-2_loong64.deb
     digest: 0d4c7d34f69d56cc287e478af83d7cfddcf44a5ba77b6c4bf8a8afa7864c9f7d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_loong64.deb
+    digest: 07c9253e9b743f0bc0f696c091a84d08a18f172e600311e0aadf508c494659a5
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
     digest: c0a9c5a24ac81fd6e5641d36d47600df17b732fe3a5c024753da8e32679a1447
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc4_4.0.0+ds-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc4_4.0.0+ds-3_loong64.deb
     digest: 04d2a5b464a65ed87d48e331080c46b39c6b2e088c5b4d251f06a46355dc905a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lilv/liblilv-0-0_0.24.12-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lilv/liblilv-0-0_0.24.12-2_loong64.deb
     digest: 802937863bd86fcc896dee8df836285c0fd60ecf9dcb173b20f7ab3521fe3317
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
     digest: 6b486a85ac27b4001d13fb43838047f46ea84c3b97baa48d0ede572ccd47817f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_loong64.deb
     digest: c3d8669054edf11e7182e2a5add9e6cd29e324da3ef1e51d6c251719547da66a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lz4/liblz4-1_1.9.3-deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-19/libllvm19_19.1.4-1_loong64.deb
+    digest: 209b06fa65813ba8416031b068949ca03ca9058899dffe337a7b4d7d840d7363
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lz4/liblz4-1_1.9.3-deepin_loong64.deb
     digest: 223608f8e5ab70c862665634392467d8cdb27b39d749f8367ecf8f709ffd0044
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
     digest: 3ae2965f4f532a1dfc813c0d9ba0461219093f4f0ab50c9f3ca77ba99d71cf34
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma5_5.4.5-0.3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_loong64.deb
     digest: 8922429eeb2d802e40eaba8567afb65504a70988e500d4d7a455f1ea6c79f20f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_loong64.deb
     digest: 8179fb6587d2de06e44f88785a1a3a530b8b8317d17c0dd4a4878505f6eb30cf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmd/libmd0_1.0.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmd/libmd0_1.0.4-1_loong64.deb
     digest: f54d26b7c46c848e15a460cd03140e8a436ea2f5b6b7e287e47994d1c627dbc8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
     digest: 38b04a9c6431d337342ef954a98ddc75b6ea0da7b17d321cf5f4ba17e73d9dea
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
     digest: 501c91fa0ba7cc9f6bceff658ffdba2323039a590719a2030f2dd37266d296aa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount-dev_2.39.3-6deepin1_loong64.deb
-    digest: 73941c73eb241e1f14e1437904f999a5281cd7f9ab011c4fe07bc7bcda5de9cc
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_loong64.deb
+    digest: b6a33875c9e10005da90db18aadaa4f044f4b694ccfe0b69973a41e881d4c104
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount1_2.39.3-6deepin1_loong64.deb
-    digest: 09d325477885d70857f69af079ae718949684f01e4ef75de78bc39a08ba3c25d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_loong64.deb
+    digest: 31a69b95233506e4afc628618c8fc0b9ca0c1cd0b69f97ee83e6bc5f7c17f6c3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lame/libmp3lame0_3.100-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lame/libmp3lame0_3.100-6_loong64.deb
     digest: 4a2df6ca32a6a40ac918843adb284bb0929ae321f2c3dd269e40749d542af562
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_loong64.deb
     digest: f03a7545dff01e921e9dbcb683464188c28cd289d557af0778efbb9962f93db2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
     digest: 9b74501e7c7e6f5d5708bfb897a6710f2144da4806717be60cadb34d2e180353
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
     digest: 4a5019080a0454a1380d3353dbc52b5bfebd3ad8f4c210425beeef8b6e5113e8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmysofa/libmysofa1_1.2.1~dfsg0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmysofa/libmysofa1_1.2.1~dfsg0-1_loong64.deb
     digest: af51c3ea198343b87345b6699d46a0610d20bc9d6064d15ef51125edc5972d08
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncursesw6_6.4-4_loong64.deb
-    digest: 4db1ea7ab75ab8e38d6ea0e9c408766dd8328c84ded9e53aae7f6bba29e8e7e7
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libncursesw6_6.4-4deepin2_loong64.deb
+    digest: 348b042a2c913c259e223f4ccc0052ff32f358644c10c7263b10860574386b5f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libnettle8_3.7.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libnettle8_3.7.3-1_loong64.deb
     digest: b49e593029d91c73f2240ffb5f129e3a47f613aadbf8ab5f50d592b2a5abdc98
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_loong64.deb
+    digest: 73c2009828b2dbd6d42c3d6f2c48f38b6c0ba6887c71bf4bf10e997d4072ca08
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_loong64.deb
+    digest: 2f4801803d9f124c23da8511728b5ef3c46729dce1f3a546bc8a7fa9c2857cdc
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_loong64.deb
+    digest: 59a844a4d9b530458f137a4ad44d01fb7ab1a92a693870fbea4dc788e207772b
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_loong64.deb
+    digest: 87540ce4f8f6865f114b3153ebcb0f623a912010d3cf1e361714e6489260c9ca
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
     digest: b8ccd5bf943ded55cccdc92d59c8abb35a1fb65fc3425ebe35670d37b7bdad6f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl-dev_1.3.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_loong64.deb
     digest: 20dfccabfb63024f4d18c0dddf6271436dd6b423643d8140ab157055c006b31c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl2_1.3.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl2_1.3.0-2_loong64.deb
     digest: 295c4fdb7405a01bac01bc50e542232014a5225cac5f675bfbe33ea41d1acd67
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libo/libogg/libogg0_1.3.5-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libo/libogg/libogg0_1.3.5-3_loong64.deb
     digest: 45f908be81e813e6326426acd4c5675adac085383a93bf5b87bee2942a2152bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_loong64.deb
-    digest: 72259f4ed0b1127c554e3747b8763fc18659dc5178fc2fe32ada313357c1802a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openexr/libopenexr-3-1-30_3.1.5-5.1deepin0_loong64.deb
+    digest: f2a82e6b75289420895cb3beb98481b49cda79510dee00b21dd73e720cb1647b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl0_1.7.0-1_loong64.deb
-    digest: c912f8a5180cda07f485be9334b8ca0c1bf779bc2449ec5fa08c347e5f18a132
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
+    digest: cd4ffaeb85402fdee4cd618e5d95b20857b2eb83f25d6109f8026b714b4af470
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_loong64.deb
+    digest: 5ce97ab48242d9a6440c70f71408b84db1d2417a4e61007e08dfc3f748d1c4c9
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_loong64.deb
     digest: 575da3427fe1632f4dde973fd2cf3b4a15dac1a77d612bedebeae18d1968095e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_loong64.deb
     digest: d5f7b919880e85ef999377610d15bc712151a6ae5b5aaf9752cc59d21923992f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/opus/libopus0_1.3.1-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/opus/libopus0_1.3.1-3_loong64.deb
     digest: 49e4f3ab950054084d1cbdfe848f0dfa73c4ae0f8ceabe0a6987c522a26e3765
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/p11-kit/libp11-kit0_0.25.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_loong64.deb
     digest: 75dc180effd2912fd0a127952cc27c52ff0e900d7c8b79f3bb4b0d1ac1a120e3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_loong64.deb
     digest: c1e53075721790fad6dadb0f0c6f85da39b2e127374424a63ac010d4d7972f74
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpangocairo-1.0-0_1.52.2+ds-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pango1.0/libpangocairo-1.0-0_1.52.2+ds-1_loong64.deb
     digest: 145fc9b1b4e85cca2d15a606d73ad0fdaadfd2c16d23afa399ea2d9f68cb09b3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pango1.0/libpangoft2-1.0-0_1.52.2+ds-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pango1.0/libpangoft2-1.0-0_1.52.2+ds-1_loong64.deb
     digest: 5d476421c3f46fc235e62292a437b6320e9f8cad252f6277a3c607faa5095afa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-16-0_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-16-0_10.39-2_loong64.deb
     digest: c8062fb10212742a2ee3206282e185e1072fb891c17ae8bbb73777d7f4ebd93b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-32-0_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-32-0_10.39-2_loong64.deb
     digest: c5694b615e555a112c2ec14ecd8002cf48bbeaefaa8a83c4c81f5bcb80825e31
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-8-0_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-8-0_10.39-2_loong64.deb
     digest: ecc34edbd930aae24bd00654a682592d396e5f0b3d94ad3c40baa300e2cdd0c1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-dev_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-dev_10.39-2_loong64.deb
     digest: 165eb3c1854d96d79f71a381b0ce8c04cdc8984d36587f15e77fa36e78320fd9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-posix3_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-posix3_10.39-2_loong64.deb
     digest: efb78bfaecc447039df6ceaf21a40055d692ceea4a38e700e280dfd05c521881
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/libperl5.36_5.36.0-10_loong64.deb
-    digest: 04a865c6db98c65a2a540eb254174d4c012db34fc3b333ed5649fecedbfd0fbc
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_loong64.deb
+    digest: dc6587b5ad4bb6a51f30edd225d1aa4d0f2e5c24107aeaa8bdb41e13f2136fd5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
     digest: 9b68dc19b458a678ae21f5eec1f27f011f0c8da502cf3cf234b5cf4f8e2b093d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pixman/libpixman-1-0_0.42.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pixman/libpixman-1-0_0.42.2-1_loong64.deb
     digest: 0b76c37a85a00b26233f17a3cc0e4459649ba286528614f121767c9b82c4d3a7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/libpkgconf3_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_loong64.deb
     digest: 7fa4ed870a512323dc2bdebb32e85ab5c08036153b042a932beec468b3ba6089
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libplacebo/libplacebo338_6.338.2-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libplacebo/libplacebo338_6.338.2-2deepin0_loong64.deb
     digest: f247587cc9803514aaf71659234cdf48ae6ca97924fc65d7b0afc0a1e0606ae6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng-dev_1.6.40-2_loong64.deb
-    digest: b264603a1bf9d98f62b3a2372c640f37c77a8eb45d7cef5fd450115c2cf8e2ce
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_loong64.deb
+    digest: e4ec70f1232bf8277e218069968f1504e1324ee03260852234fe852a687a0fa6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng16-16_1.6.40-2_loong64.deb
-    digest: f865dc5b460fcb0d70dc87894a98da21ebde6149302056fe9a15a3687d388b9d
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_loong64.deb
+    digest: 711fc166523e536c981def0bc709970f34be02ed60226bc129d2b1911b4ac46a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_loong64.deb
     digest: e8f253a5d32a8a0872ed67fc096d933401d73e9518d6c104d1c99c278bd9ff74
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin0_loong64.deb
-    digest: bb3d14036e696499a14e7f3f0bef0569cc8a95e67f7fce254009ae60f9775f79
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin2_loong64.deb
+    digest: f8b456061231d8a60d142a4acfc334423bde9b68688a4123d97b0a1ac8948bb8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_loong64.deb
-    digest: 8c5d37ea50aeb08f936ee1e57b5f295cbc5d76690d92c265b26fbf0e14e687c6
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_loong64.deb
+    digest: 450c63cece1053b61ad1db303e20cf3008cd130f59907df2610dee985a1ac250
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_loong64.deb
+    digest: 48076d0b45bdee001ab7b435296ab05853ab64402092af005e07437dcc838640
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
     digest: 9d68b88d2e9de4c313b75ec6ebd8df51105856bf8998470dc7faf770308ddc40
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pulseaudio/libpulse0_16.1+dfsg1-5.1deepin1_loong64.deb
-    digest: b5c627561d8420b2cf208fd15c4175e61d122fec8878052138f1e827dffdd7a1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pulseaudio/libpulse0_17.0+dfsg1-2deepin1_loong64.deb
+    digest: f88e6830b6c1c94a8c0c337d6f79ebb19c2bddf0eaac23be7a0c15fce8e833b0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_loong64.deb
     digest: fccfbd0ff96d62aa2476f942b4e819b2bdce28f714ea360e036da7a0b3732597
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_loong64.deb
-    digest: 759e427492a789316db477eb515bcf7c94f688f88e5ed2cbb5da033a06b33966
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_loong64.deb
+    digest: 1d472fc15c2ee3bd55b69219903a7ff8fb6a5b880cfc1f2506c8ebb459f9b0f7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_loong64.deb
-    digest: 86f63bfe267ae688785e96f5671516a53846e3459ff9ca54a4896f83968990e7
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_loong64.deb
+    digest: 86eda0624899d0be7965e8bf0b2189986b67daa8d280ff596e736b50bc1bc4e5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5concurrent5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: c7f95d6cf667ef1f72d5578ab19dac529759f91b8a3498899b3a26470d39f314
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5concurrent5_5.15.8-1+deepin10_loong64.deb
+    digest: 4c330225d04476b211c25fb45182623a822441c515588fc53b7d052863b41795
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: 5f41ab472678cfac09bca24a1d116bebb94d93710e266d8821f7f044d4aeabc3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin10_loong64.deb
+    digest: 01379ff92666bfde1747846a28d55d11a8027c0be777f118e5ea2521e8ad10ef
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5dbus5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: 19e395796ffca5cca8385d856c72c3f7163a6d3b2edd4ef4d25ec4fbac1a99f3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5dbus5_5.15.8-1+deepin10_loong64.deb
+    digest: 3af5dbd50a8b599a0d58725eff5644dcf46aff0c480fe5f90d578f40407d93ff
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5gui5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: 2a14b68dc73329968f75d54928ff652ca815774a35ea5eb1691f15482034ac6e
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5gui5_5.15.8-1+deepin10_loong64.deb
+    digest: d8a1a1ecf11953fc5f2514bf24ebf8e5b4d12b7b9e6a77b0caf9ce2236617023
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5network5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: a8f7337ba23af9032d15c212aae7b3e0582250741a4221c14a98c5b8648fd3e3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5network5_5.15.8-1+deepin10_loong64.deb
+    digest: 7d89d6d4f24b8986465ecb2c1c6fe035f2133a00735cc6e811423233a1f825d7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qtbase-opensource-src/libqt5widgets5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: b2ba5a6592ceecf92c9826e9310ff4cea5db5b1fa488ec8adb14349c8c2d03b0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qtbase-opensource-src/libqt5widgets5_5.15.8-1+deepin10_loong64.deb
+    digest: 46201e8a320adafb199282c036d6306d56d7d1a1bb984c70dbb8a655d824a406
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: df1fb644c6f18c557df389f7c8caccb8041cdbcbb3ba64cc4bdf5bd9dfcf95f3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 27f9e657d136a934f173a715d878d3d055b4f380e81fbabc76aacb44b6fc94c9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 05d37808475216a0a62fb277a78a21045f6a3371c9771eb614a38e175c67d861
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 1523b859d621d9a86bca84826591ec2ca94247e2529e9c3a407fba06593552fa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: b4bf3ee86fcbc0055e09cddc5cf75dadf7f2d92f2991207c6a0c591d9ddcf3cd
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 51e1362bb514f7878aff724ed92035df7451ef96fe7de71c4452057340d8d867
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
     digest: eefebd3f3d07b0f7d2f89e0ba469128aba20e0a1093ee0cc1853c3ddbdfa8616
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
     digest: 0cb93130f4822644f809425794909492760cee0cc6c3d5596883a07edfbf9993
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 6512d39f8b25de932f919e8c1c5f6819ca71277f4c8a2ce5590ae347b98ca552
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 0eb4ed0089c77f53f38c49e30098727c78489b0d390a2ced33cba5de167aa5f9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
     digest: f748a917685218c990c97766bd2e9cf73caea758ba095bde0c76aed5d8b2c14f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 32d4331abcf04409ac6526eb631f53c4d4d78e4c284441f6f22a468f17290dca
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 734dbb8e7e72a7e29fdcafa4d17f6dd1f2385c738b075858d68f3e7c06a8c8d9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: a3d00166167d5a06e1fbb75780ca2965eb064eee915591358584a7feef57968b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: ce9b72f2477ff977aa84f328fed1bb4f74f1eeb63487bce88634bd2ae819fcdc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 51d746486ddd8b214d7078de53fcc35701972f22cafd0248368176e06b80ea10
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 1756c764caeabe3b193dfd61c1d9f8f78e5cd8e63421c1c2e6c6c4d2adf00a20
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: c2cd48cbfdef345b85b35d08ada160aa696a1b23afe9f9a224ad2fd9ba7c17ec
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 6321e7ffab0c4908deb4c93b1ea695b9a8e001c3f15cdb1e83af3be2dec5d072
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 31feabbf3ad584c4c450c37b5abb61ee289e05b11bbf04533131075201387b35
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 528f7878f461a24885cc8a1b453918d5225555a719a83cc1daf0d874d97af6a2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 66477a2004afb5d4126dac018fba698d22e6e526f67e4531464ea04f8addd702
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 889af35681f2708a99b089a4c9aa5f22e487da2125af9132d3f0e7b579b408fd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: ac8528c19b56097b2476dce90edd35521971fab57e90fac1e44545866acf2e00
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 017f06d3ed3ed61c79b1305c5143cc23741d512d7e5bed5bb8afdf5409f9dd53
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 34291f35a8454f65214fa6ae65d31569edb74d581aed75bd502885f575e20915
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: f8f3e1362f96ce18bbf6ab415b4fca82bf4f057b122c26dc956f3f0bfbc3e571
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_loong64.deb
     digest: fc8cb023930b048f2caa531b913d991b4690a9f4692a9e4fbb423618ec67121b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_loong64.deb
     digest: 7a0239be93289e6b8d54806f5ffec75a9f4aea7cee0af219fc1932e64abde72e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 11eea51f1f01f37a4fecad877eaef15584bfd9792fa5cb6ed74bed8dce2119e2
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 13e6c88915bb0c09c85a950bd41a150ecbab7b6bbac87d72900b3484e217055f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
     digest: a4651ca09a7927998b556155807a65a4b68d19a83f8a3a0907e4129f0ed983a3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin4_loong64.deb
-    digest: 57068128d34bae2f408d6d8ca07061a6f034327b67ed03f27fc1e9aebff727a5
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_loong64.deb
+    digest: 7637f2f08e271e14a5b05007e2fd18a8facc2c6fc3f29fe1ba5e2c5ea0d037c2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: d3aa28809160e26462914fc87cd6b4fcb84bb59c9a925d864811c0fc8ab4a1d1
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 0904fa02b80b91fcce261f02f8aeeacbcb2e166edfc9fbb8e9804639c22e6a56
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 26a96679e3356a3214126b3f58b1c6a2cd448f955925733340fe6fc1627ca7b9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 529b35f3c63e834096085de61a2494f89aeb2103b184d5d8bf2e5035e60340aa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
     digest: bfc60cbd6ee84fd4a6ee2d1002c27389d58dd451f8ec8bfde0e74fc8dbcfbbf4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rust-rav1e/librav1e0_0.6.6-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rust-rav1e/librav1e0_0.6.6-3_loong64.deb
     digest: 1e6853c1d99619004034edd20102899b5896035984ed273409bf107d39139d94
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/libreadline8_8.2-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/libraw/libraw23_0.21.1-7deepin1_loong64.deb
+    digest: a4add147370c4417e729290c4b2d43a350de67d78b8e982f4c5085bab47b3fad
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/libreadline8_8.2-3_loong64.deb
     digest: a1c114f0856366970ce731783250b16f1a600a917ac54eb45b3fc765a7dc5e8d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/librist/librist4_0.2.7+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/librist/librist4_0.2.7+dfsg-1_loong64.deb
     digest: 14d4514b719515758c011e60486cdd4b3e652f1d556375f5e21a3e9029766874
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_loong64.deb
     digest: fd93daa92c7be19210c417596d4c9213d3c734eb2ccaa2de3244fb40b1deb1e9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rubberband/librubberband2_2.0.0-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_loong64.deb
+    digest: 8809a7bd4cd047bccc1e7198bfb8e154716a647cc619ac7d49cbde13b7ebcb1b
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rubberband/librubberband2_2.0.0-2deepin0_loong64.deb
     digest: 8bd87966a533d809c87632a6d1beacae81e14672974fd6113217acbbe3cc6121
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_loong64.deb
     digest: 923a9d2f3cf3cbd71aa95c2451e47021ba3c4b93789a8128b93b8df4f8090d82
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/libsecret-1-0_0.21.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_loong64.deb
+    digest: 330cc540349e985f4837e68c0c021dede1939f25516cbbb1dc7016ca0595ce4f
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_loong64.deb
+    digest: 5a7bd78f37915ec3255c7a90b6abff4e0ae332f3555ebcb3cf8fe78c6545de7d
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/libsecret-1-0_0.21.4-1_loong64.deb
     digest: 84c524ce5af9c16cdca0a706120eb9fcc0c8ba9067a3633fb8a599fc83529225
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/libsecret-1-dev_0.21.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/libsecret-1-dev_0.21.4-1_loong64.deb
     digest: 72f863657a4a0bd90d380b0061e983a9ead765cffcb08467d560a54d25b78f19
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsecret/libsecret-common_0.21.4-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsecret/libsecret-common_0.21.4-1_all.deb
     digest: 2c12c067604e4872a281ddd17347c2a8bfa35ec65c086d46aed37414786205ab
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_loong64.deb
-    digest: 704642e23cbbdbae01b29f6f6e9d7e8f23431a4cc5f33cdf74d7f119fcd12823
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
+    digest: 3560dfdbcf90fef6f1fe16715e1bc7543a4e84b8759c58f71db0d93054bb7d49
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1_3.5-1deepin2_loong64.deb
-    digest: a19a49923398b268c9f2f8e45bca89a70779d5b1b788f9f295e428e731868fe6
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_loong64.deb
+    digest: f03e930d7d2d49c1d6355bce0b584177d61403d2e181c29767f2d853b716702a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
     digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors5_3.6.0-7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors5_3.6.0-7_loong64.deb
     digest: 654049e53be85d4dab717bbfeb848f579c19d0cafd926a845357c62813263cb2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
     digest: cd6de58ec8972c1be0f4028a31b7b94d8079bd1c0bb6af78c21ab1c1a0b245a2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol2_3.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol2_3.5-2_loong64.deb
     digest: ffe0ab79dca28bc304448ab0b91016fdd679746ce0d4395abbf9c38cf0c9774d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/serd/libserd-0-0_0.30.10-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/serd/libserd-0-0_0.30.10-2_loong64.deb
     digest: 75c43427715f5ef52ffe1ce86f2514f30e725c257270984dac743fcabf7c9dbf
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libsframe1_2.41-6deepin4_loong64.deb
-    digest: aa7ec26e2e4c7d58d81c3887fb70e0fb352b36d0738b1b933d709052c21b7351
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libsframe1_2.41-6deepin7_loong64.deb
+    digest: b6b33b68d72cec967790b24d3dd45254886983d05530278cb622c900df0ba341
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
     digest: 9667bac75f00cdf47520a2ec5d444bcafb4c8eb3e13efdf86218f5c69d68652b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_loong64.deb
     digest: ee12b9b2406d779965c510510bd32f01ab931f62eea583bc206c1d41f4a0711c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shine/libshine3_3.1.1-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/shine/libshine3_3.1.1-2_loong64.deb
     digest: 83ec46f7ce2381f484401aa33d7540cfd954f5064ab2c3372ba55f67c9204b8a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsm/libsm6_1.2.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsm/libsm6_1.2.3-1_loong64.deb
     digest: 9af2780f0816a5e2c10bbbe3abb974ba236ecf0beef15a49040433889c678847
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/snappy/libsnappy1v5_1.2.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/snappy/libsnappy1v5_1.2.1-1_loong64.deb
     digest: 037f2de80f65e4491772282c5c45bc286cca8a804f4141f55bd146b1dba20ccc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsndfile/libsndfile1_1.0.31-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsndfile/libsndfile1_1.0.31-2_loong64.deb
     digest: 1724af768ad3f06d2bd8533b94e1327ef2ebe725405744cd510620afaec64a7f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsodium/libsodium23_1.0.18-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsodium/libsodium23_1.0.18-1_loong64.deb
     digest: 967fe90420e1c2608209f23f3a959adc2a3395203139559ef52a957bde15123a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_loong64.deb
     digest: 0ffa187ef4755909e7306c416ef177f3bb28b70c2509a558b9dee95f9e6c62f2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsoxr/libsoxr0_0.1.3-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_loong64.deb
     digest: bb803883ea5a502ae59c3ee986680ce3612863406469d327009684d7377b27cc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
     digest: 760ec85164e31b757b0e46274b5a1eafe5a6ce53ccd0e1c4c1d7e5338e93c31e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/speex/libspeex1_1.2.1-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/speex/libspeex1_1.2.1-2_loong64.deb
     digest: 7f1a740deb7ae14c28a109d35664b0af52ed580d5c66fddda97c5d8863767760
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sphinxbase/libsphinxbase3_0.8+5prealpha+1-13deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sphinxbase/libsphinxbase3_0.8+5prealpha+1-13deepin1_loong64.deb
     digest: 416e4dec45cb4847d95530f2f79740701ffafb8d3bd2b923498f7b7d0103bcc0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_loong64.deb
     digest: 7b26d965fb478c5ae7993ed753ffbb881ad0632063875a8c68585b56a7c70ee7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sratom/libsratom-0-0_0.6.8-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sratom/libsratom-0-0_0.6.8-1_loong64.deb
     digest: 1e6f514dcd307dfad649d7193b49d8899a9f8e3fb1aac7d6c514846d1044d01d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
     digest: dea4a89cee5d7d70b6143ef55501595bfa963aee8777e0f1b10f46a78dc9e578
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_loong64.deb
     digest: 55cc8ef205639767d2c5162b6424297d7866b3d77be3ec600b70ddf3345cd6d9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openssl/libssl3_3.2.0-2deepin2_loong64.deb
-    digest: 6c401bd2a8b58f0d6cbeed6121446336cee004f1a03701025112e090410c20d8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_loong64.deb
+    digest: bb45ae77a9bd5170e8616a550c54e2c419435abce629ade62605dcf0aa544d11
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/startup-notification/libstartup-notification0-dev_0.12-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openssl/libssl3_3.2.4-0deepin2_loong64.deb
+    digest: 0ecb05782da1c411a407535eb0fe4a9118a0b635cf5577b496fc0698aa1f70fe
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/startup-notification/libstartup-notification0-dev_0.12-deepin1_loong64.deb
     digest: 015bc8b5de45378848a03ed1f5547c954e8433d30b1b47a9cb83a4ad092993fd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
     digest: d5528cf8ef1dcf19b1b3245d894851bbddc35132ef3fd22e8c399fd5af91a514
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin3_loong64.deb
-    digest: fa0ba450d1f551bce877461affc516d864f4c3413b6e49a22f31996483f9b462
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_loong64.deb
+    digest: 35e491e460731f9dd6e054429c576a0cef5fca817c034943b0463e6cf8503db3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_loong64.deb
     digest: d402b79e3fbfa42586f89b0b86c376772ec033ff6252032e0ea7edb831a9bf2d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin0_loong64.deb
-    digest: cf508308ab2db7b6f381e0a201e51991c236be2b25ecba58ba3f2db3f827670f
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin2_loong64.deb
+    digest: 68892b6c67bece2121e7b91ef42f9cf8c6537fa3887417953dc82837a245b36d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin0_loong64.deb
-    digest: 8eb5ae15892c3d3e93600e472e3ce69ab742f99b1622a1030d80a822e42989f9
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin2_loong64.deb
+    digest: 62165ae4da8e988e34843872acc420a44bcc4dd65c725bec9012e3dbc97383e7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin0_loong64.deb
-    digest: 0dea4074d37171a31a99d1f773b67f88ed06d6027597da7c5cebae6352d8b478
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin2_loong64.deb
+    digest: cdc134708e57d8d48bfc3379da2ae325de64d2409ec5c2217abe303f3c3d0554
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd0_255.2-4deepin3_loong64.deb
-    digest: 00df4db71c335976879e8d9dbe2ec14f1fd13a7cfce8973e6b22e6a3a7cc2fc8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libsystemd0_255.2-4deepin11_loong64.deb
+    digest: 2e66a084ee5197d6ca309c766a7fb0d9a4b397359e21a5b7a920dce4695cfcf4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_loong64.deb
     digest: 75dde4d8be25c4d18dcf4e27dffff588fabf9c2b365b3c22b2cbd12af97d90b3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
     digest: 3a87af58b0b3becac7062da11264d083cd68190e7dd421c2cbd00da8841cfa25
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libthai/libthai0_0.1.29-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libthai/libthai0_0.1.29-1_loong64.deb
     digest: f870e0bd959b21558d99b2e89c1dd637b8eab46382616482a7eec19df681978f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtheora/libtheora0_1.1.1+dfsg.1-15_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtheora/libtheora0_1.1.1+dfsg.1-15_loong64.deb
     digest: 490265a0c220145d4a1552c50a9fe1d580a70f56db7eee7e2c609bce3b7560b1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff-dev_4.5.1+git230720-1deepin0_loong64.deb
-    digest: 753a87ac79cf923ae461b4f0fa6370faa6c0ec7fa99bb51a14eadddb545bbb0c
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_loong64.deb
+    digest: 56033bdf7bd17609fa7eb714726113303a0bd3bb7cbc95547389a7167d871510
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff6_4.5.1+git230720-1deepin0_loong64.deb
-    digest: 7c8e051f81e8e0f70230d168a2addbd4717990953f7849ca9e7553d91313275a
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_loong64.deb
+    digest: 7766d08dd3b606d683be1d3856fe5b8717b04b5992b06a6b2ab2dad5c95e27df
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiffxx6_4.5.1+git230720-1deepin0_loong64.deb
-    digest: a609eb6be988a394d8b968ce5980552f8ccd3b4617f32458a7d2c2e91213a1d7
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiffxx6_4.5.1+git230720-5_loong64.deb
+    digest: 56f034dd11efeb6bf5d645d2f1d022b75a05b4cc3d3cc460442dfd69cf05d659
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libtinfo6_6.4-4_loong64.deb
-    digest: e4acb568f126357a2ab0d6cccee72d797ec67d0a05dd39193d03ea3260a550b7
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libtinfo6_6.4-4deepin2_loong64.deb
+    digest: 467061b6263e636ede974929d823a1758f1ab21c9a25ab998dd89a0d9ad9122b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
     digest: 74bddc18e3289947b20653433e82025873f5679ccba52f258ca4912e435a09ee
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_loong64.deb
     digest: 398023207ec9cd9852423ff943a2471c9e413273d3d6e654251d3a9d66820b34
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc3_1.3.2-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc3_1.3.2-2_loong64.deb
     digest: 9af8a36a1e38bb90c2cf99639596b5368ecdf03c5a51721bd723735eb3e7cfb8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
     digest: b2217959e0d34e5ce86a75b82acb235e1b887696044937815544c576c7abc9a7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/twolame/libtwolame0_0.4.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/twolame/libtwolame0_0.4.0-2_loong64.deb
     digest: 62ab9f3a9467e09cb86d27e1201e94435e96858fc0afbfe48a6760ab75902d17
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev-dev_255.2-4deepin3_loong64.deb
-    digest: 436043a98f6b3de4f3ea6e930a8d85aca1a5352c8ad6d4f25eff0577064eb553
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev-dev_255.2-4deepin11_loong64.deb
+    digest: bcd190055456a57ecb533f4906186fb0dee6e326adaac353e29a90d17095208c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev1_255.2-4deepin3_loong64.deb
-    digest: a2c6c79a2af46a97ff9ad890557612531086eff933cb486361fb10daf4c44b45
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev1_255.2-4deepin11_loong64.deb
+    digest: e60fd5fd032a8f940a703134978d2ff8ad7b702ad7f9d8419c0529a720759671
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
     digest: 52fe8c374d5b0f18d538139bb314839f707a1ee6da3090d411fb9c2aa9c93e49
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin2_loong64.deb
-    digest: 98a085e21ff00683036041911185645b017627880df3b8a8c91a21f1c1f407b3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin10_loong64.deb
+    digest: 5bde07ab9c215ffd5b04ef5042323f7b251b9347058c8e48f4b73ff9a72d686c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin2_loong64.deb
-    digest: 36765e0d103cbcdc554245559b19d3c89bee0345fe7d24b5e7e32db0f38a4ed3
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin10_loong64.deb
+    digest: 39afc45936e6355271254995cd53a7198ee3d8637c183e242342c3a25ba25b4f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libu/libunistring/libunistring2_0.9.10-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libu/libunistring/libunistring2_0.9.10-6_loong64.deb
     digest: 100d2bd250eff9cdc1ce0492cb7fffc306e620aef5886e1b12245f3f020d569c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_loong64.deb
-    digest: 48c616dfb3a357311ea0507bf7c43740e66a2eb1f85027c116a3f7f20067f4e8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_loong64.deb
+    digest: f3e5aa1a85b3ab2076819261a56469b215cb519efa66d6417065e1826ca7a6ac
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva-drm2_2.20.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libva/libva-drm2_2.20.0-2_loong64.deb
     digest: bbbdab85f21232ec1d4f1522042a0870fbdc5561814169b40702b4652b65816b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva-x11-2_2.20.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libva/libva-x11-2_2.20.0-2_loong64.deb
     digest: c7f773c72c5f5b6ed54a1734e03513d4e210f34485f22e33186f20f4a57ff6f1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libva/libva2_2.20.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libva/libva2_2.20.0-2_loong64.deb
     digest: c9b43b4eba7d7a808c429e72008944b8c19989cf3d7ed95c03a31f72fe9d8c26
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvdpau/libvdpau1_1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvdpau/libvdpau1_1.5-2_loong64.deb
     digest: b1fa2eccc60fa8e56e311145d90a5f293a5422e46387c8c7fb3d352151c47d59
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvidstab/libvidstab1.1_1.1.0-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvidstab/libvidstab1.1_1.1.0-deepin1_loong64.deb
     digest: 2426d25458a68233bce71e89668c2a8a521388f606e526e85188c562760249b6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvorbis/libvorbis0a_1.3.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvorbis/libvorbis0a_1.3.7-1_loong64.deb
     digest: eb315ca7dd23b9be47670ac80776ad4945deeab95fbb6d5116a236d47acfd4ef
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvorbis/libvorbisenc2_1.3.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvorbis/libvorbisenc2_1.3.7-1_loong64.deb
     digest: 5cdb7cf3b7e5750527c1eb4a33e3907865783979f1e554b97b0a83cbc3bc7939
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_loong64.deb
     digest: ee8791150f1bfe803c6dc3cbbb699a5f6db83f9acea98d0d7af33db8cc50d929
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libv/libvpx/libvpx7_1.11.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libv/libvpx/libvpx7_1.11.0-2_loong64.deb
     digest: 87761187efccb8f8f00932cd8e54936a5fa674fde974afa5cdfef2d91868f989
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_loong64.deb
     digest: 26506d91259634d45f99029bf6f969ca5b0e81c39630b0cacb7bd8f959e628f8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_loong64.deb
     digest: 6d09f8d682a373ad28cdee87a1b7c0857d759688554d5b3ae751e5d7054c2ed8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
     digest: 80b9f218239d0521b8c10264860dbf34673b210b56e82ee01ce149a997c57a0a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
     digest: 87c13b7db15b7c19111c5af081825d48550cd48c351e3c5ddfac976939bd67b1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-client0_1.23.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-client0_1.23.0-1_loong64.deb
     digest: 97b7ea92806efbc9f377c790ca5200dd234c35230a6206927ee090097c4e8c85
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-cursor0_1.23.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_loong64.deb
     digest: b457f29596f3639d06b47104e9e9f34bea93014798fcce7aa018a27ad6d6b9ed
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-server0_1.23.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-server0_1.23.0-1_loong64.deb
     digest: 4857b80945e09375cdbf0caa322f75fb243f8d6d97cf31bfae8111854f40e11e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebm/libwebm1_1.0.0.31-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebm/libwebm1_1.0.0.31-1_loong64.deb
     digest: e94dcc495430d1a7cbe0c2130043ef0db8037519e7d82550d5b62e9fbfe9959c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
     digest: d1393a8e0ee0c5e7110a47cd729f042ac19b418bc2560f4fcb330ff1addddada
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp7_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_loong64.deb
     digest: 2a7085499257d278cebe95b0cdc5e9f61c0375319a8683959155a6b7fa57dc78
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
     digest: 6d33f9002478ee47a87b1906776df767e1248a29ff07c07e03aa44980d5326ef
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_loong64.deb
     digest: 09f59a459dbd3ee2c0d7adebaccaa0fb9ce46598f13257bcbdfc6dd4a61dac1c
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_loong64.deb
     digest: d52b6cde771aadcec6f49bfa11bcd2b8780f308f9640215fd30c2881d0dcf0a7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-6_1.8.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-6_1.8.7-1_loong64.deb
     digest: 0e818e4cdefbcf50c1f4c632eb4f0a45ff5b7582d4072a4c64620dc684b49ccd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
     digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
     digest: 9ff2157ecf2cb67c552cb49d624b32ab2393991a184e5151b233288c9a71113d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-xcb1_1.8.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_loong64.deb
     digest: 727ef7465319b0edc7070f9b440a76a29ac1437608a23d98e5679f06d94f6fd5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/x264/libx264-160_0.160.3011.1+dde-deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/x264/libx264-160_0.160.3011.1+dde-deepin_loong64.deb
     digest: 0c2e8d6f6a31c91f056bbd561ad300f498dfafca6616fe34f4acb5457ef6accd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/x265/libx265-199_3.5-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/x265/libx265-199_3.5-deepin1_loong64.deb
     digest: 7e6ff46a8ef0f5ceb00173fa0ab6ffdfa723cd7df39026a74b67b1f00780cad6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
     digest: 15f907de0f88e9aac91b9fca3c609de2330cfe0c847b91d73ed5f3e2c4d098f7
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau6_1.0.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau6_1.0.9-1_loong64.deb
     digest: 13a646d0cdb63a9a5025ab6f5f692e077b51b5735fb06a1300f6fd544d6496bc
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xavs2/libxavs2-13_1.4.1-1+dde_loong64.deb
+    digest: f71a806a15e1fd259ad7c67c41aca0543affe2673ed1bec8198813c62b3829eb
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_loong64.deb
     digest: faa6e26dcacc1349e55f3d40813207148897ff77d47c34ff17fb6585ede18f79
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri2-0_1.15-1_loong64.deb
-    digest: 25459f6ecf5eadd32fa1d076d9bb086c3b6d78720615d3f45280b135c002931c
-  - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_loong64.deb
     digest: 7bcaa840cef1cb99090ae88b987047b83388b4d2b7aef06b8063a211a8418fea
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-glx0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-glx0_1.15-1_loong64.deb
     digest: 19924e487af19c6fbe893bdf9cec301cf3225013122dbd9b40afce27b9cc3694
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_loong64.deb
     digest: 812dc26f817bf6c032d5301a99fc395df44ad95306f8d6cd9f2aa74cbf547d1f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_loong64.deb
     digest: 5573f2fe0db5d1ba31fee4ac95e63f7c29f05dfc1bd932cf702fe1e6b33461f4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_loong64.deb
     digest: a0fbc54aaff67469c3acf51904c2013621636668bf28b6918a207fd7f819acb1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-present0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-present0_1.15-1_loong64.deb
     digest: a47fb8a989a5a6844449830afe9a7234458acb96014de72cf64a18dc78a4707f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-randr0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-randr0_1.15-1_loong64.deb
     digest: bbc5a60430c0641edbdc2736cf3108d35bcb30388ef769e830646b8f4fc01b4f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_loong64.deb
     digest: fb2143791db0e7dee5969bd2b5459439a0d59052000bf26be30e023e2cff77ce
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-render0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-render0_1.15-1_loong64.deb
     digest: f43e74d65d509258147ed6230046648a92fdc906733abf3445373b311032a2a3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shape0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shape0_1.15-1_loong64.deb
     digest: 6bd302fe80140947738703a1d3a00fde8036d7b423ab9a591f7bad1b34c09606
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shm0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shm0_1.15-1_loong64.deb
     digest: f75b6dab7eea8f98e0264c63cbb31b5b21df9679c8b309ce7893d7a4866cb845
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-sync1_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-sync1_1.15-1_loong64.deb
     digest: 6646259959aa296666facf3d598730c7789d51338cd2a81bf9aab79ea9a986cd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_loong64.deb
     digest: 09d6ff65d108b01df3a41e6ce112545c05e8d246bd441fa41e8c365a8f606272
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_loong64.deb
     digest: 604e97953f434b25d0f23f6eed233ed6a797612c2de320262fbb1dff394f9075
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xinerama0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xinerama0_1.15-1_loong64.deb
     digest: b77443ecd34f97d68467689a5d7247170fa1fc06910c19cfbf8d160a8e901d49
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xinput0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xinput0_1.15-1_loong64.deb
     digest: 4fe01e9c81e5b0f199645e25d5ee57837a035f46e50db39193cdb58655bc45da
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xkb1_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_loong64.deb
     digest: d00aabdea0d36cb2980759bc6a56de64b6f74810aa8c25a31dc674ffe40c5f2b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
     digest: 3d4b82cd16df0487be74f8f9f79d27fd7b0c5252c2a1c7bd2e03fa6453059728
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1_1.15-1_loong64.deb
     digest: 6977bdf22da615ab81df4414e047090a560e73cffa04acc6f2ed27bf2c77e5fb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_loong64.deb
     digest: fa296588f4f92220332e72311db7631b9e5734469551e34dfbef79b5bbd2b328
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_loong64.deb
     digest: ce4dc98b358a67e1b9653e4492845673a1f6d75512298389758bfb5f1ca2a463
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxext/libxext6_1.3.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxext/libxext6_1.3.4-1_loong64.deb
     digest: 151ada3ad16057453b554909ae0ae403c46b8d5560643043a92f4a18ca069de0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxfixes/libxfixes3_6.0.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxfixes/libxfixes3_6.0.0-1_loong64.deb
     digest: 12c47fb6cbb173e015a075830b727791bf872ec2491e789658172f714566d297
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxi/libxi6_1.8.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxi/libxi6_1.8.1-1_loong64.deb
     digest: 87c3b78f2e6507074344c7afe0c56aee5a833e8076da0f43ddee28ab53d922f6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
     digest: ba47dce288d90726795169d45ddf9b07f57c9391776ab2a4833ac26fe01a9c90
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_loong64.deb
     digest: 0373a8af7f464e5daf826bb10a59fbb7e353b52447842d18555f79a9eff2eee9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_loong64.deb
     digest: a4e72ca7887958f24270607f6d7897af906a345aa470bdd4a644fa5b66189538
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_loong64.deb
     digest: 6a26f4aaae7e9a8bbc63fd4b6bd8dfdc81a85238a63d7f38d479569bcabeaae0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxrender/libxrender-dev_0.9.10-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxrender/libxrender-dev_0.9.10-1_loong64.deb
     digest: 200bb56d2406e42e19c43725828befaff326ccfcd888c32d4f6e00a7cd998d83
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxrender/libxrender1_0.9.10-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxrender/libxrender1_0.9.10-1_loong64.deb
     digest: 8b25a070d6897778e58585524e411ce4591bcc37a642e0a202e064486906e8a3
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxshmfence/libxshmfence1_1.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_loong64.deb
     digest: 0d235925c3c0d5ff0a3be29607a3800e616b58fcb46b0eafb7a9e3ba70d7d0fb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xvidcore/libxvidcore4_1.3.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xvidcore/libxvidcore4_1.3.7-1_loong64.deb
     digest: df6e32f02df3fb4156ae67404a2b90539a38f12abe66358e83f80c4c1d80c6ca
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_loong64.deb
     digest: 8bf8c69d8210c9e7ca528ec7bb43bb8c39c9493cbe05aca024926e68602b83cd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_loong64.deb
     digest: 5db04094a96e73a685b42d380eea7a3f3b84feeb02d941531246ecf45345d6fe
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_loong64.deb
     digest: 16dfedbf2e2e2882ca15f980b7c3df0b57a2a0989e5a6bf94b84b4847a68257d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zimg/libzimg2_3.0.3+ds1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zimg/libzimg2_3.0.3+ds1-deepin1_loong64.deb
     digest: 9cb7ecf4fa9ab63dbcea9c63bc74d11ded7072278d565ace02f9ecf97531dbfa
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zeromq3/libzmq5_4.3.5-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zeromq3/libzmq5_4.3.5-1_loong64.deb
     digest: ea9300e3470746654e2977f1f42d4577d502625781cdf053bea7aeff012ea17b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
     digest: 542cb13caf60619314815e4a117fb1e39c3540a241aa52a34fb9cc7b4717f08e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_loong64.deb
     digest: a4bae41cbfe530058e9c63f4b3c34294f1b4b726d8f022b9eca8f7e81833fe13
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zvbi/libzvbi-common_0.2.35-18_all.deb
-    digest: 1fc738c696936a298eab3f5a6061ae0189078abddbdf7ef3da2b39537d47aa85
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zvbi/libzvbi-common_0.2.43-2deepin1_all.deb
+    digest: 8c4f70100c1fcb2755b08644f2326f0c42cf037e89c22cb69e4d0dd0798cae8f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zvbi/libzvbi0_0.2.35-18_loong64.deb
-    digest: c65295d36e1fb593d029ebda8348ae9a95f386a10e7689c1312a97cb769857a8
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zvbi/libzvbi0_0.2.43-2deepin1_loong64.deb
+    digest: 3a04740acd8957ba0e5eb2a4266d92ddf4bdc9c12b2c2a75ae868ef24f1cd189
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
     digest: e200be025cd227c34cb852eb20d4b7ad0d371095fdba7b7c4febc7ea7a2221e2
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/linux-upstream/linux-libc-dev_23.01.01.14+STE_loong64.deb
-    digest: 995dd21c2ade67bf170fcf9cf5d9b5f3edd4d964ce74f70fa242bebe3009f685
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_loong64.deb
+    digest: a594841362d365a0b93ae0462935964f0efbb0c90da4be064351388804154202
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
     digest: a6b376c2fd149cc6cabd93cd94dea5c9793fe8e9b9773c22bb9a12812ac52cf4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/make-dfsg/make_4.3-4.1_loong64.deb
-    digest: 7869d745da7ed65da3280054b10c6763397a71bf22a8a7b55f2efccac6ce406b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/make-dfsg/make_4.4.1-1_loong64.deb
+    digest: 549a2844f1ba5051fd3be57714c0e2498054ebf269ecfe235e532a0b363e4f8d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/media-types/media-types_4.0.0_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_loong64.deb
+    digest: df2142c0fe0e2665b0f4f7068f4c2aa5d4f5fcd564b2fa570b993c83598dd157
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/netbase/netbase_6.4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_loong64.deb
-    digest: 8569bcf5afca194968c0e49c3a71fbf106bdb5f6281db535142a5b8ea1a46e18
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.3.3-1_loong64.deb
+    digest: 7f3efc85c206a71b7442ee3e18dfe4f2dba6c0c62c28ab38b4960be5d28998ae
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/patch/patch_2.7.6-7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/patch/patch_2.7.6-7_loong64.deb
     digest: 713a6fe43f8c66f410ed5eca4b57361868d6da0f05e2ef9f7300f7fe524ee2e5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-base_5.36.0-10_loong64.deb
-    digest: 2c2ff9c3322f33ec19ed0c0170001fde2d9ff60937d323f154aac0a1a660fe82
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-base_5.36.0-10deepin1_loong64.deb
+    digest: 0c82d65a772e2396c06bc94b1266087c4f490b0fccf8b55c47b95ed82b7e5ff9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
-    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
+    digest: b79ccae8397e919ee917cd187b8be2d3b10eb598f43cf72a9d9a50c3d81ec288
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl_5.36.0-10_loong64.deb
-    digest: dc3b0b73a582471f146be8f35e39d61ef9046a2a4f3ee2a29684f8ed12d2a598
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl_5.36.0-10deepin1_loong64.deb
+    digest: 030b888ad983a63b0cec1e207f3f372abd6b61d64efbe23c781dae2af2634838
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkg-config_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkg-config_1.8.1-4_loong64.deb
     digest: fb2ca56eebecd5c9dd6f9150062f349edcd4863390463d536927b6232658f8f0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_loong64.deb
     digest: 872f0376191a3cc26d0fcf9f60b5a2e81d68576cf18aa24449574147e7ce697f
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf_1.8.1-4_loong64.deb
     digest: 3e3b1b4df76ba6899f213996a11d75d1b01acc5ef6a9445ca9bb637cb8cd126b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_loong64.deb
     digest: ab21a1c47406aa070515796262c63097b15c72fbcdc2e33d98a646c0471cfebb
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_loong64.deb
-    digest: f90145024163b5f423db6765b8ced01439e819859419cfe9eb9fe7ffc6cfd0f7
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_loong64.deb
+    digest: b4144ee10587be066eb49793ff81bdf1e6542b4398a99bce1f61660fee4bedfe
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12_3.12.4-0deepin1_loong64.deb
-    digest: a003a420b5bda72fb4bbea54eaf3a3a3c74fea3c741ce8141646832b82140be0
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_loong64.deb
+    digest: ea8a8be4b657b9b94b2a1e1fb27fff9a7fabd64a17007147088feaba6a7a970a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3_3.12.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_loong64.deb
     digest: 2068886f43d893b3d801afe06bdbed2ac6cfbd3dd14b1d2b5658fb691d45615e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
     digest: 99aa344e806f799b1008841a76c4f83ad58f508aa7216f7df5adae3aa860fdbd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: b2c23ea458f84eaf5df7f06ceeccf24047551cabc4abd35782060399cd2c8ad6
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin15_loong64.deb
+    digest: 147a8ebede9ff9af80b530c3c602ef4f5bfec785f1379ba5352993af5856d94b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 4a50a0bec4830e8b4d5468af3ca9b8bb08bcea4892539c2133c6cfe8d06889de
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin15_loong64.deb
+    digest: 0b03b9857d8b77e0ccdc3ffdc70a08035bb59756fa803cfc8a022c87789fc218
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 339c762f9680d23b12e5ac41068c139b969cf6d035fd286bac37cb3dba4433f9
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 8e412a2aa98348c58e7f528fd04c00feb90320acc2b6cbed873c3094890a49ec
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 352c93151474b4e0843755cf4248d5678df53a42e9058d07408427a848b52b08
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 5bebc32a419c38803377c01265c89450b74b82ab8098a71593f9292962919432
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 2e76edf66678b456d8d2772efd47d38a50c140d74084a166fd2faf1a63da2b00
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 8bb4163c0c9da5c501f1937e79f1f9db15bc57b502de5d711f51239748d3c1ce
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 6cc78a068f206bc90e8cea49b01dac72ac0356213fe52643cec12a23f6b82353
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 61fa7ec1e9023d7c55286b469b6238769eb86b1fa2cfdd45aaa291fe2005e57a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 89d3909a21672e5f10a559a89e5d81efb9056f516935422e9b2dbcd0126503ea
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 3dea4403705fc32119023d852123e8327e56bd1a68f6aac8acb3c230351b769a
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
     digest: cf6fafc95fdce9f99b2bfd283100163a1c316fc596dd6ab9da30821d1faeb0d5
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_loong64.deb
     digest: d9703d3d43bc45d7190b56022d278654f40a2ef3a53314a6426f018ed1e0eca0
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
     digest: 64b8adf192160cd12b0e63cba2d112fe0f0f361f83df2666c5017e55e5383fd9
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 13e2e5d5ae5fbaa5b971f6e5d4b48c1d72cef2e77af4344e7b802e0f4170228b
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 82c70661bd53c58e196bbfede69b23bd2bcbd36829aeafa838cdaa4627893a98
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_loong64.deb
     digest: 8d025380c93576e65ed0941ed9b0a568d366c9554497570335f4426be7068545
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
     digest: 0f27c4de0f6b1d21b037e49d0d94effc72f061f8fbe742365dd83f2ccbb0c782
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
     digest: 18aca243a15bb51fb26de8579e2fd58cc2234f31dd4db73fda2d734a41308887
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/readline-common_8.2-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/readline-common_8.2-3_all.deb
     digest: 35fe59faceb8d9def8b6aa664e091eac8444887bc1f33ba2cf22099c3646e7bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_loong64.deb
     digest: 5a68197175ff3bf8f57fdd1066b62efcb547e877ae2c3b057f5b5a9c8add94c4
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shared-mime-info/shared-mime-info_2.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_loong64.deb
     digest: a0cd2345f1c869975ba98b8ead9048f32746d72966162472ce531ae48ecb0e9e
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tar/tar_1.35+dfsg-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tar/tar_1.35+dfsg-3_loong64.deb
     digest: 48cc0cc32829c68c7b58e74f141fe552f9a3f5c9e6da77ad54184530debc0cff
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/uuid-dev_2.39.3-6deepin1_loong64.deb
-    digest: 54727a76b166231d74f5116fc6732bf97ac9aa2ee8f8b49bbf0ee5b8358c5483
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_loong64.deb
+    digest: 8097f0f8c46e7619c944b22fb4160d60ac3b3eb5aab3d5ea26a7c83816ed24bd
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
     digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
     digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-render-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-render-dev_2024.1-1_all.deb
     digest: 7fb5329b624a9bcf86b4c6f4a3df92650c1c6a2041f0a75f4ae5c6f819915eba
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
     digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_loong64.deb
     digest: 7022910932f96b7af8fa6e5ffe31a20515e47e9ae3dbab9781012f132e4e3198
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
     digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/xz-utils_5.4.5-0.3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/xz-utils_5.4.5-0.3_loong64.deb
     digest: 914f9a81a1be1c08e1489ae0d463c9e68f725da465d2dda0cba519f87a00ddc8
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
     digest: b40d74ed9b2014e3a3bcb7c6121a17e16424d0ef19c9ee1aef977b7460b1b1b6
   - kind: file
-    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
     digest: 135455e7368c3c73d5984305019c2574ebc5501f2d650e77addbc4d87db55503


### PR DESCRIPTION
Added support for HEIC, HEIF, and AVIF formats.

Log: Image format extension support
Task: https://pms.uniontech.com/task-view-378959.html

## Summary by Sourcery

Add support for HEIC, HEIF, and AVIF image formats and update packaging accordingly

New Features:
- Support HEIC, HEIF, and AVIF image formats via Qt imageformats and libheif plugins

Enhancements:
- Bump deepin-album version to 6.0.37.1
- Copy Qt imageformats plugins and install libheif plugin files with LIBHEIF_PLUGIN_PATH set
- Switch Linglong source URLs to internal mirror and add kimageformat6-plugins dependency
- Update dependency URLs and digests for numerous packages