### PR TITLE
fix: Handling translation errors in lo languages

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.38.1
+  version: 6.0.39.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.39) unstable; urgency=medium
+
+  * Update version to 6.0.39.
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Fri, 08 Aug 2025 13:53:15 +0800
+
 deepin-album (6.0.38) unstable; urgency=medium
 
   * Update version to 6.0.38. 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.38.1
+  version: 6.0.39.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.38.1
+  version: 6.0.39.1
   kind: app
   description: |
     album for deepin os.

--- a/src/translations/deepin-album_lo.ts
+++ b/src/translations/deepin-album_lo.ts
@@ -4,202 +4,203 @@
 <context>
     <name>AlbumControl</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="257"/>
+        <location filename="../src/albumControl.cpp" line="278"/>
         <source>All photos and videos</source>
         <translation>ទីត្រូវការទាំងអស់នូវរូបថតនិងវីដេអូ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="285"/>
+        <location filename="../src/albumControl.cpp" line="306"/>
         <source>Disk is busy, cannot eject now</source>
         <translation>ດ຿ວງກ່ོངས་ມີ່ນົມ, ບໍ່ສາມາດອອກຈາກດ຿ວງກ່ོངསທັນທີ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="286"/>
+        <location filename="../src/albumControl.cpp" line="307"/>
         <source>OK</source>
         <translation>ຕົວຢ່າງ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="903"/>
+        <location filename="../src/albumControl.cpp" line="928"/>
         <source>Fullscreen</source>
         <translation>ແຜ່ນແບບໃຫ້ເບິ່ງຄ່ອງ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="906"/>
+        <location filename="../src/albumControl.cpp" line="931"/>
         <source>Exit fullscreen/slideshow</source>
         <translation>ອອກຈາກແຜ່ນແບບໃຫ້ເບິ່ງຄ່ອງ/ໂຄງສ້າງສົນທະນາ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="912"/>
+        <location filename="../src/albumControl.cpp" line="937"/>
         <source>Help</source>
         <translation>ຊ່ວຍເບິ່ງ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="915"/>
+        <location filename="../src/albumControl.cpp" line="940"/>
         <source>Display shortcuts</source>
         <translation>ສະແໜ່ລາຍການຂ້ອນຂ້າງ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="918"/>
+        <location filename="../src/albumControl.cpp" line="943"/>
         <source>Display in file manager</source>
         <translation>ສະແໜ່ໃນຜູ້ຈັດການເອົາໄຂ່ໄມໂດຽ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="921"/>
+        <location filename="../src/albumControl.cpp" line="946"/>
         <source>Slide show</source>
         <translation>ໂຄງສ້າງສົນທະນາ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="924"/>
+        <location filename="../src/albumControl.cpp" line="949"/>
         <source>View</source>
         <translation>ເບິ່ງ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="927"/>
+        <location filename="../src/albumControl.cpp" line="952"/>
         <source>Export photos</source>
         <translation>ចោលរូបថតចេញ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="930"/>
+        <location filename="../src/albumControl.cpp" line="955"/>
         <source>Import photos/videos</source>
         <translation>បញ្ចូលរូបថតនិងវីដេអូ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="933"/>
+        <location filename="../src/albumControl.cpp" line="958"/>
         <source>Select all</source>
         <translation>ເລົ່າທີ່ງົນ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="936"/>
+        <location filename="../src/albumControl.cpp" line="961"/>
         <source>Copy</source>
         <translation>ຄຸມຄອບ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="939"/>
+        <location filename="../src/albumControl.cpp" line="964"/>
         <source>Delete</source>
         <translation>ລຶບ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="942"/>
+        <location filename="../src/albumControl.cpp" line="967"/>
         <source>Photo/Video info</source>
         <translation>ຂំណុោះរូប/វីដេអូ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="945"/>
+        <location filename="../src/albumControl.cpp" line="970"/>
         <source>Set as wallpaper</source>
         <translation>ຕັ້ງເປັນພາບພື້ນຫຼັງ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="948"/>
+        <location filename="../src/albumControl.cpp" line="973"/>
         <source>Rotate clockwise</source>
         <translation>ຫມຸນຕາມຕົວເລກ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="951"/>
+        <location filename="../src/albumControl.cpp" line="976"/>
         <source>Rotate counterclockwise</source>
         <translation>ຫມຸນຕາມຕົວເລກ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="957"/>
+        <location filename="../src/albumControl.cpp" line="982"/>
         <source>Zoom in</source>
         <translation>ຂະຫຍາຍ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="960"/>
+        <location filename="../src/albumControl.cpp" line="985"/>
         <source>Zoom out</source>
         <translation>ຢັບຢອດ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="963"/>
+        <location filename="../src/albumControl.cpp" line="988"/>
         <source>Previous</source>
         <translation>ກາງກັນ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="966"/>
+        <location filename="../src/albumControl.cpp" line="991"/>
         <source>Next</source>
         <translation>ຕົວເລກ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="969"/>
+        <location filename="../src/albumControl.cpp" line="994"/>
         <source>Favorite</source>
         <translation>ສະແດງຢູ່ໃນລາຍການທີ່ມັກ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="972"/>
