### PR TITLE
fix(album): remove anti-double-click and fix right view not refreshing

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -428,9 +428,13 @@ void AlbumView::onCreateNewAlbumFromDialog(const QString &newalbumname, int UID)
     }
 
     m_pLeftListView->onUpdateLeftListview();
-    //清除其他已选中的项
-    QModelIndex index2;
-    emit m_pLeftListView->m_pCustomizeListView->pressed(index2);
+    // 同步AlbumView状态到新创建的相册，确保右侧视图显示正确
+    m_currentAlbum = newalbumname;
+    m_currentUID = UID;
+    m_currentType = COMMON_STR_CUSTOM;
+    m_currentItemType = ablumType;
+    m_pLeftListView->setFocusToCustomizeView();
+    updateRightView();
 }
 
 void AlbumView::onCreateNewAlbumFrom(const QString &albumname, int UID)

--- a/src/album/albumview/leftlistview.cpp
+++ b/src/album/albumview/leftlistview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -763,6 +763,13 @@ QString LeftListView::getItemCurrentType()
 int LeftListView::getItemDataType()
 {
     return  m_ItemCurrentDataType;
+}
+
+void LeftListView::setFocusToCustomizeView()
+{
+    if (m_pCustomizeListView) {
+        m_pCustomizeListView->setFocus();
+    }
 }
 
 void LeftListView::updateAlbumItemsColor()

--- a/src/album/albumview/leftlistview.h
+++ b/src/album/albumview/leftlistview.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,6 +37,7 @@ public:
     void updatePhotoListView();
     void updateAlbumItemsColor();
     void updateCustomizeListView();
+    void setFocusToCustomizeView();
 
 private:
     void initUI();

--- a/src/album/albumview/leftlistwidget.cpp
+++ b/src/album/albumview/leftlistwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -77,13 +77,8 @@ void LeftListWidget::mousePressEvent(QMouseEvent *e)
     QModelIndex index = indexAt(e->pos());
     if (!index.isValid()) {
         emit sigMousePressIsNoValid();
-    }
-
-    //屏蔽双击与重复点击
-    if (!index.isValid() || m_indexLastPress == index.row()) {
         return;
     }
-    m_indexLastPress = index.row();
 
     DListWidget::mousePressEvent(e);
 }
@@ -147,10 +142,5 @@ void LeftListWidget::SaveRename(QPoint p)
 
 void LeftListWidget::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
 {
-    //没有选中项，则重置m_indexLastPress
-    if (selected.indexes().length() == 0) {
-        m_indexLastPress = -1;
-    }
-
     DListWidget::selectionChanged(selected, deselected);
 }

--- a/src/album/albumview/leftlistwidget.h
+++ b/src/album/albumview/leftlistwidget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -40,8 +40,6 @@ signals:
     void sigMouseMoveEvent();
     void sigMouseReleaseEvent(QModelIndex index);
 private:
-    //最近点击item的索引
-    int m_indexLastPress = -1;
 };
 
 #endif  // LEFTLISTWIDGET_H


### PR DESCRIPTION
fix(album): remove anti-double-click and fix right view not refreshing                             
                                         
  Remove row-index-based anti-double-click mechanism in LeftListWidget                               
  that caused valid clicks to be falsely intercepted after list structure                            
  changes (e.g., inserting a new album shifts row numbers). Also fix the                             
  right-side view not refreshing after creating a new album by directly                              
  managing AlbumView state in onCreateNewAlbumFromDialog instead of relying                          
  on an emit pressed(invalidIndex) signal chain with unreliable timing.                              
                                                                                                     
  移除左侧列表防双击机制。原方案使用行号(int)记录最近点击，列表插入新                                
  相册后行号偏移，导致后续点击被错误拦截。同时修复创建新相册后右侧视图不                             
  刷新问题：用直接状态赋值+updateRightView() 替代 emit pressed(invalidIndex)                         
  信号链，消除时序依赖。                                                                             
                                                                                                     
  Changes:                                                                                           
  - leftlistwidget.h: remove m_indexLastPress member                                                 
  - leftlistwidget.cpp: remove anti-double-click check in mousePressEvent                            
                       and reset logic in selectionChanged                                           
  - albumview.cpp: replace signal-chain with direct state management in                              
                   onCreateNewAlbumFromDialog                                                        
                                                                                                     
  Log: 移除防双击机制并修复视图刷新
  Bug: https://pms.uniontech.com/bug-view-251633.html