### PR TITLE
chore: Bump version to 6.0.51

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.51) unstable; urgency=medium
+
+  * chore: Unify linglong.yaml
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 05 Mar 2026 19:22:22 +0800
+
 deepin-album (6.0.50) unstable; urgency=medium
 
   * chore: Update compiler flags for security enhancements

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.50.1
+  version: 6.0.51.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
As title.

Log: Bump version to 6.0.51

## Summary by Sourcery

Build:
- Update linglong package manifest to reference version 6.0.51.1.