### PR TITLE
fix: connect delete signal for imported images deletion

### DIFF
--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -128,6 +128,8 @@ BaseView {
     }
 
     function runDeleteImg() {
+        if (!visible)
+            return
         menuItemStates.executeDelete()
         getNumLabelText()
     }
@@ -223,6 +225,13 @@ BaseView {
         to: 0
         duration: GStatus.sidebarAnimationEnabled ? GStatus.animationDuration : 0
         easing.type: Easing.OutExpo
+    }
+
+    Connections {
+        target: deleteDialog
+        function onSigDoDeleteImg() {
+            runDeleteImg()
+        }
     }
 
     Component.onCompleted: {


### PR DESCRIPTION
Connect deleteDialog.sigDoDeleteImg signal in Component.onCompleted and add visibility check in runDeleteImg to handle both title bar and context menu delete actions.

修复已导入视图中图片无法删除的问题，在Component.onCompleted中
永久连接删除信号，并在runDeleteImg中添加可见性检查。

Log: 修复已导入视图图片删除无效的问题
PMS: BUG-355723
Influence: 已导入视图的右键菜单删除和标题栏删除按钮均可正常工作，
删除后图片移入最近删除。

## Summary by Sourcery

Bug Fixes:
- Ensure image deletion actions work correctly in the imported images view from both the title bar button and context menu.