### PR TITLE
fix(video): refresh thumbnail and duration after camera recording

### DIFF
--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -6,6 +6,9 @@
 #include "dbmanager/dbmanager.h"
 #include "fileMonitor/fileinotifygroup.h"
 #include "imageengine/imageenginethread.h"
+#include "imageengine/imagedataservice.h"
+#include "imageengine/movieservice.h"
+#include "unionimage/unionimage.h"
 #include "utils/devicehelper.h"
 #include "utils/classifyutils.h"
 
@@ -16,6 +19,7 @@
 
 #include <QStandardPaths>
 #include <QFileInfo>
+#include <QTimer>
 #include <QUrl>
 #include <QFileDialog>
 #include <QProcess>
@@ -807,6 +811,7 @@ void AlbumControl::initMonitor()
     m_fileInotifygroup = new FileInotifyGroup(this) ;
     connect(m_fileInotifygroup, &FileInotifyGroup::sigMonitorChanged, this, &AlbumControl::slotMonitorChanged);
     connect(m_fileInotifygroup, &FileInotifyGroup::sigMonitorDestroyed, this, &AlbumControl::slotMonitorDestroyed);
+    connect(m_fileInotifygroup, &FileInotifyGroup::sigVideoFileStable, this, &AlbumControl::slotVideoFileStable);
     qDebug() << "AlbumControl::initMonitor - Function exit";
 }
 
@@ -914,6 +919,76 @@ void AlbumControl::slotMonitorChanged(QStringList fileAdd, QStringList fileDelet
     emit sigRefreshAllCollection();
 
     qDebug() << "AlbumControl::slotMonitorChanged - Function exit";
+}
+
+static const int kVideoRetryIntervalMs = 2000;
+static const int kVideoStableRetryLimit = 3;
+
+bool AlbumControl::shouldRetryVideo(const QString &path)
+{
+    qint64 currentSize = QFileInfo(path).size();
+    if (m_videoStableSize.value(path, 0) != currentSize) {
+        m_videoStableSize[path] = currentSize;
+        m_videoStableCount.remove(path);
+        return true;
+    }
+    int count = m_videoStableCount.value(path, 0) + 1;
+    if (count < kVideoStableRetryLimit) {
+        m_videoStableCount[path] = count;
+        return true;
+    }
+    qWarning() << "Video file size unchanged after" << kVideoStableRetryLimit
+                << "retries, giving up:" << path;
+    m_videoStableSize.remove(path);
+    m_videoStableCount.remove(path);
+    return false;
+}
+
+void AlbumControl::slotVideoFileStable(const QStringList &files)
+{
+    QStringList needRetry;
+    for (const QString &path : files) {
+        if (!QFile::exists(path)) {
+            qWarning() << "Video file no longer exists, stop retrying:" << path;
+            m_videoStableSize.remove(path);
+            m_videoStableCount.remove(path);
+            continue;
+        }
+        if (LibUnionImage_NameSpace::isVideo(path)) {
+            MovieService::instance()->clearMovieInfoCache(QUrl::fromLocalFile(path));
+            DBImgInfo info = getDBInfo(path, true);
+            if (info.itemType == ItemTypeNull) {
+                qWarning() << "Video file still invalid, will retry:" << path;
+                needRetry << path;
+                continue;
+            }
+            ImageDataService::instance()->addMovieDurationStr(path, m_movieInfos.value(path).duration);
+            DBImgInfo oldInfo = DBManager::instance()->getInfoByPath(path);
+            if (!oldInfo.filePath.isEmpty()) {
+                info.albumUID = oldInfo.albumUID;
+            }
+            DBManager::instance()->insertImgInfos(DBImgInfoList() << info);
+            m_videoStableSize.remove(path);
+        }
+        ImageDataService::instance()->getThumnailImageByPathRealTime(path, false, true);
+    }
+    emit sigRefreshCustomAlbum(-1);
+    emit sigRefreshImportAlbum();
+    emit sigRefreshAllCollection();
+
+    if (!needRetry.isEmpty()) {
+        QStringList filteredRetry;
+        for (const QString &path : needRetry) {
+            if (shouldRetryVideo(path)) {
+                filteredRetry << path;
+            }
+        }
+        if (!filteredRetry.isEmpty()) {
+            QTimer::singleShot(kVideoRetryIntervalMs, this, [this, filteredRetry]() {
+                slotVideoFileStable(filteredRetry);
+            });
+        }
+    }
 }
 
 void AlbumControl::slotMonitorDestroyed(int UID)

--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -385,6 +385,9 @@ public slots:
     //自动导入路径被删除
     void slotMonitorDestroyed(int UID);
 
+    //视频文件写入完成后刷新缩略图和视频信息
+    void slotVideoFileStable(const QStringList &files);
+
 #if 0
     //加载设备路径的数据
     void sltLoadMountFileList(const QString &strPath);
