### PR TITLE
chore: Update version to 6.0.42

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.41.1
+  version: 6.0.42.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.42) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Wed, 13 Aug 2025 11:39:40 +0800
+
 deepin-album (6.0.41) unstable; urgency=medium
 
   * chore: Update .gitignore and clean up Lao translations

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.41.1
+  version: 6.0.42.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.41.1
+  version: 6.0.42.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
as title

Log: Update version to 6.0.42

## Summary by Sourcery

Bump deepin-album package version to 6.0.42.1 across all architectures and update changelog.

Chores:
- Update version field from 6.0.41.1 to 6.0.42.1 in arm64, amd64, and loong64 linglong.yaml files
- Refresh associated source file digests to match the new version
- Add new entry to debian changelog for version 6.0.42