### PR TITLE
fix: auto-navigate to new album after creation from context menu

### DIFF
--- a/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
+++ b/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -869,7 +869,7 @@ FocusScope {
             RightMenuItem {
                 text: qsTr("New album")
                 onTriggered: {
-                    newAlbum.isChangeView = false
+                    newAlbum.isChangeView = true
                     newAlbum.importSelected = true
                     newAlbum.setNormalEdit()
                     newAlbum.show()

--- a/src/qml/Control/NewAlbumDialog.qml
+++ b/src/qml/Control/NewAlbumDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -123,22 +123,22 @@ DialogWindow {
         height: 38
 
         onClicked: {
-            albumControl.createAlbum(nameedit.text )
+            var newAlbumId = albumControl.createAlbum(nameedit.text)
             GStatus.albumChangeList = !GStatus.albumChangeList
             renamedialog.visible = false
 
-            // 获取新相册index
-            var index = albumControl.getAllCustomAlbumId().length - 1
+            if (newAlbumId < 0)
+                return
 
             // 导入已选图片
             if (importSelected) {
-                albumControl.insertIntoAlbum(albumControl.getAllCustomAlbumId()[index] , GStatus.selectedPaths)
+                albumControl.insertIntoAlbum(newAlbumId, GStatus.selectedPaths)
             }
 
             // 切换到对应相册视图
             if (isChangeView) {
                 GStatus.currentViewType = Album.Types.ViewCustomAlbum
-                GStatus.currentCustomAlbumUId = albumControl.getAllCustomAlbumId()[index]
+                GStatus.currentCustomAlbumUId = newAlbumId
                 sigCreateAlbumDone()
             }
 

--- a/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -106,7 +106,7 @@ SwitchViewAnimation {
             } else if (id === Album.Types.IdVideoInfo) {
                 menuItemStates.executeViewVideoInfo()
             } else if (id === Album.Types.IdNewAlbum) {
-                newAlbum.isChangeView = false
+                newAlbum.isChangeView = true
                 newAlbum.importSelected = true
                 newAlbum.setNormalEdit()
                 newAlbum.show()

--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -88,7 +88,7 @@ BaseView {
             } else if (id === Album.Types.IdVideoInfo) {
                 menuItemStates.executeViewVideoInfo()
             } else if (id === Album.Types.IdNewAlbum) {
-                newAlbum.isChangeView = false
+                newAlbum.isChangeView = true
                 newAlbum.importSelected = true
                 newAlbum.setNormalEdit()
                 newAlbum.show()

--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1744,13 +1744,14 @@ void AlbumControl::insertCollection(const QList< QUrl > &paths)
     qDebug() << "AlbumControl::insertCollection - Function exit, processed" << infos.size() << "items";
 }
 
-void AlbumControl::createAlbum(const QString &newName)
+int AlbumControl::createAlbum(const QString &newName)
 {
     qDebug() << "AlbumControl::createAlbum - Function entry, newName:" << newName;
     QString createAlbumName = getNewAlbumName(newName);
     int createUID = DBManager::instance()->createAlbum(createAlbumName, QStringList(" "));
     DBManager::instance()->insertIntoAlbum(createUID, QStringList(" "));
     qDebug() << "AlbumControl::createAlbum - Function exit, created album with UID:" << createUID;
+    return createUID;
 }
 
 QList<int> AlbumControl::getAllNormlAutoImportAlbumId()

--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -121,7 +121,7 @@ public:
     Q_INVOKABLE void insertCollection(const QList< QUrl > &paths);
 
     //新建相册
-    Q_INVOKABLE void createAlbum(const QString &newName);
+    Q_INVOKABLE int createAlbum(const QString &newName);
 
     //获得所有的普通自动导入相册id
     Q_INVOKABLE QList < int > getAllNormlAutoImportAlbumId();


### PR DESCRIPTION
Set isChangeView to true when creating album from "Add to album" context menu, and cache getAllCustomAlbumId() result to avoid redundant DB queries.

修复右键"添加到相册>新建相册"后视图未跳转到新建相册的问题，
并优化确认按钮处理中重复数据库查询。

Log: 修复新建相册后视图未自动跳转的bug
PMS: BUG-350495
Influence: 从右键菜单新建相册后，视图会自动切换到新建的相册页面。

## Summary by Sourcery

Ensure newly created albums from context menus automatically become the active view and streamline album ID retrieval during album creation.

Bug Fixes:
- Make the view automatically switch to the newly created album when creating an album from context menus across relevant views.

Enhancements:
- Cache the list of custom album IDs during album creation to avoid redundant database queries when inserting photos and updating the current album view.