@@ -403,6 +406,7 @@ private:
     void getAllBlockDeviceName();
     void updateBlockDeviceName(const QString &blks);
     void onUnMountedExecute(const QString &deviceKey, DeviceType type);
+    bool shouldRetryVideo(const QString &path);
 
 signals:
     void sigRefreshAllCollection();
@@ -465,6 +469,8 @@ private :
     QMap < QString, DBImgInfoList > m_dayDateMap; //日数据集
     QMap < int, QString > m_customAlbum; //自定义相册
     QMap < QString, MovieInfo> m_movieInfos; //movieInfo的合集
+    QMap<QString, qint64> m_videoStableSize; //视频重试时记录的文件大小
+    QMap<QString, int> m_videoStableCount; //视频文件大小连续不变的次数
 
     FileInotifyGroup *m_fileInotifygroup {nullptr}; //固定文件夹监控
 

--- a/src/src/fileMonitor/fileinotify.cpp
+++ b/src/src/fileMonitor/fileinotify.cpp
@@ -20,6 +20,8 @@
 #include <QDir>
 
 enum {MASK = IN_MODIFY | IN_CREATE | IN_DELETE};
+static const int kVideoStableCheckIntervalMs = 1000;
+static const qint64 kVideoSizeFirstRecord = -1;
 
 FileInotify::FileInotify(QObject *parent)
     : QObject(parent)
@@ -158,6 +160,8 @@ void FileInotify::clear()
     m_pendingDirs.clear();
     m_parentDirs.clear();
     m_parentToChildren.clear();
+    m_pendingFileSize.clear();
+    m_pendingVideoFiles.clear();
 
     if (m_timer && m_timer->isActive()) {
         m_timer->stop();
@@ -209,9 +213,13 @@ void FileInotify::getAllPicture(bool isFirst)
 
     //筛选出新增图片文件
     for (auto path : filePaths) {
-        if (!allPaths.contains(path)) {
+        if (!allPaths.contains(path) && !m_newFile.contains(path)) {
             qDebug() << "New file detected:" << path;
             m_newFile << path;
+            //对视频文件标记为待监控（不记录大小，在onNeedSendPictures末尾记录）
+            if (LibUnionImage_NameSpace::isVideo(path)) {
+                m_pendingVideoFiles << path;
+            }
         }
     }
 
@@ -278,7 +286,45 @@ void FileInotify::onNeedSendPictures()
         }
     }
 
-    m_timer->stop();
+    //将新发现的视频文件标记为待监控，用-1表示首次记录，下次定时器才记录实际大小
+    for (const QString &path : m_pendingVideoFiles) {
+        m_pendingFileSize[path] = kVideoSizeFirstRecord;
+    }
+    m_pendingVideoFiles.clear();
+
+    //检查正在写入的视频文件是否已完成
+    QStringList stableFiles;
+    for (auto it = m_pendingFileSize.begin(); it != m_pendingFileSize.end();) {
+        QString path = it.key();
+        qint64 lastSize = it.value();
+        QFileInfo info(path);
+        if (!info.exists()) {
+            it = m_pendingFileSize.erase(it);
+            continue;
+        }
+        qint64 currentSize = info.size();
+        if (lastSize == kVideoSizeFirstRecord) {
+            it.value() = currentSize;
+            ++it;
+        } else if (currentSize > 0 && currentSize == lastSize) {
+            stableFiles << path;
+            it = m_pendingFileSize.erase(it);
+        } else {
+            it.value() = currentSize;
+            ++it;
+        }
+    }
+
+    if (!stableFiles.isEmpty()) {
+        emit sigVideoFileStable(stableFiles);
+    }
+
+    //如果还有未稳定的文件（正在写入），继续定时检查
+    if (!m_pendingFileSize.isEmpty()) {
+        m_timer->start(kVideoStableCheckIntervalMs);
+    } else {
+        m_timer->stop();
+    }
 }
 
 void FileInotify::addParentWatcher(const QString &parentPath, const QString &targetChild)

--- a/src/src/fileMonitor/fileinotify.h
+++ b/src/src/fileMonitor/fileinotify.h
@@ -33,6 +33,8 @@ signals:
 
     //监控到改变
     void sigMonitorChanged(QStringList fileAdd, QStringList fileDelete, QString album, int UID);
+    //视频文件写入完成，需要刷新缩略图
+    void sigVideoFileStable(const QStringList &files);
 
 public slots:
     //发送插入
@@ -53,6 +55,8 @@ private:
     QStringList m_pendingDirs;  //等待创建的目标目录
     QStringList m_parentDirs;   //当前监听的父级目录
     QMap<QString, QStringList> m_parentToChildren; //父级目录到子目录的映射
