### PR TITLE
fix: Fixed CMYK image display issue Fixed CMYK image display issue

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.43.1
+  version: 6.0.44.1
   kind: app
   description: |
     album for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.44) unstable; urgency=medium
+
+  * fix: Fixed CMYK image display issue Fixed CMYK image display issue
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Fri, 15 Aug 2025 10:04:43 +0800
+
 deepin-album (6.0.43) unstable; urgency=medium
 
   * fix: Add Lao translations to deepin-album.desktop

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.43.1
+  version: 6.0.44.1
   kind: app
   description: |
     album for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.43.1
+  version: 6.0.44.1
   kind: app
   description: |
     album for deepin os.

--- a/src/src/unionimage/unionimage.cpp
+++ b/src/src/unionimage/unionimage.cpp
@@ -19,6 +19,10 @@
 #include <QtSvg/QSvgRenderer>
 #include <QDir>
 #include <QDebug>
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QColorSpace>
+#endif
 
 #include "unionimage/imageutils.h"
 
@@ -28,6 +32,92 @@
 
 const QString DATETIME_FORMAT_NORMAL = "yyyy.MM.dd";
 const QString DATETIME_FORMAT_EXIF = "yyyy:MM:dd HH:mm";
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+/**
+   @brief 转换图片颜色空间到sRGB，解决CMYK等颜色空间图片显示颜色不正确的问题
+   @param image 原始图片
+   @return 转换后的图片，如果不需要转换或转换失败则返回原图
+   @note 此功能仅在Qt6中可用
+ */
+static QImage convertToSRgbColorSpace(const QImage &image)
+{
+    if (image.isNull()) {
+        return image;
+    }
+
+    QColorSpace srgbColorSpace = QColorSpace::SRgb;
+
+    bool needsConversion = false;
+    if (image.colorSpace().isValid()) {
+        qDebug() << "Image has color space:" << image.colorSpace().description();
+
+        if (image.colorSpace() != srgbColorSpace) {
+            needsConversion = true;
+            qDebug() << "Converting color space from" << image.colorSpace().description()
+                                    << "to sRGB";
+        }
+    } else {
+        qDebug() << "Image has no valid color space, checking format for potential CMYK";
+        if (image.format() == QImage::Format_CMYK8888) {
+            needsConversion = true;
+            qDebug() << "CMYK format detected, attempting conversion";
+        }
+    }
+
+    if (!needsConversion) {
+        qDebug() << "No color space conversion needed";
+        return image;
+    }
+
+    QImage convertedImage = QImage();
+
+    try {
+        convertedImage = image.convertedToColorSpace(srgbColorSpace);
+        if (!convertedImage.isNull()) {
+            qDebug() << "Color space conversion method 1 (convertedToColorSpace) succeeded";
+        } else {
+            qDebug() << "Color space conversion method 1 failed";
+        }
+    } catch (...) {
+        qDebug() << "Color space conversion method 1 threw exception";
+    }
+
+    if (convertedImage.isNull()) {
+        qDebug() << "Trying color space conversion method 2: manual color space setting";
+
+        convertedImage = image.copy();
+        convertedImage.setColorSpace(srgbColorSpace);
+
+        if (convertedImage.format() != QImage::Format_RGB888 &&
+            convertedImage.format() != QImage::Format_ARGB32 &&
+            convertedImage.format() != QImage::Format_ARGB32_Premultiplied) {
+            convertedImage = convertedImage.convertToFormat(QImage::Format_RGB888);
+        }
+
+        if (!convertedImage.isNull()) {
+            qDebug() << "Color space conversion method 2 succeeded";
+        }
+    }
+
+    if (convertedImage.isNull()) {
+        qDebug() << "Trying color space conversion method 3: basic format conversion";
+        convertedImage = image.convertToFormat(QImage::Format_RGB888);
+        convertedImage.setColorSpace(srgbColorSpace);
+
+        if (!convertedImage.isNull()) {
+            qDebug() << "Color space conversion method 3 succeeded";
+        }
+    }
+
+    if (convertedImage.isNull()) {
+        qWarning() << "All color space conversion methods failed, returning original image";
+        return image;
+    }
+
+    return convertedImage;
+}
+#endif
 
 namespace LibUnionImage_NameSpace {
 
@@ -330,11 +420,21 @@ UNIONIMAGESHARED_EXPORT bool loadStaticImageFromFile(const QString &path, QImage
                     return false;
                 }
                 errorMsg = "use old method to load QImage";
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                // 应用颜色空间转换，解决CMYK等格式的颜色显示问题 (仅Qt6)
+                res = convertToSRgbColorSpace(try_res);
+#else
                 res = try_res;
+#endif
                 return true;
             }
             errorMsg = "use QImage";
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            // 应用颜色空间转换，解决CMYK等格式的颜色显示问题 (仅Qt6)
+            res = convertToSRgbColorSpace(res_qt);
+#else
             res = res_qt;
+#endif
         } else {
             qWarning() << "No images found in file:" << path;
             res = QImage();


### PR DESCRIPTION
Log: Fixed CMYK image display issue
bug: https://pms.uniontech.com/bug-view-326991.html

## Summary by Sourcery

Fix CMYK image display by converting loaded images to sRGB under Qt6

Bug Fixes:
- Convert CMYK and other non-sRGB images to sRGB color space when loading under Qt6 to ensure correct display

Enhancements:
- Add convertToSRgbColorSpace helper with three fallback methods for robust color space conversion in Qt6