### PR TITLE
fix: remove redundant blank title from dialog windows

### DIFF
--- a/src/qml/Control/DeleteDialog.qml
+++ b/src/qml/Control/DeleteDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,7 +17,6 @@ DialogWindow {
     id: deleteDialog
     modality: Qt.WindowModal
     flags: Qt.Window | Qt.WindowCloseButtonHint | Qt.WindowStaysOnTopHint
-    title: " "
     visible: false
 
     minimumWidth: 400

--- a/src/qml/Control/ExportDialog.qml
+++ b/src/qml/Control/ExportDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,7 +16,6 @@ DialogWindow {
     id: exportdialog
     modality: Qt.WindowModal
     flags: Qt.Window | Qt.WindowCloseButtonHint | Qt.WindowStaysOnTopHint
-    title: " "
     visible: false
 
     minimumWidth: 400

--- a/src/qml/Control/NewAlbumDialog.qml
+++ b/src/qml/Control/NewAlbumDialog.qml
@@ -18,7 +18,6 @@ DialogWindow {
     id: renamedialog
     modality: Qt.WindowModal
     flags: Qt.Window | Qt.WindowCloseButtonHint | Qt.WindowStaysOnTopHint
-    title: " "
     visible: false
     property bool isChangeView: false
     property bool importSelected: false

--- a/src/qml/Control/RemoveAlbumDialog.qml
+++ b/src/qml/Control/RemoveAlbumDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,7 +14,6 @@ DialogWindow {
     id: deleteDialog
     modality: Qt.WindowModal
     flags: Qt.Window | Qt.WindowCloseButtonHint | Qt.WindowStaysOnTopHint
-    title: " "
     visible: false
 
     minimumWidth: 400


### PR DESCRIPTION
1. Remove `title: " "` from DeleteDialog, ExportDialog, NewAlbumDialog, and RemoveAlbumDialog
2. The blank title override is unnecessary and will cause display issues

Log: Remove redundant blank title property from dialog components

fix: 移除对话框窗口中多余的空白标题

1. 从 DeleteDialog、ExportDialog、NewAlbumDialog、RemoveAlbumDialog 中移除 `title: " "` 属性
2. 空白标题覆盖无实际用途，会导致显示异常

Log: 移除对话框组件中多余的空白标题属性
PMS: BUG-362237

## Summary by Sourcery

Bug Fixes:
- Fix dialog title display issues by no longer overriding titles with a single blank space in DeleteDialog, ExportDialog, NewAlbumDialog, and RemoveAlbumDialog.