### PR TITLE
  fix(album): hide status bar when search returns no results

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -2349,9 +2349,12 @@ void AlbumView::restorePicNum()
 
     int photoCount = 0;
     int videoCount = 0;
-    if (4 == m_pRightStackWidget->currentIndex()) {
-        photoCount = m_pSearchView->m_pThumbnailListView->getAppointTypeItemCount(ItemTypePic);
-        videoCount = m_pSearchView->m_pThumbnailListView->getAppointTypeItemCount(ItemTypeVideo);
+    int viewIndex = m_pRightStackWidget->currentIndex();
+    if (RIGHT_VIEW_SEARCH == viewIndex) {
+        if (m_pSearchView) {
+            photoCount = m_pSearchView->getItemCount(ItemTypePic);
+            videoCount = m_pSearchView->getItemCount(ItemTypeVideo);
+        }
     } else {
         if (COMMON_STR_RECENT_IMPORTED == m_currentAlbum) {
             photoCount = m_pImpTimeLineView->getListView()->getAppointTypeItemCount(ItemTypePic);
@@ -2365,7 +2368,7 @@ void AlbumView::restorePicNum()
         } else if (COMMON_STR_FAVORITES == m_currentAlbum) {
             photoCount = m_favoriteThumbnailList->getAppointTypeItemCount(ItemTypePic);
             videoCount = m_favoriteThumbnailList->getAppointTypeItemCount(ItemTypeVideo);
-        } else if (RIGHT_VIEW_PHONE == m_pRightStackWidget->currentIndex()) {
+        } else if (RIGHT_VIEW_PHONE == viewIndex) {
             photoCount = m_pRightPhoneThumbnailList->getAppointTypeItemCount(ItemTypePic);
             videoCount = m_pRightPhoneThumbnailList->getAppointTypeItemCount(ItemTypeVideo);
         } else {
@@ -2380,6 +2383,12 @@ void AlbumView::restorePicNum()
     }
 
     m_pStatusBar->resetUnselectedStatue(photoCount, videoCount);
+    if (RIGHT_VIEW_SEARCH == viewIndex) {
+        bool shouldBeVisible = m_pSearchView && m_pSearchView->hasSearchResults();
+        if (m_pStatusBar->isVisible() != shouldBeVisible) {
+            m_pStatusBar->setVisible(shouldBeVisible);
+        }
+    }
 }
 
 void AlbumView::paintEvent(QPaintEvent *event)

--- a/src/album/allpicview/allpicview.cpp
+++ b/src/album/allpicview/allpicview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -396,14 +396,24 @@ void AllPicView::restorePicNum()
 {
     int photoCount = 0;
     int videoCount = 0;
-    if (VIEW_ALLPICS == m_pStackedWidget->currentIndex()) {
+    const int viewIndex = m_pStackedWidget->currentIndex();
+    if (VIEW_ALLPICS == viewIndex) {
         photoCount = m_pThumbnailListView->getAppointTypeItemCount(ItemTypePic);
         videoCount = m_pThumbnailListView->getAppointTypeItemCount(ItemTypeVideo);
-    } else if (VIEW_SEARCH == m_pStackedWidget->currentIndex()) {
-        photoCount = m_pSearchView->m_pThumbnailListView->getAppointTypeItemCount(ItemTypePic);
-        videoCount = m_pSearchView->m_pThumbnailListView->getAppointTypeItemCount(ItemTypeVideo);
+    } else if (VIEW_SEARCH == viewIndex) {
+        if (m_pSearchView) {
+            photoCount = m_pSearchView->getItemCount(ItemTypePic);
+            videoCount = m_pSearchView->getItemCount(ItemTypeVideo);
+        }
     }
     m_pStatusBar->resetUnselectedStatue(photoCount, videoCount);
+    bool shouldBeVisible = true;
+    if (VIEW_SEARCH == viewIndex) {
+        shouldBeVisible = m_pSearchView && m_pSearchView->hasSearchResults();
+    }
+    if (m_pStatusBar->isVisible() != shouldBeVisible) {
+        m_pStatusBar->setVisible(shouldBeVisible);
+    }
 }
 
 void AllPicView::onKeyDelete()

--- a/src/album/searchview/searchview.cpp
+++ b/src/album/searchview/searchview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -239,6 +239,19 @@ void SearchView::improtSearchResultsIntoThumbnailView(QString s, const QString &
         m_searchPicNum = 0;
         m_stackWidget->setCurrentIndex(0);
     }
+}
+
+bool SearchView::hasSearchResults() const
+{
+    return m_searchPicNum > 0;
+}
+
+int SearchView::getItemCount(ItemType type) const
+{
+    if (m_pThumbnailListView) {
+        return m_pThumbnailListView->getAppointTypeItemCount(type);
+    }
+    return 0;
 }
 
 void SearchView::onSlideShowBtnClicked()

--- a/src/album/searchview/searchview.h
+++ b/src/album/searchview/searchview.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -41,6 +41,8 @@ class SearchView : public QWidget
 public:
     SearchView();
     void improtSearchResultsIntoThumbnailView(QString s, const QString &album, int UID, const QString& className);
+    bool hasSearchResults() const;
+    int getItemCount(ItemType type) const;
 
 public slots:
     void onSlideShowBtnClicked();

--- a/src/album/timelineview/timelineview.cpp
+++ b/src/album/timelineview/timelineview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -605,14 +605,24 @@ void TimeLineView::restorePicNum()
 {
     int photoCount = 0;
     int videoCount = 0;
-    if (VIEW_TIMELINE == m_pStackedWidget->currentIndex()) {
+    const int viewIndex = m_pStackedWidget->currentIndex();
+    if (VIEW_TIMELINE == viewIndex) {
         photoCount = m_timeLineThumbnailListView->getAppointTypeItemCount(ItemTypePic);
         videoCount = m_timeLineThumbnailListView->getAppointTypeItemCount(ItemTypeVideo);
-    } else if (VIEW_SEARCH == m_pStackedWidget->currentIndex()) {
-        photoCount = pSearchView->m_pThumbnailListView->getAppointTypeItemCount(ItemTypePic);
-        videoCount = pSearchView->m_pThumbnailListView->getAppointTypeItemCount(ItemTypeVideo);
+    } else if (VIEW_SEARCH == viewIndex) {
+        if (pSearchView) {
+            photoCount = pSearchView->getItemCount(ItemTypePic);
+            videoCount = pSearchView->getItemCount(ItemTypeVideo);
+        }
     }
     m_pStatusBar->resetUnselectedStatue(photoCount, videoCount);
+    bool shouldBeVisible = true;
+    if (VIEW_SEARCH == viewIndex) {
+        shouldBeVisible = pSearchView && pSearchView->hasSearchResults();
+    }
+    if (m_pStatusBar->isVisible() != shouldBeVisible) {
+        m_pStatusBar->setVisible(shouldBeVisible);
+    }
 }
 
 void TimeLineView::onKeyDelete()


### PR DESCRIPTION
- Add visibility control in restorePicNum() for all three views
  - Use m_searchPicNum to detect empty search results
  - Hide status bar (photo count + slider) when no search results found
  - Restore status bar visibility when search results exist

  修复(album): 搜索无结果时隐藏底部状态栏

  - 在三个视图的 restorePicNum() 中添加状态栏可见性控制
  - 使用 m_searchPicNum 判断搜索结果是否为空
  - 搜索无结果时隐藏项目数量标签和缩略图滑动条
  - 搜索有结果时恢复正常显示

  Log: 修复搜索无结果时底部仍显示项目数量和滑动条的问题，通过 m_searchPicNum 判断搜索结果并在
  restorePicNum() 中控制状态栏可见性
  Bug: https://pms.uniontech.com/bug-view-238691.html

## Summary by Sourcery

Bug Fixes:
- Prevent the photo count and slider status bar from showing when a search returns no results in album, all pictures, and timeline views, while restoring it when results exist.