### PR TITLE
fix: Keyboard shortcut issue

### DIFF
--- a/src/qml/Control/NewAlbumDialog.qml
+++ b/src/qml/Control/NewAlbumDialog.qml
@@ -35,6 +35,31 @@ DialogWindow {
 
     signal sigCreateAlbumDone() //创建相册完成信号
 
+    function confirmCreate() {
+        if (nameedit.text === "")
+            return
+        var newAlbumId = albumControl.createAlbum(nameedit.text)
+        GStatus.albumChangeList = !GStatus.albumChangeList
+        renamedialog.visible = false
+
+        if (newAlbumId < 0)
+            return
+
+        if (importSelected) {
+            albumControl.insertIntoAlbum(newAlbumId, GStatus.selectedPaths)
+        }
+
+        if (isChangeView) {
+            GStatus.currentViewType = Album.Types.ViewCustomAlbum
+            GStatus.currentCustomAlbumUId = newAlbumId
+            sigCreateAlbumDone()
+        }
+
+        if (leftSidebar.x !== 0) {
+            showSliderAnimation.start()
+        }
+    }
+
     function setNormalEdit(num)
     {
         //重新设置焦点和名称
@@ -89,6 +114,7 @@ DialogWindow {
         selectByMouse: true
 //        alertText: qsTr("The file already exists, please use another name")
 //        showAlert: FileControl.isShowToolTip(source,nameedit.text)
+        onAccepted: confirmCreate()
     }
 
 
@@ -122,31 +148,7 @@ DialogWindow {
         width: 185
         height: 38
 
-        onClicked: {
-            var newAlbumId = albumControl.createAlbum(nameedit.text)
-            GStatus.albumChangeList = !GStatus.albumChangeList
-            renamedialog.visible = false
-
-            if (newAlbumId < 0)
-                return
-
-            // 导入已选图片
-            if (importSelected) {
-                albumControl.insertIntoAlbum(newAlbumId, GStatus.selectedPaths)
-            }
-
-            // 切换到对应相册视图
-            if (isChangeView) {
-                GStatus.currentViewType = Album.Types.ViewCustomAlbum
-                GStatus.currentCustomAlbumUId = newAlbumId
-                sigCreateAlbumDone()
-            }
-
-            //侧边栏如果是关闭状态，侧边栏会自动打开
-            if (leftSidebar.x !== 0) {
-                showSliderAnimation.start()
-            }
-        }
+        onClicked: confirmCreate()
     }
 
     onVisibleChanged: {


### PR DESCRIPTION
log: The LineEdit in NewAlbumDialog.qml does not handle the Enter key event; only the Confirm button's onClicked event handles the confirmation logic.

pms: bug-359959

## Summary by Sourcery

Fix album creation dialog so confirming creation works consistently from both the Enter key in the name field and the confirm button.

Bug Fixes:
- Allow creating a new album from the dialog by pressing Enter in the name input field.

Enhancements:
- Deduplicate album creation logic by centralizing it in a shared confirmCreate() function used by both the input and the confirm button.