### PR TITLE
fix(scrollbar): add scrollbar to all collection and imported views

### DIFF
--- a/src/deepin-album.qrc
+++ b/src/deepin-album.qrc
@@ -52,6 +52,8 @@
         <file>qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml</file>
         <file>qml/StatusBar.qml</file>
         <file>qml/Control/FilterComboBox.qml</file>
+        <file>qml/Control/WidgetScrollBar.qml</file>
+        <file>qml/Control/FlickableScrollBar.qml</file>
         <file>qml/Control/ListView/VideoLabel.qml</file>
         <file>qml/ThumbnailImageView/SearchView.qml</file>
         <file>qml/Control/ExportDialog.qml</file>

--- a/src/qml/Control/FlickableScrollBar.qml
+++ b/src/qml/Control/FlickableScrollBar.qml
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+
+// 适用于纯 QML Flickable/ListView 的 ScrollBar 封装
+// 内置绑定循环防护和拖拽冲突处理
+ScrollBar {
+    id: control
+
+    required property Flickable flickable
+
+    orientation: Qt.Vertical
+    policy: ScrollBar.AsNeeded
+    height: flickable.height
+    anchors.right: flickable.parent.right
+    anchors.top: flickable.parent.top
+    active: flickable.moving || control.hovered || control.pressed
+    size: flickable.visibleArea.heightRatio
+    visible: flickable.contentHeight > flickable.height
+    snapMode: ScrollBar.NoSnap
+    minimumSize: 0.1
+
+    property real viewPos: flickable.visibleArea.yPosition
+    onViewPosChanged: { if (!pressed) position = viewPos }
+
+    onPressedChanged: {
+        if (pressed) {
+            flickable.cancelFlick()
+            flickable.interactive = false
+        } else {
+            flickable.interactive = true
+        }
+    }
+
+    onPositionChanged: {
+        if (pressed) {
+            var maxScroll = flickable.contentHeight - flickable.height
+            if (maxScroll > 0)
+                flickable.contentY = Math.max(0, Math.min(position * maxScroll, maxScroll))
+        }
+    }
+}

--- a/src/qml/Control/WidgetScrollBar.qml
+++ b/src/qml/Control/WidgetScrollBar.qml
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import org.deepin.dtk 1.0
+
+// 适用于 QmlWidget 嵌入 QWidget 的滚动条组件
+// 样式参数与 DTK ScrollBar 一致（FlowStyle.qml）
+Rectangle {
+    id: root
+
+    anchors.right: parent.right
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    width: GStatus.verticalScrollBarWidth
+    color: "transparent"
+
+    // 由 QmlWidget 暴露的属性驱动
+    required property real contentRatio
+    required property real scrollPosition
+
+    // 可配置样式参数（与 DTK FlowStyle.qml 一致）
+    property int trackMargin: 2
+    property int handleWidthNormal: 4
+    property int handleWidthActive: 12
+    property int handleMinHeight: 30
+    property int hideDelay: 450
+    property int fadeOutDuration: 1500
+    property color handleColorLight: Qt.rgba(0, 0, 0, 0.5)
+    property color handleColorDark: Qt.rgba(1, 1, 1, 0.3)
+
+    property bool needScroll: contentRatio < 0.99
+    property real trackHeight: height - trackMargin * 2
+    property bool showHandle: false
+    property bool hovered: trackMouse.containsMouse
+    property bool pressed: trackMouse.drag.active
+    property int handleWidth: (hovered || pressed) ? handleWidthActive : handleWidthNormal
+    property real _lastDragPos: 0
+
+    property real handleHeight: Math.max(handleMinHeight, trackHeight * contentRatio)
+    property real handleY: trackMargin + scrollPosition * (trackHeight - handleHeight)
+    onHandleYChanged: { if (!trackMouse.drag.active) scrollHandle.y = handleY }
+
+    onScrollPositionChanged: {
+        if (needScroll && !trackMouse.drag.active) {
+            showHandle = true
+        }
+    }
+
+    Timer {
+        id: hideTimer
+        interval: root.hideDelay
+        onTriggered: {
+            if (!trackMouse.containsMouse && !trackMouse.drag.active)
+                root.showHandle = false
+        }
+    }
+
+    onShowHandleChanged: {
+        if (showHandle) {
+            hideTimer.stop()
+            hideTimer.start()
+        }
+    }
+
+    MouseArea {
+        id: trackMouse
+        anchors.fill: parent
+        hoverEnabled: true
+        drag.target: scrollHandle
+        drag.axis: Drag.YAxis
+        drag.minimumY: root.trackMargin
+        drag.maximumY: root.trackHeight - scrollHandle.height + root.trackMargin
+
+        onContainsMouseChanged: {
+            if (containsMouse) {
+                root.showHandle = true
+                hideTimer.stop()
+            } else if (!drag.active) {
+                hideTimer.restart()
+            }
+        }
+
+        onPositionChanged: {
+            if (drag.active) {
+                var maxTravel = root.trackHeight - scrollHandle.height
+                var newPos = maxTravel > 0 ? (scrollHandle.y - root.trackMargin) / maxTravel : 0
+                if (Math.abs(newPos - root._lastDragPos) > 0.001) {
+                    root._lastDragPos = newPos
+                    root.scrollPositionChangedFromDrag(newPos)
+                }
+            }
+        }
+    }
+
+    Rectangle {
+        id: scrollHandle
+        opacity: 0.0
+        visible: root.needScroll && scrollHandle.opacity > 0
+        anchors.right: parent.right
+        anchors.rightMargin: root.trackMargin
+        width: root.handleWidth
+        height: root.handleHeight
+        radius: width / 2
+
+        color: DTK.themeType === ApplicationHelper.LightType
+               ? root.handleColorLight
+               : root.handleColorDark
+
+        Connections {
+            target: root
+            function onShowHandleChanged() {
+                if (root.showHandle) {
+                    scrollHandle.opacity = 1.0
+                    fadeOutAnim.stop()
+                } else {
+                    fadeOutAnim.start()
+                }
+            }
+        }
+
+        NumberAnimation {
+            id: fadeOutAnim
+            target: scrollHandle
+            property: "opacity"
+            from: 1.0
+            to: 0.0
+            duration: root.fadeOutDuration
+        }
+
+        Behavior on width { NumberAnimation { duration: 150 } }
+    }
+
+    signal scrollPositionChangedFromDrag(real pos)
+}

