### PR TITLE
fix(import): prevent duplicate entries and wrong prompts on re-import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ build
 .claude/
 .trellis/
 AGENTS.md
+.codegraph/

--- a/src/src/dbmanager/dbmanager.cpp
+++ b/src/src/dbmanager/dbmanager.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,6 +21,8 @@
 #include <QtConcurrent/QtConcurrent>
 
 //#include "imageengineapi.h"
+
+static const int kSqlBatchSize = 500;
 
 DBManager *DBManager::m_dbManager = nullptr;
 std::once_flag DBManager::instanceFlag;
@@ -84,6 +85,41 @@ const QStringList DBManager::getAllPaths(const ItemType &filterType) const
 
     qDebug() << "DBManager::getAllPaths - Exit, paths:" << paths;
     return paths;
+}
+
+QSet<QString> DBManager::getExistingPaths(const QStringList &paths) const
+{
+    QSet<QString> existing;
+    if (paths.isEmpty())
+        return existing;
+
+    QMutexLocker mutex(&m_dbMutex);
+    m_query->setForwardOnly(true);
+
+    //分批查询，避免超过 SQLITE_MAX_VARIABLE_NUMBER（默认999）
+    for (int batchStart = 0; batchStart < paths.size(); batchStart += kSqlBatchSize) {
+        int batchEnd = std::min(batchStart + kSqlBatchSize, static_cast<int>(paths.size()));
+        int batchCount = batchEnd - batchStart;
+
+        QStringList placeholders;
+        for (int i = 0; i < batchCount; ++i)
+            placeholders << "?";
+
+        QString sql = QString("SELECT DISTINCT FilePath FROM ImageTable3 WHERE PathHash IN (%1)").arg(placeholders.join(","));
+        if (!m_query->prepare(sql))
+            return existing;
+
+        for (int i = batchStart; i < batchEnd; ++i)
+            m_query->addBindValue(LibUnionImage_NameSpace::hashByString(paths.at(i)));
+
+        if (!m_query->exec())
+            return existing;
+
+        while (m_query->next())
+            existing << m_query->value(0).toString();
+    }
+
+    return existing;
 }
 
 const DBImgInfoList DBManager::getAllInfos(int loadCount)const

--- a/src/src/dbmanager/dbmanager.h
+++ b/src/src/dbmanager/dbmanager.h
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -68,6 +67,7 @@ public:
 
     // TableImage
     const QStringList       getAllPaths(const ItemType &filterType = ItemTypeNull) const;
+    QSet<QString>           getExistingPaths(const QStringList &paths) const;
     const DBImgInfoList     getAllInfos(int loadCount = 0) const;
     const DBImgInfoList     getAllInfosSort(const ItemType &filterType = ItemTypeNull) const;
     const DBImgInfoList     getAllInfosByUID(QString UID) const;

--- a/src/src/imageengine/imageenginethread.cpp
+++ b/src/src/imageengine/imageenginethread.cpp
@@ -9,6 +9,7 @@
 #include "albumControl.h"
 #include "utils/classifyutils.h"
 #include <QDebug>
+#include <QSet>
 
 #include <QDirIterator>
 
