### PR TITLE
fix(view): fix unable to open image already imported via main menu

### DIFF
--- a/src/qml/PreviewImageViewer/MainStack.qml
+++ b/src/qml/PreviewImageViewer/MainStack.qml
@@ -26,23 +26,23 @@ FadeInoutAnimation {
         }
     }
 
-    // 设置当前使用的图片源
+    // 设置当前使用的图片源，返回目录下的图片列表供调用方复用
     function setSourcePath(path) {
-        if (FileControl.isCurrentWatcherDir(path)) {
-            // 更新当前文件路径
+        if (FileControl.isCurrentWatcherDir(path)
+                && GControl.globalModel.containsImagePath(path)) {
             GControl.currentSource = path;
-        } else {
-            var sourcePaths = FileControl.getDirImagePath(path);
-            if (sourcePaths.length > 0) {
-                GControl.setImageFiles(sourcePaths, path);
-                // 记录当前读取的图片信息
-                FileControl.resetImageFiles(sourcePaths);
-                console.log("Load image info", path);
-                switchImageView();
-            } else {
-                switchOpenImage();
-            }
+            return GControl.globalModel.imageUrlStrings();
         }
+        let sourcePaths = FileControl.getDirImagePath(path);
+        if (sourcePaths.length > 0) {
+            GControl.setImageFiles(sourcePaths, path);
+            // 记录当前读取的图片信息
+            FileControl.resetImageFiles(sourcePaths);
+            switchImageView();
+        } else {
+            switchOpenImage();
+        }
+        return sourcePaths;
     }
 
     function switchImageView() {
@@ -128,10 +128,11 @@ FadeInoutAnimation {
                 fileDialog.open();
             }
             onAccepted: {
-                var path = fileDialog.selectedFiles[0]
-                stackView.setSourcePath(path);
-                if (FileControl.isAlbum() && GControl.currentSource.toString() !== "") {
-                    var sourcePaths = FileControl.getDirImagePath(path);
+                if (fileDialog.selectedFiles.length === 0)
+                    return;
+                let path = fileDialog.selectedFiles[0];
+                let sourcePaths = stackView.setSourcePath(path);
+                if (FileControl.isAlbum() && sourcePaths.length > 0) {
                     albumControl.importAllImagesAndVideos(sourcePaths);
                 }
             }

--- a/src/src/imagedata/imagesourcemodel.cpp
+++ b/src/src/imagedata/imagesourcemodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -94,7 +94,7 @@ int ImageSourceModel::rowCount(const QModelIndex &parent) const
 /**
    @return 返回传入文件路径 \a file 在数据模型中的索引，无此文件则返回 -1
  */
-int ImageSourceModel::indexForImagePath(const QUrl &file)
+int ImageSourceModel::indexForImagePath(const QUrl &file) const
 {
     // qDebug() << "ImageSourceModel::indexForImagePath - Entry";
     if (file.isEmpty()) {
@@ -104,6 +104,20 @@ int ImageSourceModel::indexForImagePath(const QUrl &file)
 
     // qDebug() << "ImageSourceModel::indexForImagePath - Exit";
     return imageUrlList.indexOf(file);
+}
+
+bool ImageSourceModel::containsImagePath(const QUrl &file) const
+{
+    return !file.isEmpty() && imageUrlList.contains(file);
+}
+
+QStringList ImageSourceModel::imageUrlStrings() const
+{
+    QStringList result;
+    result.reserve(imageUrlList.size());
+    for (const QUrl &url : imageUrlList)
+        result << url.toString();
+    return result;
 }
 
 /**

--- a/src/src/imagedata/imagesourcemodel.h
+++ b/src/src/imagedata/imagesourcemodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,7 +23,9 @@ public:
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    Q_INVOKABLE int indexForImagePath(const QUrl &file);
+    Q_INVOKABLE int indexForImagePath(const QUrl &file) const;
+    Q_INVOKABLE bool containsImagePath(const QUrl &file) const;
+    Q_INVOKABLE QStringList imageUrlStrings() const;
     Q_SLOT void setImageFiles(const QList<QUrl> &files);
     Q_SLOT void removeImage(const QUrl &fileName);
 


### PR DESCRIPTION
Check if target image exists in viewer model before fast-path switch, and skip import when image is already in album database.

通过主菜单打开已导入相册的图片时，检查图片是否在查看器模型中，
若不在则重新加载目录图片；同时跳过已存在图片的重复导入。

Log: 修复已导入图片通过主菜单打开无法跳转的问题
PMS: BUG-361027
Influence: 修复后从主菜单打开任意路径的已导入图片均可正常跳转显示，
不再误报"照片/视频已存在"。

## Summary by Sourcery

Ensure images opened from the main menu correctly display in the preview viewer, even when already imported into an album.

Bug Fixes:
- Fix failure to switch to images opened from the main menu when they are already present in the viewer model.
- Avoid re-importing images into albums when opening files from the main menu if they already exist in the album database.