+        <location filename="../src/albumControl.cpp" line="997"/>
         <source>Unfavorite</source>
         <translation>ລຶບອອກຈາກລາຍການທີ່ມັກ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="975"/>
+        <location filename="../src/albumControl.cpp" line="1000"/>
         <source>New album</source>
         <translation>ອັລບັ້ມໃຫມ່</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="978"/>
+        <location filename="../src/albumControl.cpp" line="1003"/>
         <source>Rename album</source>
         <translation>ຕັ້ງຊື່ອັລບັ້ມ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="981"/>
+        <location filename="../src/albumControl.cpp" line="1006"/>
         <source>Page up</source>
         <translation>ກາງກັນ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="984"/>
+        <location filename="../src/albumControl.cpp" line="1009"/>
         <source>Page down</source>
         <translation>ຕົວເລກ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1026"/>
+        <location filename="../src/albumControl.cpp" line="1051"/>
         <source>Photos</source>
         <translation>ຮູບພາບ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1029"/>
+        <location filename="../src/albumControl.cpp" line="1054"/>
         <source>Albums</source>
         <translation>ອັລບັ້ມ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1032"/>
+        <location filename="../src/albumControl.cpp" line="1057"/>
         <source>Settings</source>
         <translation>ຕັ້ງຄ່າ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1601"/>
+        <location filename="../src/albumControl.cpp" line="1629"/>
         <source>Favorites</source>
         <translation>ທີ່ມັກ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1603"/>
+        <location filename="../src/albumControl.cpp" line="1631"/>
         <source>Screen Capture</source>
         <translation>ບິດສຽງຈາກຫນ້າຈອດ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1605"/>
+        <location filename="../src/albumControl.cpp" line="1633"/>
         <source>Camera</source>
         <translation>ການຖ່າຍຮູບ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1607"/>
+        <location filename="../src/albumControl.cpp" line="1635"/>
         <source>Draw</source>
         <translation>ວັດ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1700"/>
+        <location filename="../src/albumControl.cpp" line="1728"/>
         <source>Unnamed</source>
         <translation>ບໍ່ມີຊື່</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2145"/>
+        <location filename="../src/albumControl.cpp" line="2170"/>
+        <location filename="../src/albumControl.cpp" line="2174"/>
         <source>%1Year%2Month%3Day</source>
         <translation>%1ខែ%2ថ្ម%3ឆ្នាំ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2199"/>
+        <location filename="../src/albumControl.cpp" line="2224"/>
         <source>Channel</source>
         <translation>បណ្ឌិត</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="2400"/>
+        <location filename="../src/albumControl.cpp" line="2445"/>
         <source>Pictures</source>
         <translation>រូបភាព</translation>
     </message>
@@ -228,7 +229,7 @@
     </message>
     <message>
         <source>%1 is released under %2</source>
-        <translation>%1ត្រូវបានចេញផ្អើលនៅក្រោម%2</translation>
+        <translation type="vanished">%1ត្រូវបានចេញផ្អើលនៅក្រោម%2</translation>
     </message>
     <message>
         <location filename="../qml/AlbumTitle.qml" line="177"/>
@@ -252,21 +253,25 @@
     </message>
     <message>
         <location filename="../qml/AlbumTitle.qml" line="262"/>
+        <location filename="../qml/AlbumTitle.qml" line="340"/>
         <source>Y</source>
         <translation>ཡ</translation>
     </message>
     <message>
         <location filename="../qml/AlbumTitle.qml" line="274"/>
+        <location filename="../qml/AlbumTitle.qml" line="341"/>
         <source>M</source>
         <translation>ម</translation>
     </message>
     <message>
         <location filename="../qml/AlbumTitle.qml" line="285"/>
+        <location filename="../qml/AlbumTitle.qml" line="342"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
         <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="343"/>
         <source>All</source>
         <translation>ທັງໝົດ</translation>
     </message>
@@ -324,7 +329,7 @@
         <translation>%1 ວິດີໂອ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="192"/>
+        <location filename="../qml/ThumbnailImageView/CollecttionView/AllCollection.qml" line="181"/>
         <source>No results</source>
         <translation>ບໍ່ມີຜົນລັບ</translation>
     </message>
@@ -352,12 +357,12 @@
         <translation>%1 ວິດີໂອ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="152"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="155"/>
         <source>0 item</source>
         <translation>0 ອັນຕະລາງ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="214"/>
+        <location filename="../qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml" line="219"/>
         <source>No results</source>
         <translation>ບໍ່ມີຜົນລັບ</translation>
     </message>
@@ -365,22 +370,31 @@
 <context>
     <name>DBManager</name>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="465"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="480"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="522"/>
         <source>Screen Capture</source>
         <translation>ບິດສຽງຈາກຫນ້າຈອດ</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="466"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="481"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="498"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="527"/>
         <source>Camera</source>
         <translation>ການຖ່າຍຮູບ</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="467"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="532"/>
         <source>Draw</source>
         <translation>ວັດ</translation>
     </message>
     <message>
-        <location filename="../src/dbmanager/dbmanager.cpp" line="1991"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2021"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2041"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2045"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2047"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2053"/>
         <source>(copy)</source>
         <translation>(ចំណាកស់)</translation>
     </message>
@@ -416,22 +430,22 @@
 <context>
     <name>DeepinStorage</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1091"/>
