### PR TITLE
chore: update version to 6.0.52

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-album (6.0.52) unstable; urgency=medium
+
+  * fix(import): remove DB record when importing empty folder
+  * fix: auto-navigate to new album after creation from context menu
+  * fix: hide filter button when no photos or videos exist
+  * fix: connect delete signal for imported images deletion
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 16 Apr 2026 20:40:38 +0800
+
 deepin-album (6.0.51) unstable; urgency=medium
 
   * chore: Unify linglong.yaml

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.51.1
+  version: 6.0.52.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
- bump version to 6.0.52

Log : bump version to 6.0.52

## Summary by Sourcery

Chores:
- Update application package version in linglong configuration to 6.0.52.1.