### PR TITLE
fix: move menu separator above first custom album item

### DIFF
--- a/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
+++ b/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
@@ -876,9 +876,6 @@ FocusScope {
                 }
             }
 
-            MenuSeparator {
-            }
-
             Repeater {
                 id: recentFilesInstantiator
                 property bool bRreshEnableState: false
@@ -887,6 +884,13 @@ FocusScope {
                     albumControl.getAllCustomAlbumId().length
                 }
                 delegate: RightMenuItem {
+                    readonly property bool isFirstAlbum: index === 0
+                    height: {
+                        if (!visible)
+                            return 0
+                        return isFirstAlbum ? GStatus.rightMenuItemHeight + separatorLoader.height : GStatus.rightMenuItemHeight
+                    }
+                    topPadding: isFirstAlbum && separatorLoader.active ? separatorLoader.height : 0
                     text: {
                         GStatus.albumChangeList
                         return albumControl.getAllCustomAlbumName()[index]
@@ -901,6 +905,14 @@ FocusScope {
                         albumControl.insertIntoAlbum(customAlbumId , GStatus.selectedPaths)
                         DTK.sendMessage(thumbnailImage, qsTr("Successfully added to “%1”").arg(albumControl.getAllCustomAlbumName(GStatus.albumChangeList)[index]), "notify_checked")
                         recentFilesInstantiator.bRreshEnableState = !recentFilesInstantiator.bRreshEnableState
+                    }
+
+                    Loader {
+                        id: separatorLoader
+                        active: isFirstAlbum
+                        anchors.top: parent.top
+                        width: parent.width
+                        sourceComponent: MenuSeparator {}
                     }
                 }
             }


### PR DESCRIPTION
Move static MenuSeparator into first RightMenuItem delegate via Loader.

将固定的菜单分隔线移至第一个自定义相册项上方，使用 Loader 动态加载。

Log: 调整自定义相册菜单分隔线位置
PMS: BUG-323509
Influence: 自定义相册菜单分隔线仅在第一个相册项上方显示，改善菜单视觉布局。

## Summary by Sourcery

Adjust custom album context menu layout so the separator appears above the first custom album item instead of as a static entry.

Bug Fixes:
- Ensure the custom album menu separator is only shown above the first custom album item via a dynamically loaded separator.

Enhancements:
- Update custom album menu item height to account for the separator when present, improving visual alignment.