+        <location filename="../src/albumControl.cpp" line="1116"/>
         <source>%1 Drive</source>
         <translation>%1 ດັບ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1095"/>
+        <location filename="../src/albumControl.cpp" line="1120"/>
         <source>Blank %1 Disc</source>
         <translation>ພາກະ ນີ້ %1</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1099"/>
+        <location filename="../src/albumControl.cpp" line="1124"/>
         <source>%1 Encrypted</source>
         <translation>%1 ຈົບ</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1102"/>
+        <location filename="../src/albumControl.cpp" line="1127"/>
         <source>%1 Volume</source>
         <translation>%1 ສ້ວນ</translation>
     </message>
@@ -512,42 +526,44 @@
         <translation>%1 វិдеអីវូ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="168"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="179"/>
         <source>Import to:</source>
         <translation>បញ្ចូលទៅ:</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="178"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="189"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="192"/>
         <source>Import</source>
         <translation>បញ្ចូល</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="178"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="189"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="192"/>
         <source>New Album</source>
         <translation>បាល់បាសថ្មី</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="205"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="216"/>
         <source>Import All</source>
         <translation>បញ្ចូលទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="206"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="217"/>
         <source>Import 1 Item</source>
         <translation>បញ្ចូល 1 ធាតុ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="207"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="218"/>
         <source>Import %1 Items</source>
         <translation>បញ្ចូល %1 ធាតុ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="214"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="225"/>
         <source>Import successful</source>
         <translation>បញ្ចូលជៀរជ្រៅ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="266"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="276"/>
         <source>No results</source>
         <translation>គ្មានលទ្ធភាពណ៍</translation>
     </message>
@@ -555,17 +571,17 @@
 <context>
     <name>DeviceLoadDialog</name>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="42"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="61"/>
         <source>Loading...</source>
         <translation>กำลading...</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="51"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="70"/>
         <source>Cancel</source>
         <translation>ប៉ុلغ</translation>
     </message>
     <message>
-        <location filename="../qml/Control/DeviceLoadDialog.qml" line="59"/>
+        <location filename="../qml/Control/DeviceLoadDialog.qml" line="78"/>
         <source>Ignore</source>
         <translation>បរាយលាក់ចេញ</translation>
     </message>
@@ -632,6 +648,7 @@
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="127"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="143"/>
         <source>Select other directories</source>
         <translation>เลือกไดเรกทอรีอื่น</translation>
     </message>
@@ -669,122 +686,123 @@
 <context>
     <name>FileControl</name>
     <message>
-        <location filename="../src/filecontrol.cpp" line="834"/>
+        <location filename="../src/filecontrol.cpp" line="838"/>
         <source>Fullscreen</source>
         <translation>ផ្ទឹកពេញប្រាស់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="838"/>
+        <location filename="../src/filecontrol.cpp" line="842"/>
         <source>Exit fullscreen</source>
         <translation>ចាក់ផ្ទឹកពេញប្រាស់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="842"/>
+        <location filename="../src/filecontrol.cpp" line="846"/>
         <source>Extract text</source>
         <translation>លក្ខយៈអត្តសញ្ញាណ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="846"/>
+        <location filename="../src/filecontrol.cpp" line="850"/>
         <source>Slide show</source>
         <translation>ស្នាល់តាមរូប</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="850"/>
+        <location filename="../src/filecontrol.cpp" line="854"/>
         <source>Rename</source>
         <translation>ផ្លាស់ឈ្មោះ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="854"/>
+        <location filename="../src/filecontrol.cpp" line="858"/>
+        <location filename="../src/filecontrol.cpp" line="950"/>
         <source>Copy</source>
         <translation>ចិត្បា</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="858"/>
+        <location filename="../src/filecontrol.cpp" line="862"/>
         <source>Delete</source>
         <translation>លើយលឹក</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="862"/>
+        <location filename="../src/filecontrol.cpp" line="866"/>
         <source>Rotate clockwise</source>
         <translation>បង្វើលូកត្រើមម៉ាស់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="866"/>
+        <location filename="../src/filecontrol.cpp" line="870"/>
         <source>Rotate counterclockwise</source>
         <translation>បង្វើលូកត្រូវក្រោយម៉ាស់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="870"/>
+        <location filename="../src/filecontrol.cpp" line="874"/>
         <source>Set as wallpaper</source>
         <translation>ជាប្រព័ន្ធពង្រាប់ផ្កាយ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="874"/>
+        <location filename="../src/filecontrol.cpp" line="878"/>
         <source>Display in file manager</source>
         <translation>បង្ហាញនៅក្នុងឧបកម្មគ្រប់គ្រងឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="878"/>
+        <location filename="../src/filecontrol.cpp" line="882"/>
         <source>Image info</source>
         <translation>ព័ត៍េះសារទិន្និងព័ត៍េះសារ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="882"/>
+        <location filename="../src/filecontrol.cpp" line="886"/>
         <source>Previous</source>
         <translation>មុន</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="886"/>
+        <location filename="../src/filecontrol.cpp" line="890"/>
         <source>Next</source>
         <translation>បន្ទាប់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="890"/>
