### PR TITLE
fix(import): remove DB record when importing empty folder

### DIFF
--- a/src/src/imageengine/imageenginethread.cpp
+++ b/src/src/imageengine/imageenginethread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -181,6 +181,11 @@ void ImportImagesThread::runDetail()
         // 存在无法导入
         int skiped = tempPaths.size() - noReadCount;
         qWarning() << "No valid files to import, skipped:" << skiped;
+        // 防止空文件夹导入后重启仍显示空相册
+        if (m_UID >= DBManager::u_CustomStart) {
+            qDebug() << "Removing empty custom auto-import album, UID:" << m_UID;
+            DBManager::instance()->removeCustomAutoImportPath(m_UID);
+        }
         emit sigImportFailed(skiped);
         return;
     }


### PR DESCRIPTION
Clean up custom auto-import album entry in the import thread when no valid files are found, preventing it from reappearing after restart.

导入空文件夹失败时清理数据库记录，避免重启后出现空相册。

Log: 修复导入空文件夹后重启出现空相册的问题
PMS: BUG-350493
Influence: 导入空文件夹或无可导入文件的文件夹时，不再残留数据库记录，重启后行为一致。

## Summary by Sourcery

Clean up import handling so that database entries for custom auto-import albums are removed when importing from a folder with no valid files, preventing empty albums from persisting after restart.

Bug Fixes:
- Delete the custom auto-import album database record when an import finds no valid files, avoiding empty albums reappearing after application restart.

Enhancements:
- Update source file copyright metadata to cover years 2023–2026.