### PR TITLE
chore: update version to 6.0.59

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-album (6.0.59) unstable; urgency=medium
+
+  * fix(import): prevent duplicate entries and wrong prompts on re-import
+  * fix: avoid small blank window before fullscreen slideshow
+  * fix(collection): refresh model data even when view is invisible
+  * fix: restored images should not appear in Favorites
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 28 May 2026 19:44:38 +0800
+
 deepin-album (6.0.58) unstable; urgency=medium
 
   * fix(dialog): disable enableInWindowBlendBlur effect in all dialogs

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.58.1
+  version: 6.0.59.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
- bump version to 6.0.59

Log : bump version to 6.0.59

## Summary by Sourcery

Bug Fixes:
- Update package version to 6.0.59.1 to align with the latest release.