+        <location filename="../src/filecontrol.cpp" line="894"/>
         <source>Zoom in</source>
         <translation>ពោតសំខាន់ឡើង</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="894"/>
+        <location filename="../src/filecontrol.cpp" line="898"/>
         <source>Zoom out</source>
         <translation>ពោតសំខាន់ចុះ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="898"/>
+        <location filename="../src/filecontrol.cpp" line="902"/>
         <source>Open</source>
         <translation>បុក</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="902"/>
+        <location filename="../src/filecontrol.cpp" line="906"/>
         <source>Print</source>
         <translation>រុញុប</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="926"/>
+        <location filename="../src/filecontrol.cpp" line="930"/>
         <source>Image Viewing</source>
         <translation>ការមូលដ្កាក់ព័ត៍េះសារ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="930"/>
+        <location filename="../src/filecontrol.cpp" line="934"/>
         <source>Help</source>
         <translation>ជួយ</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="934"/>
+        <location filename="../src/filecontrol.cpp" line="938"/>
         <source>Display shortcuts</source>
         <translation>បង្ហាញប្រភេទប្រមាស់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="942"/>
+        <location filename="../src/filecontrol.cpp" line="946"/>
         <source>Settings</source>
         <translation>ការកំណត់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="950"/>
+        <location filename="../src/filecontrol.cpp" line="954"/>
         <source>Select all</source>
         <translation>ជ្រូតទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../src/filecontrol.cpp" line="958"/>
+        <location filename="../src/filecontrol.cpp" line="962"/>
         <source>Live Text</source>
         <translation>ព័ត៍េះអក្សរ</translation>
     </message>
@@ -810,42 +828,42 @@
 <context>
     <name>GlobalStatus</name>
     <message>
-        <location filename="../src/globalstatus.cpp" line="807"/>
+        <location filename="../src/globalstatus.cpp" line="863"/>
         <source>1 item selected (1 photo)</source>
         <translation>1 រូបត្រូវបានជ្រើនជម្ល់</translation>
     </message>
     <message>
-        <location filename="../src/globalstatus.cpp" line="809"/>
+        <location filename="../src/globalstatus.cpp" line="865"/>
         <source>1 item selected (1 video)</source>
         <translation>1 វីដេអូត្រូវបានជ្រើនជម្ល់</translation>
     </message>
     <message>
-        <location filename="../src/globalstatus.cpp" line="811"/>
+        <location filename="../src/globalstatus.cpp" line="867"/>
         <source>%1 items selected (%1 photos)</source>
         <translation>%1 រូបត្រូវបានជ្រើនជម្ល់</translation>
     </message>
     <message>
-        <location filename="../src/globalstatus.cpp" line="813"/>
+        <location filename="../src/globalstatus.cpp" line="869"/>
         <source>%1 items selected (%1 videos)</source>
         <translation>%1 វីដេអូត្រូវបានជ្រើនជម្ល់</translation>
     </message>
     <message>
-        <location filename="../src/globalstatus.cpp" line="815"/>
+        <location filename="../src/globalstatus.cpp" line="871"/>
         <source>%1 item selected (1 photo, 1 video)</source>
         <translation>%1 រូបត្រូវបានជ្រើនជម្ល់ (រូបភាព ଓ ଼ីដេអូ)</translation>
     </message>
     <message>
-        <location filename="../src/globalstatus.cpp" line="817"/>
+        <location filename="../src/globalstatus.cpp" line="873"/>
         <source>%1 items selected (1 photo, %2 videos)</source>
         <translation>%1 រូបត្រូវបានជ្រើនជម្ល់ (1 ଼ីដេអូ, %2 ଼ីដេអូ)</translation>
     </message>
     <message>
-        <location filename="../src/globalstatus.cpp" line="819"/>
+        <location filename="../src/globalstatus.cpp" line="875"/>
         <source>%1 items selected (%2 photos, 1 video)</source>
         <translation>%1 រូបត្រូវបានជ្រើនជម្ល់ (%2 ଼ីដេអូ, 1 ଼ីដេអូ)</translation>
     </message>
     <message>
-        <location filename="../src/globalstatus.cpp" line="821"/>
+        <location filename="../src/globalstatus.cpp" line="877"/>
         <source>%1 items selected (%2 photos, %3 videos)</source>
         <translation>%1 រូបត្រូវបានជ្រើនជម្ល់ (%2 ଼ីដេអូ, %3 ଼ីដេអូ)</translation>
     </message>
@@ -859,6 +877,7 @@
     </message>
     <message>
         <location filename="../qml/GlobalVar.qml" line="38"/>
+        <location filename="../qml/GlobalVar.qml" line="46"/>
         <source>The file format is not supported</source>
         <translation>រាងទុកដានូវិធីសាស្ត្រមិនត្រូវបានគាំទាវ</translation>
     </message>
@@ -894,50 +913,61 @@
 <context>
     <name>ImportTimeLineView</name>
     <message>
-        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="195"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="211"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="430"/>
         <source>Import</source>
         <translation>ນໍາເຂົ້າ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="320"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="341"/>
         <source>1 photo</source>
         <translation>1 ຮູບພາບ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="343"/>
         <source>1 video</source>
         <translation>1 ວິດີໂອ</translation>
     </message>
