### PR TITLE
fix(album): refresh album name in context menu after rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ build
 .specstory
 .promptx/
 .spec-workflow/
+.claude/
+.trellis/
+AGENTS.md

--- a/src/qml/SideBar/SideBarItemDelegate.qml
+++ b/src/qml/SideBar/SideBarItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -158,8 +158,10 @@ ItemDelegate {
         if (keyLineEdit.text !== "" && albumControl.renameAlbum(albumControl.getAllCustomAlbumId()[index], keyLineEdit.text)) {
             songName.text = keyLineEdit.text
 
-            // 通知自定义相册视图刷新相册名称
+            // Notify custom album view to refresh album name
             GStatus.sigCustomAlbumNameChaged(GStatus.currentCustomAlbumUId, songName.text)
+            // Refresh album list in context menu
+            GStatus.albumChangeList = !GStatus.albumChangeList
         }
     }
     function switchToPrevious(){


### PR DESCRIPTION
Toggle GStatus.albumChangeList on album rename to force QML property binding re-evaluation in the "Add to album" submenu.

重命名相册后切换 GStatus.albumChangeList，强制 QML 属性绑定
重新求值，使右键"添加到相册"子菜单显示更新后的名称。

Log: 修复重命名相册后右键菜单仍显示旧名的问题
PMS: BUG-321395
Influence: 重命名相册后，右键"添加到相册"菜单中的相册名称会正确更新为新名称。