### PR TITLE
fix(slideshow): disable prev/next buttons for single image slideshow

### DIFF
--- a/src/qml/PreviewImageViewer/SliderShow.qml
+++ b/src/qml/PreviewImageViewer/SliderShow.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -67,7 +67,13 @@ Item {
         repeat: true
         running: autoRun
 
-        onTriggered: switchNextImage()
+        onTriggered: {
+            if (GControl.hasMultipleImages) {
+                switchNextImage();
+            } else {
+                fadeInOutImage.restart();
+            }
+        }
     }
 
     SFadeInOut {
@@ -164,6 +170,7 @@ Item {
                     ToolTip.text: qsTr("Previous")
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
+                    enabled: GControl.hasMultipleImages
                     height: parent.height
                     icon.name: "icon_previous"
                     width: 50
@@ -197,6 +204,7 @@ Item {
                     ToolTip.text: qsTr("Next")
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
+                    enabled: GControl.hasMultipleImages
                     height: parent.height
                     icon.name: "icon_next"
                     width: 50

--- a/src/src/globalcontrol.cpp
+++ b/src/src/globalcontrol.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -204,6 +204,14 @@ bool GlobalControl::hasNextImage() const
     return hasNext;
 }
 
+bool GlobalControl::hasMultipleImages() const
+{
+    if (imageCount() <= 1) {
+        return false;
+    }
+    return hasPrevious || hasNext;
+}
+
 /**
    @return 切换到前一张图片并返回是否切换成功
  */
@@ -346,6 +354,7 @@ void GlobalControl::setImageFiles(const QStringList &filePaths, const QString &o
 
     checkSwitchEnable();
     Q_EMIT imageCountChanged();
+    Q_EMIT hasMultipleImagesChanged();
 
     // 更新视图展示模型
     viewSourceModel->resetModel(index, 0);
@@ -492,6 +501,8 @@ void GlobalControl::checkSwitchEnable()
     bool previous = (curIndex > 0 || curFrameIndex > 0);
     bool next = (curIndex < (sourceModel->rowCount() - 1) || curFrameIndex < (currentImage.frameCount() - 1));
 
+    bool oldHasMultiple = hasMultipleImages();
+
     if (previous != hasPrevious) {
         qDebug() << "GlobalControl::checkSwitchEnable - Branch: previous != hasPrevious";
         hasPrevious = previous;
@@ -501,6 +512,10 @@ void GlobalControl::checkSwitchEnable()
         qDebug() << "GlobalControl::checkSwitchEnable - Branch: next != hasNext";
         hasNext = next;
         Q_EMIT hasNextImageChanged();
+    }
+
+    if (oldHasMultiple != hasMultipleImages()) {
+        Q_EMIT hasMultipleImagesChanged();
     }
     qDebug() << "GlobalControl::checkSwitchEnable - Function exit";
 }

--- a/src/src/globalcontrol.h
+++ b/src/src/globalcontrol.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,6 +26,7 @@ class GlobalControl : public QObject
     Q_PROPERTY(int currentRotation READ currentRotation WRITE setCurrentRotation NOTIFY currentRotationChanged)
     Q_PROPERTY(bool hasPreviousImage READ hasPreviousImage NOTIFY hasPreviousImageChanged)
     Q_PROPERTY(bool hasNextImage READ hasNextImage NOTIFY hasNextImageChanged)
+    Q_PROPERTY(bool hasMultipleImages READ hasMultipleImages NOTIFY hasMultipleImagesChanged)
 
 public:
     explicit GlobalControl(QObject *parent = nullptr);
@@ -65,6 +66,8 @@ public:
     Q_SIGNAL void hasPreviousImageChanged();
     bool hasNextImage() const;
     Q_SIGNAL void hasNextImageChanged();
+    bool hasMultipleImages() const;
+    Q_SIGNAL void hasMultipleImagesChanged();
     Q_INVOKABLE bool previousImage();
     Q_INVOKABLE bool nextImage();
     Q_INVOKABLE bool firstImage();


### PR DESCRIPTION
Disable previous and next buttons when only one image is present in slideshow mode. Trigger fade animation instead of image switching.

单张图片幻灯片播放时灰化上一张/下一张按钮，定时器触发淡入淡出动画。

Log: 单张图片幻灯片播放时灰化上/下一张按钮
PMS: BUG-350479
Influence: 单张图片幻灯片模式下上一张/下一张按钮不可用，播放暂停按钮和退出按钮正常。

## Summary by Sourcery

Bug Fixes:
- Disable previous/next buttons when only one image is available in slideshow mode to prevent ineffective navigation.