-    <message>
-        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="324"/>
+    <message numerus="yes">
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
-        <translation>%n ຮູບພາບ</translation>
+        <translation>
+            <numerusform>%n ຮູບພາບ</numerusform>
+        </translation>
     </message>
-    <message>
-        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="326"/>
+    <message numerus="yes">
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
-        <translation>%n ວິດີໂອ</translation>
+        <translation>
+            <numerusform>%n ວິດີໂອ</numerusform>
+        </translation>
     </message>
-    <message>
-        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="328"/>
+    <message numerus="yes">
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
-        <translation>%n ລາຍການ</translation>
+        <translation>
+            <numerusform>%n ລາຍການ</numerusform>
+        </translation>
+    </message>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
         <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="150"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="423"/>
         <source>Imported on</source>
         <translation>ចាក់ចំណាក់នៃ</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="150"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="423"/>
         <source>1 item</source>
         <translation>1 ធាតុ</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="150"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="423"/>
         <source>%1 items</source>
         <translation>%1 ធាតុ</translation>
     </message>
@@ -946,91 +976,91 @@
     <name>InfomationDialog</name>
     <message>
         <source>Basic info</source>
-        <translation>ព័ត៍ទូទៅ</translation>
+        <translation type="vanished">ព័ត៍ទូទៅ</translation>
     </message>
     <message>
         <source>File name</source>
-        <translation>ឈ្មោះឯកសារ</translation>
+        <translation type="vanished">ឈ្មោះឯកសារ</translation>
     </message>
     <message>
         <source>Size</source>
-        <translation>ទៅហ្គ្រេង</translation>
+        <translation type="vanished">ទៅហ្គ្រេង</translation>
     </message>
     <message>
         <source>Dimensions</source>
-        <translation>ទីវัด</translation>
+        <translation type="vanished">ទីវัด</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation>ប្រភេទ</translation>
+        <translation type="vanished">ប្រភេទ</translation>
     </message>
     <message>
         <source>Date captured</source>
-        <translation>ថ្តិការបញ្ចប់</translation>
+        <translation type="vanished">ថ្តិការបញ្ចប់</translation>
     </message>
     <message>
         <source>Date modified</source>
-        <translation>ថ្តិការកំណត់</translation>
+        <translation type="vanished">ថ្តិការកំណត់</translation>
     </message>
     <message>
         <source>Details</source>
-        <translation>លក្ខណៈ</translation>
+        <translation type="vanished">លក្ខណៈ</translation>
     </message>
     <message>
         <source>Aperture</source>
-        <translation>ទូទៅ</translation>
+        <translation type="vanished">ទូទៅ</translation>
     </message>
     <message>
         <source>Exposure program</source>
-        <translation>កម្មវិធីការបញ្ចុច</translation>
+        <translation type="vanished">កម្មវិធីការបញ្ចុច</translation>
     </message>
     <message>
         <source>Focal length</source>
-        <translation>ប្រវត្តិភាព</translation>
+        <translation type="vanished">ប្រវត្តិភាព</translation>
     </message>
     <message>
         <source>ISO</source>
-        <translation>ISO</translation>
+        <translation type="vanished">ISO</translation>
     </message>
     <message>
         <source>Exposure mode</source>
-        <translation>របូរ៉</translation>
+        <translation type="vanished">របូរ៉</translation>
     </message>
     <message>
         <source>Exposure time</source>
-        <translation>ពេលការបញ្ចុច</translation>
+        <translation type="vanished">ពេលការបញ្ចុច</translation>
     </message>
     <message>
         <source>Flash</source>
-        <translation>ភ្នំភ្លើង</translation>
+        <translation type="vanished">ភ្នំភ្លើង</translation>
     </message>
     <message>
         <source>Flash compensation</source>
-        <translation>ការប្រកប់ភ្នំភ្លើង</translation>
+        <translation type="vanished">ការប្រកប់ភ្នំភ្លើង</translation>
     </message>
     <message>
         <source>Max aperture</source>
-        <translation>ទូទៅអតិក៍តិច</translation>
+        <translation type="vanished">ទូទៅអតិក៍តិច</translation>
     </message>
     <message>
         <source>Colorspace</source>
-        <translation>លំដាប់ពណ៌</translation>
+        <translation type="vanished">លំដាប់ពណ៌</translation>
     </message>
     <message>
         <source>Metering mode</source>
-        <translation>ລోវියා ཟියුគ្រោះ</translation>
+        <translation type="vanished">ລోវියා ཟියුគ្រោះ</translation>
     </message>
     <message>
         <source>White balance</source>
-        <translation>ខៀរ མានភាពសញ្ញាពណ៌</translation>
+        <translation type="vanished">ខៀរ མានភាពសញ្ញាពណ៌</translation>
     </message>
     <message>
         <source>Device model</source>
-        <translation>ອື໅ື໅ མຸນୀນ ཏຳງ</translation>
+        <translation type="vanished">ອື໅ື໅ མຸນୀນ ཏຳງ</translation>
     </message>
     <message>
         <source>Lens model</source>
-        <translation>ເປັນໂປິດ མຸນୀນ</translation>
+        <translation type="vanished">ເປັນໂປິດ མຸນୀນ</translation>
     </message>
 </context>
 <context>