@@ -99,19 +100,16 @@ bool ImportImagesThread::ifCanStopThread(void *imgobject)
 void ImportImagesThread::runDetail()
 {
     qDebug() << "Starting import process for UID:" << m_UID;
-    //相册中本次导入之前已导入的所有路径
-    DBImgInfoList oldInfos = AlbumControl::instance()->getAllInfosByUID(QString::number(m_UID));
-    QStringList allOldImportedPaths;
-    for (DBImgInfo info : oldInfos) {
-        allOldImportedPaths.push_back(info.filePath);
-    }
+    //相册中本次导入之前已导入的所有路径(查AlbumTable3而非ImageTable3的UID字段)
+    QStringList allOldImportedPathsList = DBManager::instance()->getPathsByAlbum(m_UID);
+    QSet<QString> allOldImportedPaths(allOldImportedPathsList.begin(), allOldImportedPathsList.end());
     qDebug() << "Found" << allOldImportedPaths.size() << "previously imported paths";
 
     QStringList tempPaths;
     QStringList filePaths;
     DBImgInfoList dbInfos;
     //判断是否含有目录
-    for (QString path : m_paths) {
+    for (const QString &path : m_paths) {
         //是目录，向下遍历,得到所有文件
         if (QDir(path).exists()) {
             qDebug() << "Processing directory:" << path;
@@ -127,12 +125,17 @@ void ImportImagesThread::runDetail()
         }
     }
 
+    //针对候选路径查询ImageTable3中已存在的路径，避免全表加载
+    QSet<QString> allDBPaths = DBManager::instance()->getExistingPaths(tempPaths);
+
     //条件过滤
     int noReadCount = 0; //记录已存在于相册中的数量，若全部存在，则不进行导入操作
+    QStringList alreadyInDBPaths; //已存在于数据库中(其他相册)的路径，只需关联不需要重新插入
+    //注意：alreadyInDBPaths 与 allOldImportedPaths 互斥——allOldImportedPaths 命中时已 continue，不会进入下方的 allDBPaths 判断
     int i = 0;
-    for (QString imagePath : tempPaths) {
+    for (const QString &imagePath : tempPaths) {
         i++;
-        //已导入
+        //已导入当前相册
         if (allOldImportedPaths.contains(imagePath)) {
             qDebug() << "Skipping already imported file:" << imagePath;
             m_checkRepeat = true;
@@ -156,22 +159,40 @@ void ImportImagesThread::runDetail()
                 qWarning() << "Skipping file with invalid format:" << imagePath;
                 continue;
             }
-            dbInfo.albumUID = QString::number(m_UID);
-            dbInfos << dbInfo;
 
+            //检查ImageTable3中是否已存在该路径(可能在其他相册UID下)
+            if (allDBPaths.contains(imagePath)) {
+                //已存在，只需关联到当前相册，不重复插入
+                alreadyInDBPaths << imagePath;
+                qDebug() << "File already in DB, linking to album only:" << imagePath;
+            } else {
+                dbInfo.albumUID = QString::number(m_UID);
+                dbInfos << dbInfo;
+                qDebug() << "Added file to import list:" << imagePath;
+            }
             filePaths << imagePath;
-            qDebug() << "Added file to import list:" << imagePath;
         } else {
             qWarning() << "Skipping inaccessible file:" << imagePath;
         }
         emit sigImportProgress(i, tempPaths.size());
     }
 
-    //已全部存在，无需导入
-    if (noReadCount == tempPaths.size() && tempPaths.size() > 0 && m_checkRepeat) {
+    //已全部存在于当前相册，无需导入
+    if (noReadCount == tempPaths.size() && tempPaths.size() > 0) {
         qDebug() << "All files already exist in album, skipping import";
         QStringList urlPaths;
-        for (QString path : tempPaths) {
+        for (const QString &path : tempPaths) {
+            urlPaths.push_back("file://" + path);
+        }
+        emit sigRepeatUrls(urlPaths);
+        return;
+    }
+    //合集/已导入视图下(UID<0)，全部图片已在数据库中(当前相册或其他相册)，显示已导入提示
+    //收藏(UID=0)和自定义相册(UID>0)不应被拦截，需要走正常流程关联到对应相册
+    if (noReadCount + alreadyInDBPaths.size() == tempPaths.size() && tempPaths.size() > 0 && m_checkRepeat && m_UID < 0) {
+        qDebug() << "All files already exist in DB, showing repeat notification";
+        QStringList urlPaths;
+        for (const QString &path : tempPaths) {
             urlPaths.push_back("file://" + path);
         }
         emit sigRepeatUrls(urlPaths);
@@ -196,8 +217,16 @@ void ImportImagesThread::runDetail()
     });
 
     //导入图片数据库ImageTable3
-    qDebug() << "Inserting" << dbInfos.size() << "images into database";
-    DBManager::instance()->insertImgInfos(dbInfos);
+    if (!dbInfos.isEmpty()) {
+        qDebug() << "Inserting" << dbInfos.size() << "images into database";
+        DBManager::instance()->insertImgInfos(dbInfos);
+    }
+
+    //更新已存在于数据库中的图片的UID关联
+    if (!alreadyInDBPaths.isEmpty() && m_UID >= 0) {
+        qDebug() << "Updating UID for" << alreadyInDBPaths.size() << "existing images";
+        DBManager::instance()->addCustomAlbumIdByPaths(m_UID, alreadyInDBPaths);
+    }
 
     //导入图片数据库AlbumTable3
     if (m_UID >= 0) {


### PR DESCRIPTION
ImageTable3 uses composite PK (PathHash, UID), causing REPLACE INTO to insert new rows when same image is imported to a different album. Also getAllInfosByUID used exact match on comma-separated UID field, failing to detect existing album membership.

- Use getPathsByAlbum (AlbumTable3) instead of getAllInfosByUID for reliable album membership check
- Batch-check DB existence via getAllPaths + QSet to avoid duplicate ImageTable3 rows when importing to a different album
- Link existing images via addCustomAlbumIdByPaths instead of re-insert
- Show "already imported" prompt for collection/imported views when all files exist in DB; show "import successful" for cross-album imports

Log: 修复相册重复导入同文件未去重及提示不正确的bug
PMS: BUG-321485
Influence: 修复合集和已导入视图中同一图片显示多次的问题，同时修正重复导入时的提示行为

## Summary by Sourcery

Improve image import logic to avoid duplicate database entries and correct repeat-import notifications across albums.

Bug Fixes:
- Prevent duplicate ImageTable3 entries when re-importing the same image into different albums.
- Ensure album membership is determined from album data rather than comma-separated UID fields in the image table.
- Fix incorrect repeat-import prompts so users see appropriate messages when files already exist in the album or only in other albums.

Enhancements:
- Batch-check existing image paths in the database and reuse them by linking to the current album instead of reinserting.
- Skip database insertion and UID updates when there are no new images to import.