### PR TITLE
fix: The right-click menu for the album fails to appear.

### DIFF
--- a/src/qml/SideBar/SideBarItemDelegate.qml
+++ b/src/qml/SideBar/SideBarItemDelegate.qml
@@ -155,10 +155,10 @@ ItemDelegate {
         songName.visible = true;
         siderIcon.visible = true;
         keyLineEdit.visible = false;
-        if (keyLineEdit.text !== "" && albumControl.renameAlbum(albumControl.getAllCustomAlbumId()[index], keyLineEdit.text)) {
+        if (keyLineEdit.text !== "" && albumControl.renameAlbum(model.uuid, keyLineEdit.text)) {
             songName.text = keyLineEdit.text
 
-            // 通知自定义相册视图刷新相册名称
+            // 通知相册视图刷新相册名称（包括系统相册和自定义相册）
             GStatus.sigCustomAlbumNameChaged(GStatus.currentCustomAlbumUId, songName.text)
         }
     }

--- a/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
+++ b/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
@@ -219,12 +219,13 @@ BaseView {
         text: qsTr("No results")
     }
 
-    // 1.自定义相册，若没有数据，显示导入图片视图
-    // 2.自动导入相册，无内容时，显示没有图片或视频时显示
+    // 自定义/系统自动导入/普通自动导入相册无内容时，显示导入图片视图
     NoPictureView {
         visible: numLabelText === ""  && filterType === 0
-        bShowImportBtn: isCustom
-        iconName: isCustom ? "nopicture1" : (GStatus.currentViewType === Album.Types.ViewCustomAlbum ? "nopicture2" : "nopicture3")
+        bShowImportBtn: isCustom || isSystemAutoImport || isNormalAutoImport
+        iconName: (isCustom || isSystemAutoImport || isNormalAutoImport)
+                  ? "nopicture1"
+                  : (GStatus.currentViewType === Album.Types.ViewCustomAlbum ? "nopicture2" : "nopicture3")
     }
 
     NumberAnimation {

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -2180,9 +2180,17 @@ void AlbumControl::updateInfoPath(const QString &oldPath, const QString &newPath
 bool AlbumControl::renameAlbum(int UID, const QString &newName)
 {
     qDebug() << "AlbumControl::renameAlbum - Function entry, UID:" << UID << "newName:" << newName;
-    DBManager::instance()->renameAlbum(UID, newName);
-    qDebug() << "AlbumControl::renameAlbum - Function exit, returning: true";
-    return true;
+    // 根据 UID 推断相册类型
+    AlbumDBType atype = AlbumDBType::Custom;
+    if (UID == 0) {
+        atype = AlbumDBType::Favourite;
+    } else if (isAutoImportAlbum(UID)) {
+        atype = AlbumDBType::AutoImport;
+    }
+
+    bool ok = DBManager::instance()->renameAlbum(UID, newName, atype);
+    qDebug() << "AlbumControl::renameAlbum - Function exit, returning:" << ok;
+    return ok;
 }
 
 QVariant AlbumControl::searchPicFromAlbum(int UID, const QString &keywords, bool useAI)


### PR DESCRIPTION
log: Design Issues

bug: https://pms.uniontech.com/bug-view-337467.html

## Summary by Sourcery

Fix system album sidebar context menu behavior and extend system album management capabilities.

Bug Fixes:
- Ensure the system album right-click menu appears even when the album has no content, with actions disabled as appropriate.
- Correct album renaming to work for all album types, including system and auto-import albums, and refresh their names in the view.

Enhancements:
- Allow renaming and deletion of system albums from the sidebar context menu while keeping underlying files intact.
- Track and manage the currently selected system album in the sidebar to keep selection consistent after deletions.
- Show the import prompt for empty system and auto-import albums, aligning the empty-state experience with custom albums.