@@ -1155,11 +1185,13 @@
     </message>
     <message>
         <location filename="../qml/MainAlbumView.qml" line="246"/>
+        <location filename="../qml/MainAlbumView.qml" line="252"/>
         <source>Imported:</source>
         <translation>ISO</translation>
     </message>
     <message>
         <location filename="../qml/MainAlbumView.qml" line="253"/>
+        <location filename="../qml/MainAlbumView.qml" line="290"/>
         <source>%1/%2</source>
         <translation>ISO</translation>
     </message>
@@ -1170,6 +1202,7 @@
     </message>
     <message>
         <location filename="../qml/MainAlbumView.qml" line="270"/>
+        <location filename="../qml/MainAlbumView.qml" line="276"/>
         <source>Import failed</source>
         <translation>អន្តញ្ញាណបញ្ចូនបរិច្ចាណចំនុចបានล้มเหลว</translation>
     </message>
@@ -1195,12 +1228,12 @@
 <context>
     <name>MenuItemStates</name>
     <message>
-        <location filename="../qml/MenuItemStates.qml" line="104"/>
+        <location filename="../qml/MenuItemStates.qml" line="120"/>
         <source>Export successful</source>
         <translation>ចំណាយចេញបានជោតល្អៗ</translation>
     </message>
     <message>
-        <location filename="../qml/MenuItemStates.qml" line="106"/>
+        <location filename="../qml/MenuItemStates.qml" line="122"/>
         <source>Export failed</source>
         <translation>ចំណាយចេញបានលាយលង្កា</translation>
     </message>
@@ -1294,7 +1327,7 @@
 <context>
     <name>PathManager</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="1073"/>
+        <location filename="../src/albumControl.cpp" line="1098"/>
         <source>System Disk</source>
         <translation>រាល់កាន់ទូរទឹក</translation>
     </message>
@@ -1303,6 +1336,7 @@
     <name>PropertyActionItemDelegate</name>
     <message>
         <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
+        <location filename="../qml/PreviewImageViewer/InformationDialog/PropertyActionItemDelegate.qml" line="95"/>
         <source>The file already exists, please use another name</source>
         <translation>ឯកសារនេះទាន់មានរួចទុកឈ្មោះថ្មើង</translation>
     </message>
@@ -1310,42 +1344,50 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/albumControl.cpp" line="614"/>
+        <location filename="../src/albumControl.cpp" line="635"/>
+        <location filename="../src/albumControl.cpp" line="684"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>&apos;%1/%2/%3 %4:%5&apos;</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="645"/>
+        <location filename="../src/albumControl.cpp" line="666"/>
         <source>%1</source>
         <translation>&apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="651"/>
+        <location filename="../src/albumControl.cpp" line="672"/>
         <source>%1/%2</source>
         <translation>&apos;%1/%2&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="275"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="289"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
+        <location filename="../src/albumControl.cpp" line="678"/>
         <source>%1/%2/%3</source>
         <translation>&apos;%1/%2/%3&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="343"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="361"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="368"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="397"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="404"/>
         <source>All</source>
         <translation>ទាំងអស់</translation>
     </message>
     <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="359"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="376"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="412"/>
         <source>Photos</source>
         <translation>រូបថត</translation>
     </message>
     <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="366"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="383"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="419"/>
         <source>Videos</source>
         <translation>វិdeo</translation>
     </message>
     <message>
-        <location filename="../src/albumControl.cpp" line="1330"/>
+        <location filename="../src/albumControl.cpp" line="1355"/>
         <source>Trash</source>
         <translation>គ្រូងស្លាប់</translation>
     </message>
@@ -1366,27 +1408,36 @@
         <translation>ມືໜຶ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="303"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
         <source>Imported on</source>
         <translation>ນີ້ມື འຮືག རູກ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="303"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="322"/>
         <source> %1-%2-%3 %4</source>
         <translation> %1-%2-%3 %4</translation>
     </message>
     <message>
-        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="306"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
         <source>Imported on </source>
         <translation>ນີ້ມື འຮືག རູກ </translation>
     </message>
     <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="227"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="236"/>
+        <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="48"/>
+        <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="164"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2106"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="440"/>
         <source>Select</source>
         <translation>ເລັ໡</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1326"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
         <source>Unselect</source>
         <translation>ບໍ່ເລັ໡</translation>
     </message>
@@ -1437,59 +1488,140 @@
         <translation>%1 རູກ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="120"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="123"/>
         <source>Trash</source>
         <translation>င་ဝ་</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="141"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="144"/>
         <source>The files will be permanently deleted after the days shown on them</source>
         <translation>ໄຟລ໌ຈະຖືກລຶບຖາວອນຫຼັງຈາກຈຳນວນມື້ທີ່ສະແດງຢູ່ເທິງພວກມັນ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="156"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="159"/>
         <source>Delete All</source>
         <translation>ລຶບທັງໝົດ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="196"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="199"/>
         <source>Delete Selected (%1)</source>
         <translation>ລຶບລາຍການທີ່ເລືອກ (%1)</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="216"/>
+        <location filename="../qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml" line="219"/>
         <source>Restore Selected (%1)</source>
         <translation>ກູ້ຄືນລາຍການທີ່ເລືອກ (%1)</translation>
     </message>
