### PR TITLE
fix(qml): fix video time label color not updating on theme switch

### DIFF
--- a/src/qml/Control/ListView/VideoLabel.qml
+++ b/src/qml/Control/ListView/VideoLabel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,11 +17,7 @@ Label {
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignHCenter
 
-    property Palette textColor: Palette {
-        normal: ("black")
-        normalDark: ("white")
-    }
-    color: ColorSelector.textColor
+    color: DTK.themeType === ApplicationHelper.LightType ? "black" : "white"
     background: Rectangle {
         color: DTK.themeType === ApplicationHelper.LightType ? "#EEEEEE" : "#111111"
         radius: 20


### PR DESCRIPTION
Replace Palette/ColorSelector binding with DTK.themeType ternary expression to ensure color updates immediately when theme changes.

修复切换深色主题后视频时间文字颜色未刷新的bug，改用
DTK.themeType三元表达式直接绑定颜色。

Log: 修复深色主题下视频时间看不清
PMS: BUG-318511
Influence: 修复后主题切换时视频时间文字颜色立即更新，无需切换相册。

## Summary by Sourcery

Bug Fixes:
- Fix video time label text color not refreshing correctly after switching between light and dark themes.