### PR TITLE
fix(view): dynamic timeline title height based on font metrics

### DIFF
--- a/src/src/widgets/importtimelineview/importtimelineview.cpp
+++ b/src/src/widgets/importtimelineview/importtimelineview.cpp
@@ -12,19 +12,25 @@
 #include <QGraphicsOpacityEffect>
 #include <QTimer>
 #include <QStackedWidget>
+#include <QFontMetrics>
 
 #include <DPushButton>
 #include <DTableView>
 #include <DCheckBox>
 #include <DHiDPIHelper>
 #include <DPaletteHelper>
+#include <DFontSizeManager>
 
-const int MAINWINDOW_NEEDCUT_WIDTH = 775;
-const int LISTVIEW_MINMUN_WIDTH = 520;
-const int IMPORTTITLE_FIX_WIDTH = 90;
-const int STATUSBAR_HEIGHT = 27;
-const int TIMELINE_TITLEHEIGHT = 36;
-const int SUSPENSION_WIDGET_HEIGHT = 87;//悬浮控件高度
+static const int MAINWINDOW_NEEDCUT_WIDTH = 775;
+static const int LISTVIEW_MINMUN_WIDTH = 520;
+static const int IMPORTTITLE_FIX_WIDTH = 90;
+static const int STATUSBAR_HEIGHT = 27;
+static const int TIMELINE_TITLEHEIGHT = 36;
+static const int TITLE_TOP_PAD = 10;
+static const int TITLE_BOTTOM_PAD = 5;
+static const int TITLE_LINE_SPACING = 4;
+static const int CONTROL_TEXT_PAD = 6;
+static const int ITEM_SPACING_COMPENSATION = 4; // 补偿QListView::spacing
 
 ImportTimeLineView::ImportTimeLineView(QmlWidget *parent)
     : m_mainLayout(nullptr)
@@ -114,9 +120,29 @@ ThumbnailListView *ImportTimeLineView::getListView()
 
 void ImportTimeLineView::updateSize()
 {
-    qDebug() << "Updating ImportTimeLineView size";
-    m_importTitleItem->setGeometry(0, 0, width() - 15, SUSPENSION_WIDGET_HEIGHT);
-    qDebug() << "ImportTimeLineView size updated to:" << width() - 15 << "x" << SUSPENSION_WIDGET_HEIGHT;
+    applyHeights();
+}
+
+void ImportTimeLineView::applyHeights()
+{
+    QFont ft3 = DFontSizeManager::instance()->get(DFontSizeManager::T3);
+    ft3.setFamily("Noto Sans CJK SC");
+    QFont ft6 = DFontSizeManager::instance()->get(DFontSizeManager::T6);
+    ft6.setFamily("Noto Sans CJK SC");
+    int importH = QFontMetrics(ft3).tightBoundingRect("Ayjg").height();
+    int dateNumH = QFontMetrics(ft6).tightBoundingRect("Ayjg").height();
+    int importLabelH = importH + CONTROL_TEXT_PAD;
+    // bug76892 藏语占用更大高度
+    if (QLocale::system().language() == QLocale::Tibetan)
+        importLabelH = qMax(importLabelH, TIMELINE_TITLEHEIGHT + 25);
+    m_importLabel->setFixedHeight(importLabelH);
+    m_dateNumCheckBox->setFixedHeight(dateNumH + CONTROL_TEXT_PAD);
+    m_dateNumLabel->setFixedHeight(dateNumH + CONTROL_TEXT_PAD);
+    m_suspensionHeight = TITLE_TOP_PAD + importLabelH + TITLE_LINE_SPACING + (dateNumH + CONTROL_TEXT_PAD) + TITLE_BOTTOM_PAD;
+    // 时间线标题项高度：时间段间距(8) + 单行文字 + 标题到图片间距(2) + 补偿ITEM_SPACING
+    m_timelineTitleHeight = 8 + (dateNumH + CONTROL_TEXT_PAD) + 2 + ITEM_SPACING_COMPENSATION;
+    m_importTimeLineListView->m_blankItemHeight = qMax(m_suspensionHeight - ITEM_SPACING_COMPENSATION, TIMELINE_TITLEHEIGHT);
+    m_importTitleItem->setGeometry(0, 0, width() - 15, m_suspensionHeight);
 }
 
 void ImportTimeLineView::onCheckBoxClicked()
