### PR TITLE
fix(view): refresh album views after returning from image viewer

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -186,9 +186,10 @@ SwitchViewAnimation {
     onVisibleChanged: {
         // 窗口显示时，重置显示内容
         if (visible && GStatus.currentCollecttionViewIndex === 3) {
-            if (!GStatus.loading && !GStatus.backingToMainAlbumView) {
+            if (!GStatus.loading) {
                 flushAllCollectionView()
-                showAnimation.start()
+                if (!GStatus.backingToMainAlbumView)
+                    showAnimation.start()
             }
         }
     }

--- a/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -71,8 +71,6 @@ BaseView {
     }
 
     onVisibleChanged: {
-        if (GStatus.backingToMainAlbumView)
-            return
         allCollection.clearSelecteds()
         dayCollection.unSelectAll()
 

--- a/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
@@ -120,7 +120,7 @@ SwitchViewAnimation {
 
     onVisibleChanged: {
         // 窗口显示时，重置显示内容
-        if (visible && !GStatus.backingToMainAlbumView) {
+        if (visible) {
             flushView()
         }
     }

--- a/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
+++ b/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
@@ -34,7 +34,7 @@ BaseView {
     }
 
     onVisibleChanged: {
-        if (visible && !GStatus.backingToMainAlbumView) {
+        if (visible) {
             flushAlbumName(GStatus.currentCustomAlbumUId, albumControl.getCustomAlbumByUid(GStatus.currentCustomAlbumUId))
             flushCustomAlbumView(GStatus.currentCustomAlbumUId)
         }

--- a/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
+++ b/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,7 +25,7 @@ BaseView {
     property alias selectedPaths: theView.selectedPaths
 
     onVisibleChanged: {
-        if (!GStatus.backingToMainAlbumView)
+        if (visible)
             flushDeviceAlbumView()
     }
 

--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -101,9 +101,9 @@ BaseView {
     }
 
     onVisibleChanged: {
-        if (visible && !GStatus.backingToMainAlbumView) {
+        if (visible) {
             flushView()
-            if (show)
+            if (show && !GStatus.backingToMainAlbumView)
                 showAnimation.start()
         }
     }


### PR DESCRIPTION
Separate data refresh from animation gating in onVisibleChanged handlers. The backingToMainAlbumView flag now only suppresses entry animations, not data refresh, ensuring newly imported images are visible on return.

修复从看图界面返回相册后视图不刷新的问题，将数据刷新与动画控制解耦。

Log: 修复返回相册后不显示已导入图片的问题
PMS: BUG-313129
Influence: 从文件管理器用相册打开图片后点击返回，相册视图会正确显示新导入的图片。