+    QMap<QString, qint64> m_pendingFileSize; //文件路径到上次检查时的大小的映射，用于检测文件写入完成
+    QStringList m_pendingVideoFiles; //新发现的视频文件，等待记录初始大小
     QString m_currentAlbum;     //给定当前的相册
     int m_currentUID;           //给定当前的相册的UID
     QStringList  m_Supported;   //支持的格式

--- a/src/src/fileMonitor/fileinotifygroup.cpp
+++ b/src/src/fileMonitor/fileinotifygroup.cpp
@@ -25,6 +25,7 @@ void FileInotifyGroup::startWatch(const QStringList &paths, const QString &album
     //原cpp为signal发送的全局信号,现在改为传递的方法,发送回albumControl
     connect(watcher, &FileInotify::sigMonitorChanged, this, &FileInotifyGroup::sigMonitorChanged);
     connect(watcher, &FileInotify::pathDestroyed, this, &FileInotifyGroup::sigMonitorDestroyed);
+    connect(watcher, &FileInotify::sigVideoFileStable, this, &FileInotifyGroup::sigVideoFileStable);
 
     //加进监控list，后面方便销毁
     watchers.push_back(watcher);

--- a/src/src/fileMonitor/fileinotifygroup.h
+++ b/src/src/fileMonitor/fileinotifygroup.h
@@ -25,6 +25,8 @@ signals:
     void sigMonitorChanged(QStringList fileAdd, QStringList fileDelete, QString album, int UID);
     //自动导入路径被删除
     void sigMonitorDestroyed(int UID);
+    //视频文件写入完成，需要刷新缩略图
+    void sigVideoFileStable(const QStringList &files);
 private:
     QList<FileInotify *> watchers;
 };

--- a/src/src/imageengine/movieservice.cpp
+++ b/src/src/imageengine/movieservice.cpp
@@ -182,6 +182,18 @@ MovieInfo MovieService::getMovieInfo(const QUrl &url)
     return result;
 }
 
+void MovieService::clearMovieInfoCache(const QUrl &url)
+{
+    QMutexLocker locker(&m_bufferMutex);
+    auto it = std::remove_if(m_movieInfoBuffer.begin(), m_movieInfoBuffer.end(),
+                             [url](const std::pair<QUrl, MovieInfo> &data) {
+                                 return data.first == url;
+                             });
+    if (it != m_movieInfoBuffer.end()) {
+        m_movieInfoBuffer.erase(it, m_movieInfoBuffer.end());
+    }
+}
+
 QImage MovieService::getMovieCover(const QUrl &url)
 {
     qDebug() << "Getting movie cover for URL:" << url.toString();
@@ -237,11 +249,13 @@ MovieInfo MovieService::parseFromFile(const QFileInfo &fi)
 
     if (g_mvideo_avformat_find_stream_info(av_ctx, nullptr) < 0) {
         qWarning() << "Failed to find stream info for file:" << fi.filePath();
+        g_mvideo_avformat_close_input(&av_ctx);
         return mi;
     }
 
     if (av_ctx->nb_streams == 0) {
         qWarning() << "No streams found in file:" << fi.filePath();
+        g_mvideo_avformat_close_input(&av_ctx);
         return mi;
     }
 
@@ -253,6 +267,7 @@ MovieInfo MovieService::parseFromFile(const QFileInfo &fi)
     audioRet = g_mvideo_av_find_best_stream(av_ctx, AVMEDIA_TYPE_AUDIO, -1, -1, nullptr, 0);
     if (videoRet < 0 && audioRet < 0) {
         qWarning() << "No video or audio streams found in file:" << fi.filePath();
+        g_mvideo_avformat_close_input(&av_ctx);
         return mi;
     }
 

--- a/src/src/imageengine/movieservice.h
+++ b/src/src/imageengine/movieservice.h
@@ -96,6 +96,8 @@ public:
     MovieInfo   getMovieInfo(const QUrl &url);
     //获取视频首帧图片
     QImage      getMovieCover(const QUrl &url);
+    //清除指定URL的视频信息缓存
+    void        clearMovieInfoCache(const QUrl &url);
 private:
     struct MovieInfo parseFromFile(const QFileInfo &fi);
     explicit MovieService(QObject *parent = nullptr);


### PR DESCRIPTION
Detect video file write completion via file size stability check, then clear MovieService cache, re-parse video info, update database and duration display with retry mechanism for slow writes.

修复相机录制视频后缩略图和时长不刷新的问题，通过文件大小
稳定性检测视频写入完成，清除缓存后重新解析并更新显示。

Log: 修复相机录制视频后缩略图和时长不自动刷新
PMS: BUG-330775
Influence: 相机录制视频完成后自动刷新缩略图和时长显示，无需手动切换相册。