@@ -216,7 +242,8 @@ void ImportTimeLineView::initTimeLineViewWidget()
     m_importTitleItem = new DWidget(m_timeLineViewWidget);
     m_importTitleItem->setFocusPolicy(Qt::NoFocus);
     QVBoxLayout *titleViewLayout = new QVBoxLayout();
-    titleViewLayout->setContentsMargins(18, 10, 0, 0);
+    titleViewLayout->setContentsMargins(18, TITLE_TOP_PAD, 0, 0);
+    titleViewLayout->setSpacing(0);
     m_importTitleItem->setLayout(titleViewLayout);
 
     //已导入
@@ -227,13 +254,7 @@ void ImportTimeLineView::initTimeLineViewWidget()
     DFontSizeManager::instance()->bind(m_importLabel, DFontSizeManager::T3, QFont::Normal);
     QFont ft3 = DFontSizeManager::instance()->get(DFontSizeManager::T3);
     ft3.setFamily("Noto Sans CJK SC");
-
-    //bug76892藏语占用更大高度
-    if (QLocale::system().language() == QLocale::Tibetan) {
-        m_importLabel->setFixedHeight(TIMELINE_TITLEHEIGHT + 25);
-    } else {
-        m_importLabel->setFixedHeight(TIMELINE_TITLEHEIGHT);
-    }
+    m_importLabel->setContentsMargins(0, 0, 0, 0);
     m_importLabel->setFont(ft3);
 
     hImportLayout->addStretch(1);
@@ -242,6 +263,7 @@ void ImportTimeLineView::initTimeLineViewWidget()
 
     // 已导入下的时间和计数
     QHBoxLayout *hDateNumLayout = new QHBoxLayout();
+    hDateNumLayout->setContentsMargins(0, TITLE_LINE_SPACING, 0, 0);
     m_dateNumCheckBox = new DCheckBox();
     connect(m_dateNumCheckBox, &DCheckBox::clicked, this, &ImportTimeLineView::onCheckBoxClicked);
     hDateNumLayout->addWidget(m_dateNumCheckBox);
@@ -249,13 +271,13 @@ void ImportTimeLineView::initTimeLineViewWidget()
     QFont ft6 = DFontSizeManager::instance()->get(DFontSizeManager::T6);
     ft6.setFamily("Noto Sans CJK SC");
 
-    m_dateNumCheckBox->setFixedHeight(TIMELINE_TITLEHEIGHT);
     m_dateNumCheckBox->setFont(ft6);
+    m_dateNumCheckBox->setContentsMargins(0, 0, 0, 0);
 
     m_dateNumLabel = new DLabel();
-    m_dateNumLabel->setFixedHeight(TIMELINE_TITLEHEIGHT);
     DFontSizeManager::instance()->bind(m_dateNumLabel, DFontSizeManager::T6, QFont::Medium);
     m_dateNumLabel->setFont(ft6);
+    m_dateNumLabel->setContentsMargins(0, 0, 0, 0);
     hDateNumLayout->addWidget(m_dateNumLabel);
 
     connect(m_importTimeLineListView, &ThumbnailListView::sigShowCheckBox, this, &ImportTimeLineView::onShowCheckBox);
@@ -272,7 +294,7 @@ void ImportTimeLineView::initTimeLineViewWidget()
 
     m_importTitleItem->setAutoFillBackground(true);
     m_importTitleItem->setContentsMargins(0, 0, 0, 0);
-    m_importTitleItem->setGeometry(0, 0, this->width() - 15, SUSPENSION_WIDGET_HEIGHT);
+    applyHeights();
     qDebug() << "ImportTimeLineView::initTimeLineViewWidget - Function exit";
 }
 
@@ -369,8 +391,8 @@ void ImportTimeLineView::addTimelineLayout()
             DBImgInfo info;
             info.itemType = ItemTypeBlank;
             info.imgWidth = m_importTimeLineListView->width();
