### PR TITLE
fix(viewer): use Qt6 FileDialog API for opening images

### DIFF
--- a/src/qml/PreviewImageViewer/MainStack.qml
+++ b/src/qml/PreviewImageViewer/MainStack.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -128,7 +128,7 @@ FadeInoutAnimation {
                 fileDialog.open();
             }
             onAccepted: {
-                var path = fileDialog.fileUrls[0]
+                var path = fileDialog.selectedFiles[0]
                 stackView.setSourcePath(path);
                 if (FileControl.isAlbum() && GControl.currentSource.toString() !== "") {
                     var sourcePaths = FileControl.getDirImagePath(path);


### PR DESCRIPTION
Replace deprecated fileUrls with selectedFiles in FileDialog's onAccepted handler to fix open image dialog not working.

修复通过右上角菜单"打开图片"无法加载新图片的问题，将已废弃
的fileUrls替换为Qt6的selectedFiles属性。

Log: 修复打开图片对话框无法加载图片的问题
PMS: BUG-337523
Influence: 修复后用户通过菜单或Ctrl+O打开文件对话框选择图片后，
      可以正确加载并显示所选图片。

## Summary by Sourcery

Bug Fixes:
- Use FileDialog.selectedFiles instead of the deprecated fileUrls to restore opening images from the file dialog in the preview image viewer.