### PR TITLE
fix(view): fix multi-page image thumbnails truncated in bottom toolbar

### DIFF
--- a/src/qml/PreviewImageViewer/ThumbnailListView.qml
+++ b/src/qml/PreviewImageViewer/ThumbnailListView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,8 +21,7 @@ Control {
     property bool imageIsNull: null === targetImage
 
     // 用于外部获取当前缩略图栏内容的长度，用于布局, 10px为焦点缩略图不在ListView中的边框像素宽度(radius = 4 * 1.25)
-    property int listContentWidth: bottomthumbnaillistView.count > 10 ? (bottomthumbnaillistView.contentWidth + 10)
-                                                                      : (55 + (bottomthumbnaillistView.count - 1) * 30 + 20)
+    property int listContentWidth: bottomthumbnaillistView.contentWidth + 10
     property Image targetImage
 
     function deleteCurrentImage() {


### PR DESCRIPTION
Use contentWidth directly instead of a fixed formula that assumed each item is 30px wide, which broke when multi-page images expand wider.

修复多页图在底部工具栏缩略图显示不全的问题，改用 contentWidth
替代固定宽度公式。

Log: 修复多页图缩略图显示不全
PMS: BUG-359519
Influence: 多页图（如多页TIFF）在底部工具栏中能正确显示所有帧缩略图。