### PR TITLE
fix(collection): refresh model data even when view is invisible

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -44,9 +44,9 @@ SwitchViewAnimation {
 
     // 刷新所有项目视图内容
     function flushAllCollectionView() {
+        theView.proxyModel.refresh(filterType)
         if (!visible)
             return
-        theView.proxyModel.refresh(filterType)
         GStatus.selectedPaths = theView.selectedUrls
         getNumLabelText()
         totalTimepScopeTimer.start()


### PR DESCRIPTION
Move proxyModel.refresh() before the visibility guard so that the model is always updated after import, regardless of view state.

修复从外部打开未导入图片后返回合集界面不显示新图片的问题，
将模型刷新移到可见性判断之前，确保导入完成后数据始终更新。

Log: 修复合集界面导入图片后不刷新的问题
PMS: BUG-309453
Influence: 修复从文件管理器使用相册打开未导入图片后，返回合集界面看不到新图片的问题，需切换栏目才能显示。