--- a/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
@@ -41,6 +41,7 @@ SwitchViewAnimation {
     // property alias count: theModel.count
 
     Rectangle {
+        id: dayContainer
         anchors.fill : parent
         color: DTK.themeType === ApplicationHelper.LightType ? "#f8f8f8"
                                                               : "#202020"
@@ -48,9 +49,15 @@ SwitchViewAnimation {
         Album.QmlWidget{
             id: timeline
             anchors.fill: parent
-            anchors.margins: 0
+            anchors.rightMargin: GStatus.verticalScrollBarWidth
             focus: false
             viewType: Album.Types.WidgetDayView
+        }
+
+        WidgetScrollBar {
+            contentRatio: timeline.contentRatio
+            scrollPosition: timeline.scrollPosition
+            onScrollPositionChangedFromDrag: (pos) => timeline.setScrollPosition(pos)
         }
     }
 

--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -80,6 +80,10 @@ SwitchViewAnimation {
             top: parent.top
             horizontalCenter: parent.horizontalCenter
         }
+    }
+
+    FlickableScrollBar {
+        flickable: theView
     }
 
     Component {

--- a/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -56,6 +56,10 @@ SwitchViewAnimation {
             top: parent.top
             horizontalCenter: parent.horizontalCenter
         }
+    }
+
+    FlickableScrollBar {
+        flickable: theView
     }
 
     Component {

--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -31,9 +31,15 @@ BaseView {
         Album.QmlWidget{
             id: timeline
             anchors.fill: parent
-            anchors.margins: 0
+            anchors.rightMargin: GStatus.verticalScrollBarWidth
             focus: false
             viewType: Album.Types.WidgetImportedView
+        }
+
+        WidgetScrollBar {
+            contentRatio: timeline.contentRatio
+            scrollPosition: timeline.scrollPosition
+            onScrollPositionChangedFromDrag: (pos) => timeline.setScrollPosition(pos)
         }
     }
 

--- a/src/src/qmlWidget.cpp
+++ b/src/src/qmlWidget.cpp
@@ -8,6 +8,8 @@
 #include <QQuickWindow>
 #include <QHBoxLayout>
 #include <QPushButton>
+#include <QScrollBar>
+#include <QAbstractScrollArea>
 #include <QDebug>
 QmlCustomInternalWidget::QmlCustomInternalWidget(QQuickPaintedItem *parent) :
     QWidget(nullptr)
@@ -114,6 +116,7 @@ void QmlWidget::initWidget()
         m_view->setAttribute(Qt::WA_WState_Created, true);
         m_view->setAutoFillBackground(true);
         m_view->setVisible(true);
+        connectScrollSignals();
     }
 }
 
@@ -334,6 +337,69 @@ bool QmlWidget::event(QEvent *e)
     }
 
     return QQuickPaintedItem::event(e);
