### PR TITLE
fix(sidebar): refresh album paths before showing context menu

### DIFF
--- a/src/qml/SideBar/Sidebar.qml
+++ b/src/qml/SideBar/Sidebar.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,7 +21,11 @@ ScrollView {
     property int currentImportCustomIndex: 0 //自动导入相册当前索引值
     property int currentCustomIndex: 0 //自定义相册当前索引值
     property var devicePaths : albumControl.getDevicePaths()
-    property var albumPaths : albumControl.getAlbumPaths(GStatus.currentCustomAlbumUId)
+    property var albumPaths: []
+
+    function updateAlbumPaths() {
+        albumPaths = albumControl.getAlbumPaths(GStatus.currentCustomAlbumUId)
+    }
     property var importAlbumNames : {
         GStatus.albumImportChangeList
         albumControl.getImportAlubumAllNames()
@@ -345,6 +349,7 @@ ScrollView {
             }
 
             onItemRightClicked: {
+                updateAlbumPaths()
                 if (sidebarScrollView.albumPaths.length > 0) {
                     systemMenu.popup()
                 }
@@ -402,6 +407,7 @@ ScrollView {
             }
 
             onItemRightClicked: {
+                updateAlbumPaths()
                 importMenu.popup()
             }
 
@@ -426,6 +432,7 @@ ScrollView {
             }
 
             onItemRightClicked: {
+                updateAlbumPaths()
                 customMenu.popup()
             }
 
@@ -444,6 +451,12 @@ ScrollView {
             if (devicePaths.length === 0 && GStatus.currentViewType === Album.Types.ViewDevice)
                 backCollection()
         }
+    }
+
+    Connections {
+        target: GStatus
+        function onCurrentCustomAlbumUIdChanged() { updateAlbumPaths() }
+        function onSigFlushCustomAlbumView() { updateAlbumPaths() }
     }
 
     // 通过自定义相册列表创建相册后，导航到新相册所在行


### PR DESCRIPTION
albumPaths binding only re-evaluates when currentCustomAlbumUId changes, but deleting images doesn't change the UID, leaving menu state stale.

删除相册内全部图片后，右键侧边栏相册条目仍显示"幻灯片"和"导出"菜单项，
因为 albumPaths 绑定未刷新。弹出菜单前强制重新获取路径列表。

Log: 修复删除图片后侧边栏右键菜单状态未更新
PMS: BUG-337467
Influence: 删除相册内所有图片后，右键侧边栏相册条目不再显示"幻灯片"和"导出"菜单项

## Summary by Sourcery

Bug Fixes:
- Ensure sidebar right-click context menus correctly reflect available actions after deleting all images from an album by refreshing album paths before menu display.