-            m_importTimeLineListView->m_blankItemHeight = SUSPENSION_WIDGET_HEIGHT;
-            info.imgHeight = SUSPENSION_WIDGET_HEIGHT;
+            m_importTimeLineListView->m_blankItemHeight = qMax(m_suspensionHeight - ITEM_SPACING_COMPENSATION, TIMELINE_TITLEHEIGHT);
+            info.imgHeight = qMax(m_suspensionHeight - ITEM_SPACING_COMPENSATION, TIMELINE_TITLEHEIGHT);
             info.date = date;
             info.num = num;
             importList.append(info);
@@ -379,7 +401,7 @@ void ImportTimeLineView::addTimelineLayout()
             DBImgInfo info;
             info.itemType = ItemTypeImportTimeLineTitle;
             info.imgWidth = this->width();
-            info.imgHeight = 40;
+            info.imgHeight = m_timelineTitleHeight;
             info.date = date;
             info.num = num;
             importList.append(info);
@@ -454,18 +476,14 @@ void ImportTimeLineView::slotTimeLineDataAndNum(QString data, QString num, QStri
 
 void ImportTimeLineView::resizeEvent(QResizeEvent *ev)
 {
-    // qDebug() << "ImportTimeLineView::resizeEvent - Function entry, new size:" << ev->size();
     Q_UNUSED(ev);
     updateSize();
-    // qDebug() << "ImportTimeLineView::resizeEvent - Function exit";
 }
 
 void ImportTimeLineView::showEvent(QShowEvent *ev)
 {
-    // qDebug() << "ImportTimeLineView::showEvent - Function entry";
     Q_UNUSED(ev);
     updateSize();
-    // qDebug() << "ImportTimeLineView::showEvent - Function exit";
 }
 
 void ImportTimeLineView::dragEnterEvent(QDragEnterEvent *e)

--- a/src/src/widgets/importtimelineview/importtimelineview.h
+++ b/src/src/widgets/importtimelineview/importtimelineview.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -70,6 +70,7 @@ private slots:
      * 调整已导入界面的整体大小
      */
     void updateSize();
+    void applyHeights();
     void onCheckBoxClicked();
     //筛选显示，当先列表中内容为无结果
     void slotNoPicOrNoVideo(bool isNoResult);
@@ -80,7 +81,6 @@ signals:
     //筛选显示图片或者视频，无结果时
     void sigNoPicOrNoVideo(bool isNoResult);//1050
 public:
-    const static int title_HEIGHT = 87;
 private:
     QLayout *m_mainLayout;
     QList<QDateTime> m_timelines;
@@ -102,6 +102,8 @@ private:
     bool m_ctrlPress;
 
     QmlWidget *m_qquickContainer;
+    int m_suspensionHeight = 0;
+    int m_timelineTitleHeight = 0;
 };
 
 #endif // IMPORTTIMELINEVIEW_H

--- a/src/src/widgets/thumbnail/timelinedatewidget.cpp
+++ b/src/src/widgets/thumbnail/timelinedatewidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,25 +6,38 @@
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QFontMetrics>
 
 #include <DFontSizeManager>
 #include <dpalettehelper.h>
 #include <QDebug>
 
