### PR TITLE
fix: hide filter button when no photos or videos exist

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,6 +23,7 @@ SwitchViewAnimation {
     property string selectedText: getSelectedNum(selectedPaths)
     property alias count: theView.count
     property var selectedPaths: GStatus.selectedPaths
+    property int totalItemCount: 0
 
     function setDateRange(str) {
         dateRangeLabel.text = str
@@ -77,6 +78,7 @@ SwitchViewAnimation {
 
         var videoCountText = ""
         var videoCount = albumControl.getAllCount(2)
+        totalItemCount = photoCount + videoCount
         if(videoCount === 0) {
             videoCountText = ""
         } else if(videoCount === 1) {
@@ -138,7 +140,7 @@ SwitchViewAnimation {
             }
             width: 115
             height: 30
-            visible: parent.visible && albumControl.getAllCount() !== 0
+            visible: parent.visible && totalItemCount > 0
         }
 
         MouseArea {
@@ -175,7 +177,7 @@ SwitchViewAnimation {
             right: parent.right
             centerIn: parent
         }
-        visible: numLabelText === "" && albumControl.getAllCount() !== 0
+        visible: numLabelText === "" && totalItemCount > 0
         font: DTK.fontManager.t4
         color: Qt.rgba(85/255, 85/255, 85/255, 0.4)
         text: qsTr("No results")

--- a/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
+++ b/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -91,6 +91,7 @@ BaseView {
 
         var videoCountText = ""
         var videoCount = albumControl.getCustomAlbumInfoConut(customAlbumUId, 2)
+        totalPictrueAndVideos = photoCount + videoCount
         if(videoCount === 0) {
             videoCountText = ""
         } else if(videoCount === 1) {
@@ -165,6 +166,7 @@ BaseView {
             }
             width: 115
             height: 30
+            visible: totalPictrueAndVideos > 0
         }
 
         MouseArea {

--- a/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
+++ b/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -183,7 +183,7 @@ BaseView {
             }
             width: 115
             height: 30
-            visible: (!theView.haveSelect && totalCount > 0) || totalCount === 0
+            visible: !theView.haveSelect && totalCount > 0
         }
 
         WarningButton {

--- a/src/src/widgets/importtimelineview/importtimelineview.cpp
+++ b/src/src/widgets/importtimelineview/importtimelineview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -170,6 +170,7 @@ void ImportTimeLineView::sltCurrentFilterChanged(ExpansionPanel::FilteData &data
     //如果过滤会后数量<=0，则不可用
     bool hasItems = m_importTimeLineListView->getAppointTypeItemCount(m_ToolButton->getFilteType()) > 0;
     m_ToolButton->setEnabled(hasItems);
+    m_ToolButton->setVisible(hasItems);
     qDebug() << "Filter applied, items available:" << hasItems;
     m_importTimeLineListView->setFocus();
 }

--- a/src/src/widgets/timelineview/timelineview.cpp
+++ b/src/src/widgets/timelineview/timelineview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -265,7 +265,9 @@ void TimeLineView::sltCurrentFilterChanged(ExpansionPanel::FilteData &data)
     }
     clearAllSelection();
     //如果过滤会后数量<=0，则不可用
-    m_ToolButton->setEnabled(m_timeLineThumbnailListView->getAppointTypeItemCount(m_ToolButton->getFilteType()) > 0);
+    bool hasItems = m_timeLineThumbnailListView->getAppointTypeItemCount(m_ToolButton->getFilteType()) > 0;
+    m_ToolButton->setEnabled(hasItems);
+    m_ToolButton->setVisible(hasItems);
     m_timeLineThumbnailListView->setFocus();
     qDebug() << "Filter changed to type - Exit";
 }


### PR DESCRIPTION
Hide the filter combo box in toolbar when album is empty across all views. Use QML properties to track item counts instead of Q_INVOKABLE calls which do not trigger binding re-evaluation after data changes.

合集、已导入、最近删除、我的收藏、相册视图在无照片和视频时隐藏筛选按钮，
通过QML属性跟踪数量避免Q_INVOKABLE调用不触发绑定刷新的问题。

Log: 无照片视频时隐藏筛选按钮
PMS: BUG-351655
Influence: 所有视图（合集、已导入、最近删除、我的收藏、相册）在内容为空时不再显示筛选按钮，删除全部内容后筛选按钮会立即隐藏。

## Summary by Sourcery

Hide filter controls when albums or timelines contain no items, and base visibility on tracked item counts instead of ad-hoc count queries.

Bug Fixes:
- Ensure filter buttons in collection, custom album, recently deleted, and timeline views disappear when there are no photos or videos after filtering or deletion.

Enhancements:
- Track total item counts in QML via properties and reuse this state to drive filter and hint visibility instead of repeatedly querying counts from backend objects.