### PR TITLE
chore: update version to 6.0.53

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-album (6.0.53) unstable; urgency=medium
+
+  * fix(preview): use scaled decoding to bypass unionimage 4096 limit
+  * fix(preview): show navigation menu only when image is zoomed in
+  * fix(slideshow): disable prev/next buttons for single image slideshow
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 23 Apr 2026 19:57:47 +0800
+
 deepin-album (6.0.52) unstable; urgency=medium
 
   * fix(import): remove DB record when importing empty folder

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.52.1
+  version: 6.0.53.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
- bump version to 6.0.53

Log : bump version to 6.0.53

## Summary by Sourcery

Chores:
- Update application version identifiers to 6.0.53.1 in packaging configuration.