+    <message>
+        <source>%1 videos found</source>
+        <translation type="vanished">%1 видео найдено</translation>
+    </message>
+    <message>
+        <source>%1 items found</source>
+        <translation type="vanished">%1 элементов найдено</translation>
+    </message>
+    <message>
+        <source>Search results</source>
+        <translation type="vanished">Результати пошуку</translation>
+    </message>
+    <message>
+        <source>Slide Show</source>
+        <translation type="vanished">Слайд-шоу</translation>
+    </message>
+    <message>
+        <source>No search results</source>
+        <translation type="vanished">Нічого не знайдено</translation>
+    </message>
+</context>
+<context>
+    <name>RemoveAlbumDialog</name>
+    <message>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="42"/>
+        <source>Are you sure you want to delete this album?</source>
+        <translation>ທ່ານແນ່ໃຈບໍ່ວ່າຈະລຶບອັລບັ້ມນີ້?</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="55"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../qml/Control/RemoveAlbumDialog.qml" line="72"/>
+        <source>Delete</source>
+        <translation>ລຶບ</translation>
+    </message>
+</context>
+<context>
+    <name>RemoveDialog</name>
+    <message>
+        <location filename="../qml/PreviewImageViewer/Dialog/RemoveDialog.qml" line="66"/>
+        <source>Cannot move &quot;%1&quot; to the trash. Do you want to permanently delete it?</source>
+        <translation>ບໍ່ສາມາດຍ້າຍ &quot;%1&quot; ໄປຖັງຂີ້ເຫຍື້ອໄດ້. ທ່ານຕ້ອງການລຶບມັນຖາວອນບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/Dialog/RemoveDialog.qml" line="84"/>
+        <source>This action cannot be undone</source>
+        <translation>ການກະທຳນີ້ບໍ່ສາມາດກູ້ຄືນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/Dialog/RemoveDialog.qml" line="96"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../qml/PreviewImageViewer/Dialog/RemoveDialog.qml" line="106"/>
+        <source>Confirm</source>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+</context>
+<context>
+    <name>SearchView</name>
+    <message>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="51"/>
+        <source>1 photo found</source>
+        <translation>ພົບຮູບພາບ 1 ຮູບ</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="53"/>
+        <source>%1 photos found</source>
+        <translation>ພົບຮູບພາບ %1 ຮູບ</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="57"/>
+        <source>1 video found</source>
+        <translation>ພົບວິດີໂອ 1 ລາຍການ</translation>
+    </message>
+    <message>
         <location filename="../qml/ThumbnailImageView/SearchView.qml" line="59"/>
         <source>%1 videos found</source>
-        <translation>%1 видео найдено</translation>
+        <translation>ພົບວິດີໂອ %1 ລາຍການ</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/SearchView.qml" line="64"/>
         <source>%1 items found</source>
-        <translation>%1 элементов найдено</translation>
+        <translation>ພົບ %1 ລາຍການ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="96"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="99"/>
         <source>Search results</source>
-        <translation>Результати пошуку</translation>
+        <translation>ຜົນການຄົ້ນຫາ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="109"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="112"/>
         <source>Slide Show</source>
-        <translation>Слайд-шоу</translation>
+        <translation>ສະແດງຮູບພາບຕໍ່ເນື່ອງ</translation>
     </message>
     <message>
-        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="186"/>
+        <location filename="../qml/ThumbnailImageView/SearchView.qml" line="189"/>
         <source>No search results</source>
-        <translation>Нічого не знайдено</translation>
+        <translation>ບໍ່ພົບຜົນການຄົ້ນຫາ</translation>
     </message>
 </context>
 <context>
     <name>Sidebar</name>
     <message>
         <location filename="../qml/SideBar/Sidebar.qml" line="127"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="151"/>
         <source>Album “%1” removed</source>
         <translation>Альбом «%1» видалений</translation>
     </message>
@@ -1550,16 +1682,21 @@
     </message>
     <message>
         <location filename="../qml/SideBar/Sidebar.qml" line="455"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="480"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Slide show</source>
         <translation>ภาพลื่น</translation>
     </message>
     <message>
         <location filename="../qml/SideBar/Sidebar.qml" line="466"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="492"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="567"/>
         <source>Export</source>
         <translation>ส่งออก</translation>
     </message>
     <message>
         <location filename="../qml/SideBar/Sidebar.qml" line="500"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="576"/>
         <source>Delete</source>
         <translation>ลบ</translation>
     </message>
@@ -1583,11 +1720,13 @@
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="181"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="232"/>
         <source>Pause</source>
         <translation>หยุด</translation>
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="181"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="232"/>
         <source>Play</source>
         <translation>เล่น</translation>
     </message>
@@ -1598,6 +1737,7 @@
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="253"/>
         <source>Exit</source>
         <translation>ออก</translation>
     </message>
@@ -1619,6 +1759,14 @@
     <name>ThumbnailListView</name>
     <message>
         <location filename="../qml/PreviewImageViewer/ThumbnailListView.qml" line="610"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="762"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="764"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="804"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="807"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="809"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="819"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="948"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="965"/>
         <source>Delete</source>
         <translation>លើងយក</translation>
     </message>
