### PR TITLE
fix(dialog): disable enableInWindowBlendBlur effect in all dialogs

### DIFF
--- a/src/qml/Control/DeleteDialog.qml
+++ b/src/qml/Control/DeleteDialog.qml
@@ -28,7 +28,7 @@ DialogWindow {
     height: 160
 
     header: DialogTitleBar {
-        enableInWindowBlendBlur: true
+        enableInWindowBlendBlur: false
         icon {
             mode: DTK.NormalState
             name: "deepin-album"

--- a/src/qml/Control/VideoInfoDialog.qml
+++ b/src/qml/Control/VideoInfoDialog.qml
@@ -33,7 +33,7 @@ DialogWindow {
     flags: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.WindowStaysOnTopHint
 
     header: DialogTitleBar {
-        enableInWindowBlendBlur: true
+        enableInWindowBlendBlur: false
         content: Loader {
             sourceComponent: Label {
                 anchors.centerIn: parent

--- a/src/qml/PreviewImageViewer/Dialog/RemoveDialog.qml
+++ b/src/qml/PreviewImageViewer/Dialog/RemoveDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,7 +26,7 @@ DialogWindow {
     width: 400
 
     header: DialogTitleBar {
-        enableInWindowBlendBlur: true
+        enableInWindowBlendBlur: false
 
         // 仅保留默认状态，否则 hover 上会有变化效果
         icon {

--- a/src/qml/PreviewImageViewer/InformationDialog/InformationDialog.qml
+++ b/src/qml/PreviewImageViewer/InformationDialog/InformationDialog.qml
@@ -31,7 +31,7 @@ DialogWindow {
     header: DialogTitleBar {
         property string title: fileName
 
-        enableInWindowBlendBlur: true
+        enableInWindowBlendBlur: false
 
         content: Loader {
             sourceComponent: Label {


### PR DESCRIPTION
Set enableInWindowBlendBlur to false in DeleteDialog, VideoInfoDialog, RemoveDialog and InformationDialog for rendering consistency.

将 DeleteDialog、VideoInfoDialog、RemoveDialog 和
InformationDialog 的 enableInWindowBlendBlur 统一设为 false。

Log: 禁用所有对话框的窗口内混合模糊效果
PMS: BUG-362225
Influence: 所有对话框标题栏不再启用窗口内混合模糊，避免在部分环境下出现渲染异常。