+}
+
+qreal QmlWidget::scrollPosition() const
+{
+    return m_scrollPosition;
+}
+
+qreal QmlWidget::contentRatio() const
+{
+    return m_contentRatio;
+}
+
+void QmlWidget::setScrollPosition(qreal pos)
+{
+    if (!m_scrollArea)
+        return;
+
+    QScrollBar *vbar = m_scrollArea->verticalScrollBar();
+    qreal max = vbar->maximum();
+    vbar->setValue(qBound(0, qRound(qBound(0.0, pos, 1.0) * max), vbar->maximum()));
+}
+
+void QmlWidget::connectScrollSignals()
+{
+    if (!m_view)
+        return;
+
+    if (m_viewType == Types::WidgetDayView) {
+        if (auto *timeLine = dynamic_cast<TimeLineView*>(m_view))
+            m_scrollArea = qobject_cast<QAbstractScrollArea*>(timeLine->getThumbnailListView());
+    } else if (m_viewType == Types::WidgetImportedView) {
+        if (auto *importTimeLine = dynamic_cast<ImportTimeLineView*>(m_view))
+            m_scrollArea = qobject_cast<QAbstractScrollArea*>(importTimeLine->getListView());
+    }
+
+    if (!m_scrollArea)
+        return;
+
+    QScrollBar *vbar = m_scrollArea->verticalScrollBar();
+    if (!vbar)
+        return;
+
+    auto updateScrollInfo = [this, vbar]() {
+        int max = vbar->maximum();
+        int val = vbar->value();
+        int pageStep = vbar->pageStep();
+
+        qreal newPos = max > 0 ? qreal(val) / max : 0.0;
+        qreal newRatio = (max + pageStep) > 0 ? qreal(pageStep) / (max + pageStep) : 1.0;
+
+        if (!qFuzzyCompare(m_scrollPosition, newPos)) {
+            m_scrollPosition = newPos;
+            Q_EMIT scrollPositionChanged();
+        }
+        if (!qFuzzyCompare(m_contentRatio, newRatio)) {
+            m_contentRatio = newRatio;
+            Q_EMIT contentRatioChanged();
+        }
+    };
+
+    connect(vbar, &QScrollBar::valueChanged, this, updateScrollInfo);
+    connect(vbar, &QScrollBar::rangeChanged, this, updateScrollInfo);
+    updateScrollInfo();
 }
 
 void QmlWidget::updateGeometry()

--- a/src/src/qmlWidget.h
+++ b/src/src/qmlWidget.h
@@ -4,6 +4,7 @@
 #include "types.h"
 
 #include <QQuickPaintedItem>
+#include <QAbstractScrollArea>
 #include <QWidget>
 #include <DWidget>
 
@@ -35,6 +36,8 @@ class QmlWidget : public QQuickPaintedItem
 
     Q_PROPERTY(int viewType READ viewType WRITE setViewType NOTIFY viewTypeChanged)
     Q_PROPERTY(int filterType READ filterType WRITE setFilterType NOTIFY filterTypeChanged)
+    Q_PROPERTY(qreal scrollPosition READ scrollPosition NOTIFY scrollPositionChanged)
+    Q_PROPERTY(qreal contentRatio READ contentRatio NOTIFY contentRatioChanged)
 public:
     explicit QmlWidget(QQuickItem *parent = nullptr);
     void paint(QPainter *painter);
@@ -45,11 +48,15 @@ public:
     void setFilterType(int filterType);
     int filterType();
 
+    qreal scrollPosition() const;
+    qreal contentRatio() const;
+
     Q_INVOKABLE void refresh();
     Q_INVOKABLE void navigateToMonth(const QString& month);
     Q_INVOKABLE QVariantList allUrls();
     Q_INVOKABLE void unSelectAll();
     Q_INVOKABLE void selectUrls(const QStringList& urls);
+    Q_INVOKABLE void setScrollPosition(qreal pos);
 
 public slots:
     void setFocus(bool arg);
@@ -57,8 +64,11 @@ public slots:
 Q_SIGNALS:
     void viewTypeChanged();
     void filterTypeChanged();
+    void scrollPositionChanged();
+    void contentRatioChanged();
 private:
     void initWidget();
+    void connectScrollSignals();
 private:
 #ifdef USE_INNER
     QmlCustomInternalWidget *m_view;
@@ -67,6 +77,9 @@ private:
 #endif
 
     QWidget *m_lastHoveredWidget = nullptr;
+    qreal m_scrollPosition = 0.0;
+    qreal m_contentRatio = 1.0;
+    QAbstractScrollArea *m_scrollArea = nullptr;
 protected:
     virtual void geometryChanged(const QRectF & newGeometry,
                                  const QRectF & oldGeometry);


### PR DESCRIPTION
Add custom scrollbar components for QWidget-embedded views (WidgetScrollBar) and pure QML views (FlickableScrollBar), matching DTK native ScrollBar style.

为集合视图（日/月/年）和已导入视图添加滚动条，样式与DTK原生滚动条一致。

Log: 为所有集合视图和已导入视图添加滚动条
PMS: BUG-308685
Influence: 日视图、月视图、年视图、已导入视图均可显示滚动条，支持拖拽和自动隐藏。