### PR TITLE
fix: disable filename editing and show original name in trash

### DIFF
--- a/src/qml/Control/VideoInfoDialog.qml
+++ b/src/qml/Control/VideoInfoDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -77,6 +77,7 @@ DialogWindow {
                     Layout.fillWidth: true
                     title: qsTr("File name")
                     description: fileName
+                    editable: !FileControl.isTrashPath(filePath)
                     iconName: "action_edit"
                     onClicked: {
 

--- a/src/qml/PreviewImageViewer/InformationDialog/InformationDialog.qml
+++ b/src/qml/PreviewImageViewer/InformationDialog/InformationDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -90,6 +90,7 @@ DialogWindow {
                     Layout.fillWidth: true
                     corners: RoundRectangle.TopCorner
                     description: fileName
+                    editable: !FileControl.isTrashPath(filePath)
                     iconName: "action_edit"
                     implicitWidth: propFullWidth
                     title: qsTr("File name")

--- a/src/qml/PreviewImageViewer/InformationDialog/PropertyActionItemDelegate.qml
+++ b/src/qml/PreviewImageViewer/InformationDialog/PropertyActionItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,7 +13,7 @@ Control {
 
     property Component action: ActionButton {
         Layout.alignment: Qt.AlignRight
-        visible: showPicLabel.visible
+        visible: showPicLabel.visible && control.editable
 
         onClicked: {
             dealShowPicLabelClick();
@@ -29,6 +29,8 @@ Control {
     property string description
     property int descriptionWidth: control.width - leftPadding - rightPadding - 20
     property string iconName
+    // 控制是否允许编辑，为 false 时隐藏编辑按钮且无法进入编辑模式
+    property bool editable: true
     property Palette infoTextColor: Palette {
         normal: Qt.rgba(0, 0, 0, 1)
         normalDark: Qt.rgba(1, 1, 1, 1)
@@ -42,6 +44,8 @@ Control {
     signal clicked
 
     function dealShowPicLabelClick() {
+        if (!control.editable)
+            return;
         if (showPicLabel.visible) {
             showPicLabel.visible = false;
             // 每次显示编辑框时显示为图片名称

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,7 @@
 #include "printdialog/printhelper.h"
 #include "ocr/ocrinterface.h"
 #include "imagedata/imageinfo.h"
+#include "dbmanager/dbmanager.h"
 
 #include <DSysInfo>
 
@@ -35,6 +36,8 @@
 #include <unistd.h>
 
 DCORE_USE_NAMESPACE
+
+static const QString TRASH_DIR = QDir::cleanPath(albumGlobal::DELETE_PATH);
 
 const QString SETTINGS_GROUP = "MAINWINDOW";
 const QString SETTINGS_WINSIZE_W_KEY = "WindowWidth";
@@ -567,7 +570,19 @@ QString FileControl::slotGetFileName(const QString &path)
 QString FileControl::slotGetFileNameSuffix(const QString &path)
 {
     qDebug() << "FileControl::slotGetFileNameSuffix - Function entry, path:" << path;
-    QString tmppath = LibUnionImage_NameSpace::localPath(path);
+    QString tmppath = QDir::cleanPath(LibUnionImage_NameSpace::localPath(path));
+
+    // Trashed files are renamed to <hash>.<suffix> in cache dir, look up
+    // TrashTable3 by hash to recover the original filename for display
+    if (tmppath.startsWith(TRASH_DIR + "/")) {
+        QFileInfo fi(tmppath);
+        QString hash = fi.completeBaseName();
+        if (!hash.isEmpty()) {
+            DBImgInfoList infos = DBManager::instance()->getTrashImgInfos("PathHash", hash);
+            if (!infos.isEmpty())
+                return DBImgInfo::getFileNameFromFilePath(infos.first().filePath);
+        }
+    }
 
     QFileInfo info(tmppath);
     return info.fileName();
@@ -865,6 +880,15 @@ bool FileControl::isCanSupportOcr(const QString &path)
     }
     qDebug() << "FileControl::isCanSupportOcr - Function exit, returning:" << bRet;
     return bRet;
+}
+
+bool FileControl::isTrashPath(const QString &path)
+{
+    qDebug() << "FileControl::isTrashPath - Function entry, path:" << path;
+    QString localPath = QDir::cleanPath(LibUnionImage_NameSpace::localPath(path));
+    bool ret = localPath.startsWith(TRASH_DIR + "/");
+    qDebug() << "FileControl::isTrashPath - Function exit, returning:" << ret;
+    return ret;
 }
 
 bool FileControl::isCanRename(const QString &path)

--- a/src/src/filecontrol.h
+++ b/src/src/filecontrol.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -52,6 +52,7 @@ public:
     Q_INVOKABLE bool isCheckOnly();                               // 判断当前进程是否为唯一看图实例
     Q_INVOKABLE bool isSupportSetWallpaper(const QString &path);  // 是否支持设置壁纸
     Q_INVOKABLE bool isCanSupportOcr(const QString &path);
+    Q_INVOKABLE bool isTrashPath(const QString &path);
     Q_INVOKABLE bool isCanRename(const QString &path);
     Q_INVOKABLE bool isCanReadable(const QString &path);
     Q_INVOKABLE bool isRotatable(const QString &path);  // 是否可以被选旋转


### PR DESCRIPTION
Disable filename editing in info dialogs for trash items via editable property, and resolve original filename from TrashTable3 by cache path hash lookup instead of showing the hash-renamed filename.

在最近删除视图的信息对话框中禁止编辑文件名，并通过缓存路径
hash反查数据库显示删除前的原始文件名。

Log: 修复删除视图信息对话框可编辑文件名及显示hash文件名问题
PMS: BUG-350475, BUG-309591
Influence: 最近删除视图中打开图片/视频信息对话框，文件名不可编辑且显示删除前的原始名称。

## Summary by Sourcery

Prevent editing of file names in trash item info dialogs and display the original pre-deletion name instead of the hashed cache name.

Bug Fixes:
- Resolve trash info dialogs showing hashed cache filenames by looking up and displaying the original filename from the database using the cache path hash.
- Disable filename editing controls in recently deleted (trash) info dialogs for images and videos.

Enhancements:
- Expose a Q_INVOKABLE helper to retrieve the original filename for trash items based on their cached path and integrate it into image/video info dialogs.