### PR TITLE
fix: The position of the right-click menu was abnormal.

### DIFF
--- a/src/album/albumview/leftlistview.cpp
+++ b/src/album/albumview/leftlistview.cpp
@@ -361,7 +361,8 @@ void LeftListView::showMenu(const QPoint &pos)
         m_pCustomizeListView->setCurrentIndex(m_pCustomizeListView->indexAt(pos));
         emit m_pCustomizeListView->pressed(m_pCustomizeListView->indexAt(pos));
     }
-    m_pMenu->setVisible(true);
+    // popup之前不应该setVisible，不然在wayland设备上位置会出错
+    //m_pMenu->setVisible(true);
     foreach (QAction *action, m_MenuActionMap.values()) {
         action->setVisible(true);
         action->setEnabled(true);
@@ -398,6 +399,7 @@ void LeftListView::showMenu(const QPoint &pos)
 
     //菜单里面可能没有内容，强行显示出来会造成BUG
     if (needShowMenu) {
+        qDebug() << "Menu popup at cursor pos:" << QCursor::pos();
         m_pMenu->popup(QCursor::pos());
     } else {
         m_pMenu->setVisible(false);


### PR DESCRIPTION
The menu incorrectly called `setVisible(true)` before `popup()`, which caused positioning issues on Wayland devices. This has now been corrected.

fix: 右键菜单位置异常

menu在popup()之前错误调用了setVisible(true)，导致wayland设备上位置异常，现在纠正过来。

Bug: https://pms.uniontech.com/bug-view-329959.html

## Summary by Sourcery

Fix abnormal context menu positioning on Wayland by removing the premature visibility call before popup and adding a debug log for cursor position

Bug Fixes:
- Remove premature setVisible(true) call before popup to fix context menu positioning on Wayland devices

Enhancements:
- Add debug logging for menu popup cursor position