@@ -1654,11 +1802,23 @@
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/ThumbnailListView.qml" line="335"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="772"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="776"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="828"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="836"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="838"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="969"/>
         <source>Favorite</source>
         <translation>ស្វែងយកជាទូទៅ</translation>
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/ThumbnailListView.qml" line="335"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="773"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="775"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="830"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="835"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="839"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="970"/>
         <source>Unfavorite</source>
         <translation>បំបាកស្វែងយកជាទូទៅ</translation>
     </message>
@@ -1673,82 +1833,139 @@
         <translation>ថ្ងៃ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="699"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="723"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="726"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="730"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="782"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="868"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="876"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="882"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="950"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="979"/>
         <source>Photo info</source>
         <translation>ពិន្ឌៅថ្មូង</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="700"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="724"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="727"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="731"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="783"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="869"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="872"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="883"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="951"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="980"/>
         <source>Video info</source>
         <translation>វីដេអូព័ត៌មាន</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="721"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="746"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="798"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="931"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="957"/>
         <source>View</source>
         <translation>មើល</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="722"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="747"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="799"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="870"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="877"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="958"/>
         <source>Fullscreen</source>
         <translation>ពេញ화ុយស្រាប់</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="723"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="748"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="874"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="888"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="897"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="960"/>
         <source>Slide show</source>
         <translation>ស្តាកស្តាញ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="724"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="749"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="754"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="817"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="875"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="889"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="962"/>
         <source>Export</source>
         <translation>ចាក់ចេញ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="734"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="759"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="963"/>
         <source>Copy</source>
         <translation>ចិត្បារបស់</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="742"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="767"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="844"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="966"/>
         <source>Remove from album</source>
         <translation>ចែកចេញពីបញ្ចាំងរូបភាព</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="744"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="769"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="873"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="887"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="959"/>
         <source>Print</source>
         <translation>រុញ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="754"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="779"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="859"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="862"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="903"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="906"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="973"/>
         <source>Rotate clockwise</source>
         <translation>បង្វើលិចជំរុង</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="755"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="780"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="860"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="863"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="904"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="907"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="974"/>
         <source>Rotate counterclockwise</source>
         <translation>បង្វើលិចប្រឆាំង</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="756"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="781"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="881"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="978"/>
         <source>Display in file manager</source>
         <translation>បង្ហាញនៅក្នុងឧបកម្មគ្រប់គ្រងឯកសារ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="759"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="784"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="790"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="791"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="878"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="914"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="916"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="919"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="977"/>
         <source>Set as wallpaper</source>
         <translation>កំណត់ជាបំពូលរូបភាព</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="927"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="949"/>
         <source>Restore</source>
         <translation>ចំណុចសន្ធិសញ្ញា</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="964"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="986"/>
         <source>Add to album</source>
         <translation>បញ្ចូរទៅក្នុងបញ្ចាំងរូបភាព</translation>
     </message>
     <message>
-        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="968"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="990"/>
         <source>New album</source>
         <translation>បញ្ចាំងរូបភាពថ្មី</translation>
     </message>
@@ -1859,29 +2076,38 @@
 <context>
     <name>TimeLineView</name>
     <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="289"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="304"/>
         <source>1 photo</source>
         <translation>1 រូប</translation>
     </message>
     <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="291"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="306"/>
         <source>1 video</source>
         <translation>1 វីដេអូ</translation>
     </message>
-    <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="293"/>
+    <message numerus="yes">
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
-        <translation>%n រូប</translation>
+        <translation type="unfinished">
+            <numerusform>%n រូប</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="295"/>
+    <message numerus="yes">
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
-        <translation>%n វីដេអូ</translation>
+        <translation type="unfinished">
+            <numerusform>%n វីដេអូ</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
-        <location filename="../src/widgets/timelineview/timelineview.cpp" line="297"/>
+    <message numerus="yes">
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
-        <translation>%n ធាតុ</translation>
+        <translation type="unfinished">
+            <numerusform>%n ធាតុ</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -1981,6 +2207,7 @@
     </message>
     <message>
         <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="170"/>
         <source>Video CodecID</source>
         <translation>IDកម្រិតវិдеអីវី</translation>
     </message>
@@ -2095,7 +2322,7 @@
     <message>
         <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="267"/>
         <source>Rotate counterclockwise</source>
-        <translation type="unfinished"></translation>
+        <translation>ຊັກຍານາດຊັກຍານາດ</translation>
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/ViewRightMenu.qml" line="297"/>


### PR DESCRIPTION
log:

## Summary by Sourcery

Correct and enhance Lao (lo) locale translations by fixing existing string errors, adding missing entries for new dialogs and search view, marking outdated entries as vanished, and bumping the application version to 6.0.39.1.

New Features:
- Add Lao translations for RemoveAlbumDialog, RemoveDialog, and SearchView UI components

Bug Fixes:
- Fix incorrect Lao translations and placeholder formatting across various contexts (albumControl, fileControl, DBManager, timeline and thumbnail views)
- Mark obsolete translations as vanished to remove outdated entries

Enhancements:
- Update translation source locations in albumControl, fileControl, and QML files to match recent code changes
- Add missing numerus (plural) translation entries for photos, videos, and items counts

Build:
- Bump package version to 6.0.39.1 in linglong.yaml files