### PR TITLE
fix(viewer): handle fullscreen exit correctly when viewing images

### DIFF
--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -2424,9 +2424,12 @@ void MainWindow::onAddImageBtnClicked(bool checked)
 
 void MainWindow::onHideFromFullScreen()
 {
-    setTitleBarHideden(false);
-
-    m_pCenterWidget->setCurrentIndex(m_backIndex);
+    if (m_backIndex_fromFullScreen == VIEW_IMAGE) {
+        m_pCenterWidget->setCurrentIndex(VIEW_IMAGE);
+    } else {
+        setTitleBarHideden(false);
+        m_pCenterWidget->setCurrentIndex(m_backIndex);
+    }
 }
 
 void MainWindow::onExportImage(QStringList paths)


### PR DESCRIPTION
Fix the issue where exiting fullscreen after double-clicking on an image would incorrectly return to the album interface instead of staying in image viewer.

修复图片查看时双击全屏再退出全屏会异常返回到相册界面的问题。

Log: 修复图片查看全屏退出后异常返回的bug
PMS: BUG-355851
Influence: 修复后在图片查看界面双击全屏再退出全屏时，会正确停留在图片查看界面，不会异常返回到相册界面。