+static const int CONTROL_TEXT_PAD = 6;
+static const int TITLE_LINE_SPACING = 4;
+static const int TITLE_TOP_PAD = 10;
+static const int IMPORT_TIMELINE_TOP_PAD = 8;
+static const int TIMELINE_TITLEHEIGHT = 36;
+
 TimeLineDateWidget::TimeLineDateWidget(QStandardItem *item, const QString &time, const QString &num)
     :  m_chooseBtn(nullptr), m_pDate(nullptr), m_pNumCheckBox(nullptr), m_currentItem(item)
 {
     qDebug() << "Creating TimeLineDateWidget - time:" << time << "num:" << num;
-    this->setContentsMargins(0, 10, 0, 0);
-    this->setFixedHeight(90);
+    this->setContentsMargins(0, 0, 0, 0);
+
     //时间线日期
     m_pDate = new DLabel(this);
     DFontSizeManager::instance()->bind(m_pDate, DFontSizeManager::T3, QFont::DemiBold);
     QFont ft1 = DFontSizeManager::instance()->get(DFontSizeManager::T3);
     ft1.setFamily("Noto Sans CJK SC");
     m_pDate->setFont(ft1);
+    m_pDate->setContentsMargins(0, 0, 0, 0);
     m_pDate->setText(time);
-    qDebug() << "Created date label with text:" << time;
+    int dateH = QFontMetrics(ft1).tightBoundingRect("Ayjg").height();
+    int dateFixedH = dateH + CONTROL_TEXT_PAD;
+    // bug76892 藏语占用更大高度
+    if (QLocale::system().language() == QLocale::Tibetan)
+        dateFixedH = qMax(dateFixedH, TIMELINE_TITLEHEIGHT + 25);
+    m_pDate->setFixedHeight(dateFixedH);
 
     //数量
     m_pNumCheckBox = new DCheckBox(this);
@@ -34,13 +47,17 @@ TimeLineDateWidget::TimeLineDateWidget(QStandardItem *item, const QString &time,
     ft2.setFamily("Noto Sans CJK SC");
 
     m_pNumCheckBox->setFont(ft2);
+    m_pNumCheckBox->setContentsMargins(0, 0, 0, 0);
     m_pNumCheckBox->setText(num);
-    qDebug() << "Created number checkbox with text:" << num;
+    int numH = QFontMetrics(ft2).tightBoundingRect("Ayjg").height();
+    m_pNumCheckBox->setFixedHeight(numH + CONTROL_TEXT_PAD);
 
     m_pNum = new DLabel(this);
     DFontSizeManager::instance()->bind(m_pNum, DFontSizeManager::T6, QFont::Normal);
     m_pNum->setFont(ft2);
+    m_pNum->setContentsMargins(0, 0, 0, 0);
     m_pNum->setText(num);
+    m_pNum->setFixedHeight(numH + CONTROL_TEXT_PAD);
 
     onShowCheckBox(false);
 
@@ -57,7 +74,7 @@ TimeLineDateWidget::TimeLineDateWidget(QStandardItem *item, const QString &time,
     m_pbtn->setFocusPolicy(Qt::NoFocus);
 
     QHBoxLayout *NumandBtnLayout = new QHBoxLayout();
-    NumandBtnLayout->setContentsMargins(0, 0, 0, 0);
+    NumandBtnLayout->setContentsMargins(0, TITLE_LINE_SPACING, 0, 0);
     NumandBtnLayout->addWidget(m_pNumCheckBox);
     NumandBtnLayout->addWidget(m_pNum);
     NumandBtnLayout->addStretch();
@@ -65,10 +82,11 @@ TimeLineDateWidget::TimeLineDateWidget(QStandardItem *item, const QString &time,
     NumandBtnLayout->addWidget(m_chooseBtn);
 
     QVBoxLayout *TitleViewLayout = new QVBoxLayout(this);
-    TitleViewLayout->setContentsMargins(6, 0, 23, 0);
+    TitleViewLayout->setContentsMargins(6, TITLE_TOP_PAD, 23, 0);
+    TitleViewLayout->setSpacing(0);
     TitleViewLayout->addWidget(m_pDate);
-    TitleViewLayout->addStretch();
     TitleViewLayout->addLayout(NumandBtnLayout);
+    TitleViewLayout->addStretch();
     this->setLayout(TitleViewLayout);
 
     onThemeChanged(DGuiApplicationHelper::instance()->themeType());
@@ -145,7 +163,6 @@ importTimeLineDateWidget::importTimeLineDateWidget(QStandardItem *item, const QS
 {
     qDebug() << "Creating importTimeLineDateWidget - time:" << time << "num:" << num;
     this->setContentsMargins(6, 0, 0, 0);
-    this->setFixedHeight(35);
 
     //时间+照片数量
     m_pDateandNumCheckBox = new DCheckBox(this);
@@ -156,12 +173,14 @@ importTimeLineDateWidget::importTimeLineDateWidget(QStandardItem *item, const QS
     m_pDateandNumCheckBox->setFont(ft1);
     QString tempTimeAndNumber = time + " " + num;
     m_pDateandNumCheckBox->setText(tempTimeAndNumber);
-    qDebug() << "Created date and number checkbox with text:" << tempTimeAndNumber;
+    int dateNumH = QFontMetrics(ft1).tightBoundingRect("Ayjg").height();
+    m_pDateandNumCheckBox->setFixedHeight(dateNumH + CONTROL_TEXT_PAD);
 
     m_pDateandNum = new DLabel(this);
     DFontSizeManager::instance()->bind(m_pDateandNum, DFontSizeManager::T6, QFont::Normal);
     m_pDateandNum->setFont(ft1);
     m_pDateandNum->setText(tempTimeAndNumber);
+    m_pDateandNum->setFixedHeight(dateNumH + CONTROL_TEXT_PAD);
 
     onShowCheckBox(false);
 
@@ -179,8 +198,9 @@ importTimeLineDateWidget::importTimeLineDateWidget(QStandardItem *item, const QS
     m_pbtn->setFocusPolicy(Qt::NoFocus);
 
     //开始布局
+    // 顶部边距8px为与上一时间段图片的间距，底部通过m_timelineTitleHeight控制
     QHBoxLayout *TitleViewLayout = new QHBoxLayout(this);
-    TitleViewLayout->setContentsMargins(0, 0, 25, 0);
+    TitleViewLayout->setContentsMargins(0, IMPORT_TIMELINE_TOP_PAD, 25, 0);
     TitleViewLayout->addWidget(m_pDateandNumCheckBox);
     TitleViewLayout->addWidget(m_pDateandNum);
     TitleViewLayout->addStretch();

--- a/src/src/widgets/timelineview/timelineview.cpp
+++ b/src/src/widgets/timelineview/timelineview.cpp
@@ -11,22 +11,24 @@
 #include <QScroller>
 #include <QMimeData>
 #include <QGraphicsOpacityEffect>
+#include <QFontMetrics>
+#include <QGuiApplication>
 #include <QDebug>
 
 #include <DPushButton>
 #include <DTableView>
 #include <DPaletteHelper>
 #include <DCheckBox>
+#include <DFontSizeManager>
 #include <DHiDPIHelper>
 
-namespace  {
-const int VIEW_IMPORT = 0;
-const int VIEW_TIMELINE = 1;
-const int VIEW_SEARCH = 2;
-const int TITLEHEIGHT = 0;
-const int TIMELINE_TITLEHEIGHT = 36;
-const int SUSPENSION_WIDGET_HEIGHT = 87;//悬浮控件高度
-} //namespace
+static const int TITLEHEIGHT = 0;
+static const int TIMELINE_TITLEHEIGHT = 36;
+static const int TITLE_TOP_PAD = 10;
+static const int TITLE_BOTTOM_PAD = 5;
+static const int TITLE_LINE_SPACING = 4;
+static const int CONTROL_TEXT_PAD = 6;
+static const int ITEM_SPACING_COMPENSATION = 4; // 补偿QListView::spacing
 
 TimeLineView::TimeLineView(QmlWidget *parent)
     : m_mainLayout(nullptr)
@@ -61,6 +63,7 @@ void TimeLineView::initConnections()
 {
     qDebug() << "TimeLineView::themeChangeSlot - Entry";
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &TimeLineView::themeChangeSlot);
+    connect(qApp, &QGuiApplication::fontChanged, this, &TimeLineView::updateSize);
 }
 
 void TimeLineView::themeChangeSlot(DGuiApplicationHelper::ColorType themeType)
@@ -139,7 +142,8 @@ void TimeLineView::initTimeLineViewWidget()
     m_dateNumItemWidget = new DWidget(m_timeLineViewWidget);
     m_dateNumItemWidget->setFocusPolicy(Qt::ClickFocus);
     QVBoxLayout *titleViewLayout = new QVBoxLayout();
-    titleViewLayout->setContentsMargins(18, 10, 0, 0);
+    titleViewLayout->setContentsMargins(18, TITLE_TOP_PAD, 0, 0);
+    titleViewLayout->setSpacing(0);
     m_dateNumItemWidget->setLayout(titleViewLayout);
 
     //时间线
@@ -149,14 +153,7 @@ void TimeLineView::initTimeLineViewWidget()
     DFontSizeManager::instance()->bind(m_dateLabel, DFontSizeManager::T3, QFont::Normal);
     QFont ft3 = DFontSizeManager::instance()->get(DFontSizeManager::T3);
     ft3.setFamily("Noto Sans CJK SC");
-
-    //bug76892藏语占用更大高度
-    if (QLocale::system().language() == QLocale::Tibetan) {
-        m_dateLabel->setFixedHeight(TIMELINE_TITLEHEIGHT + 25);
-        qDebug() << "Setting Tibetan language specific height";
-    } else {
-        m_dateLabel->setFixedHeight(TIMELINE_TITLEHEIGHT);
-    }
+    m_dateLabel->setContentsMargins(0, 0, 0, 0);
     m_dateLabel->setFont(ft3);
 
     hDateLayout->addStretch(1);
@@ -165,6 +162,7 @@ void TimeLineView::initTimeLineViewWidget()
 
     //时间线下的计数
     QHBoxLayout *hNumLayout = new QHBoxLayout();
+    hNumLayout->setContentsMargins(0, TITLE_LINE_SPACING, 0, 0);
     m_numCheckBox = new DCheckBox();
     connect(m_numCheckBox, &DCheckBox::clicked, this, &TimeLineView::onCheckBoxClicked);
     hNumLayout->addWidget(m_numCheckBox);
@@ -172,13 +170,13 @@ void TimeLineView::initTimeLineViewWidget()
     QFont ft6 = DFontSizeManager::instance()->get(DFontSizeManager::T6);
     ft6.setFamily("Noto Sans CJK SC");
 
-    m_numCheckBox->setFixedHeight(TIMELINE_TITLEHEIGHT);
     m_numCheckBox->setFont(ft6);
+    m_numCheckBox->setContentsMargins(0, 0, 0, 0);
 
     m_numLabel = new DLabel();
-    m_numLabel->setFixedHeight(TIMELINE_TITLEHEIGHT);
     DFontSizeManager::instance()->bind(m_numLabel, DFontSizeManager::T6, QFont::Normal);
     m_numLabel->setFont(ft6);
+    m_numLabel->setContentsMargins(0, 0, 0, 0);
     hNumLayout->addWidget(m_numLabel);
 
     connect(m_timeLineThumbnailListView, &ThumbnailListView::sigShowCheckBox, this, &TimeLineView::onShowCheckBox);
@@ -195,7 +193,7 @@ void TimeLineView::initTimeLineViewWidget()
 
     m_dateNumItemWidget->setAutoFillBackground(true);
     m_dateNumItemWidget->setContentsMargins(0, 0, 0, 0);
-    m_dateNumItemWidget->setGeometry(0, 0, this->width() - 15, SUSPENSION_WIDGET_HEIGHT);
+    applyHeights();
     qDebug() << "Timeline view widget initialization completed";
 }
 
@@ -328,12 +326,12 @@ void TimeLineView::addTimelineLayout()
             m_numCheckBox->setText(num);
             m_numLabel->setText(num);
 
-            //加空白栏
+            //加空白栏，减去ITEM_SPACING(4)补偿列表spacing
             DBImgInfo info;
             info.itemType = ItemTypeBlank;
             info.imgWidth = m_timeLineThumbnailListView->width();
-            m_timeLineThumbnailListView->m_blankItemHeight = SUSPENSION_WIDGET_HEIGHT;
-            info.imgHeight = SUSPENSION_WIDGET_HEIGHT;
+            m_timeLineThumbnailListView->m_blankItemHeight = qMax(m_suspensionHeight - ITEM_SPACING_COMPENSATION, TIMELINE_TITLEHEIGHT);
+            info.imgHeight = qMax(m_suspensionHeight - ITEM_SPACING_COMPENSATION, TIMELINE_TITLEHEIGHT);
             info.date = date;
             info.num = num;
             importList.append(info);
@@ -342,7 +340,7 @@ void TimeLineView::addTimelineLayout()
             DBImgInfo info;
             info.itemType = ItemTypeTimeLineTitle;
             info.imgWidth = m_timeLineThumbnailListView->width();
-            info.imgHeight = 90;
+            info.imgHeight = m_timelineTitleHeight;
             info.date = date;
             info.num = num;
             importList.append(info);
@@ -422,13 +420,39 @@ void TimeLineView::onCheckBoxClicked()
     qDebug() << "Checkbox clicked - Exit";
 }
 
+void TimeLineView::updateSize()
+{
+    applyHeights();
+}
+
+void TimeLineView::applyHeights()
+{
+    QFont ft3 = DFontSizeManager::instance()->get(DFontSizeManager::T3);
+    ft3.setFamily("Noto Sans CJK SC");
+    QFont ft6 = DFontSizeManager::instance()->get(DFontSizeManager::T6);
+    ft6.setFamily("Noto Sans CJK SC");
+    int dateH = QFontMetrics(ft3).tightBoundingRect("Ayjg").height();
+    int numH = QFontMetrics(ft6).tightBoundingRect("Ayjg").height();
+    int dateLabelH = dateH + CONTROL_TEXT_PAD;
+    // bug76892 藏语占用更大高度
+    if (QLocale::system().language() == QLocale::Tibetan)
+        dateLabelH = qMax(dateLabelH, TIMELINE_TITLEHEIGHT + 25);
+    m_dateLabel->setFixedHeight(dateLabelH);
+    m_numCheckBox->setFixedHeight(numH + CONTROL_TEXT_PAD);
+    m_numLabel->setFixedHeight(numH + CONTROL_TEXT_PAD);
+    m_suspensionHeight = TITLE_TOP_PAD + dateLabelH + TITLE_LINE_SPACING + (numH + CONTROL_TEXT_PAD) + TITLE_BOTTOM_PAD;
+    m_timelineTitleHeight = m_suspensionHeight + ITEM_SPACING_COMPENSATION;
+    m_timeLineThumbnailListView->m_blankItemHeight = qMax(m_suspensionHeight - ITEM_SPACING_COMPENSATION, TIMELINE_TITLEHEIGHT);
+    m_dateNumItemWidget->setGeometry(0, 0, width() - 15, m_suspensionHeight);
+}
+
 void TimeLineView::resizeEvent(QResizeEvent *ev)
 {
     // qDebug() << "Resizing view to width:" << width();
     Q_UNUSED(ev);
     //m_spinner->move(width() / 2 - 20, (height() - 50) / 2 - 20);
     // qDebug() << "Resizing view to width:" << width();
-    m_dateNumItemWidget->setGeometry(0, 0, width() - 15, SUSPENSION_WIDGET_HEIGHT);
+    m_dateNumItemWidget->setGeometry(0, 0, width() - 15, m_suspensionHeight);
 //    m_pStatusBar->setFixedWidth(this->width());
 //    m_pStatusBar->move(0, this->height() - m_pStatusBar->height());
 }

--- a/src/src/widgets/timelineview/timelineview.h
+++ b/src/src/widgets/timelineview/timelineview.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -51,6 +51,8 @@ private:
     void initConnections();
     void addTimelineLayout();
     void initDropDown();
+    void updateSize();
+    void applyHeights();
     void dragEnterEvent(QDragEnterEvent *e) override;
     void dropEvent(QDropEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
@@ -85,6 +87,8 @@ public:
     int m_selPicNum;
 
     QmlWidget *m_qquickContainer;
+    int m_suspensionHeight = 0;
+    int m_timelineTitleHeight = 0;
 };
 
 #endif // TIMELINEVIEW_H


### PR DESCRIPTION
Replace hardcoded title heights with QFontMetrics-based calculations for timeline and imported views, fixing spacing issues when system font size changes. Compensate ITEM_SPACING between blank items and title items to eliminate extra gap below floating title bar.

使用QFontMetrics动态计算时间线标题高度，替代硬编码值，
修复系统字体变化时标题间距异常。补偿列表spacing消除
浮动标题栏下方多余间距。

Log: 动态计算时间线标题高度，修复字体变化时间距异常
PMS: BUG-308673
Influence: 日视图和已导入视图的标题间距现在会随系统字体大小自适应调整

## Summary by Sourcery

Adjust timeline and imported views to derive title and floating header heights from font metrics so layouts adapt to system font changes and remove extra gaps.

Bug Fixes:
- Fix incorrect spacing and clipping of timeline titles when system font size or language changes by basing heights on QFontMetrics and compensating list item spacing.

Enhancements:
- Unify dynamic height calculations for timeline headers and blank items, including Tibetan language handling, and clean up hardcoded geometry constants and margins.