### PR TITLE
fix(preview): show navigation menu only when image is zoomed in

### DIFF
--- a/src/qml/PreviewImageViewer/ImageViewer.qml
+++ b/src/qml/PreviewImageViewer/ImageViewer.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -690,6 +690,15 @@ Item {
 
         // 导航窗口是否显示
         property bool expectShow: GStatus.enableNavigation && (null !== targetImage) && (targetImage.scale > 1)
+        // Whether navigation is available (image overflows viewport),
+        // falls back to matching conditions when Loader is inactive
+        readonly property bool imageNeedNavi: item
+            ? item.imageNeedNavi
+            : (null !== targetImage
+               && window.height > GStatus.minHideHeight
+               && window.width > GStatus.minWidth
+               && (targetImage.paintedWidth * targetImage.scale > window.width
+                   || targetImage.paintedHeight * targetImage.scale > window.height))
 
         height: 112
         width: 150

--- a/src/qml/PreviewImageViewer/ViewRightMenu.qml
+++ b/src/qml/PreviewImageViewer/ViewRightMenu.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,7 @@ Menu {
     property bool isNullImage: imageInfo.type === Album.Types.NullImage
     property bool readable: !isNullImage && FileControl.isCanReadable(imageSource)
     property bool renamable: !isNullImage && FileControl.isCanRename(imageSource)
+    readonly property bool navigationMenuVisible: !isNullImage && naviLoader.imageNeedNavi
     property bool rotatable: !isNullImage && FileControl.isRotatable(imageSource.toString())
     property bool supportOcr: !isNullImage && FileControl.isCanSupportOcr(imageSource)
     property bool supportWallpaper: !isNullImage && FileControl.isSupportSetWallpaper(imageSource)
@@ -295,7 +296,7 @@ Menu {
 
         enabled: visible && window.height > GStatus.minHideHeight && window.width > GStatus.minWidth
         text: !GStatus.enableNavigation ? qsTr("Show navigation window") : qsTr("Hide navigation window")
-        visible: !isNullImage
+        visible: navigationMenuVisible
 
         onTriggered: {
             if (!parent.enabled) {


### PR DESCRIPTION
Add scale > 1 condition to navigation window menu visibility check.

导航窗口菜单项仅在图片放大时显示，增加 scale > 1 条件判断。

Log: 导航窗口菜单仅在图片放大时显示
PMS: BUG-343603
Influence: 未放大的图片不再显示导航窗口选项，避免无意义的导航操作。

## Summary by Sourcery

Bug Fixes:
- Prevent the navigation window menu from appearing for non-zoomed or null images in the preview viewer.