### PR TITLE
fix(startup): eliminate dock flicker and content pop-in

### DIFF
--- a/src/deepin-album.qrc
+++ b/src/deepin-album.qrc
@@ -11,6 +11,7 @@
         <file>qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml</file>
         <file>qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml</file>
         <file>qml/ThumbnailImageView/ThumbnailImage.qml</file>
+        <file>qml/ThumbnailImageView/DeferredView.qml</file>
         <file>qml/ThumbnailImageView/NoPictureView.qml</file>
         <file>qml/PreviewImageViewer/MainStack.qml</file>
         <file>qml/PreviewImageViewer/OpenImageWidget.qml</file>

--- a/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
@@ -17,6 +17,14 @@ BaseView {
     property int currentViewIndex: 3
     property int rollingWidth: collecttView.width + 20
 
+    // DayCollection contains heavy QWidget(TimeLineView) that slows window map.
+    // Defer creation via Loader until after map or when switching to day view (index===2).
+    // Once dayReady is true, loading is locked (active implies status===Loader.Ready).
+    property bool dayReady: false
+    // Stash day/month switch requests before Loader is ready, replay in onLoaded.
+    property bool pendingDaySwitch: false
+    property var pendingMonthArgs: undefined
+
     // 通知日视图刷新状态栏提示信息
     signal flushDayViewStatusText()
 
@@ -35,15 +43,14 @@ BaseView {
             if (monthCollection.x < 0)
                 monthCollection.x = rollingWidth
         } else if (index === 2) {
-            if (dayCollection.count === 0)
-                dayCollection.flushView()
-            if (dayCollection.x < 0)
-                dayCollection.x = rollingWidth
-            if (!dayCollection.visible) {
-                dayCollection.visible = true
+            var dayItem = dayCollectionLoader.item
+            if (!dayItem) {
+                // Day view not created yet: stash request, activate Loader, replay onLoaded
+                pendingDaySwitch = true
+                dayCollectionLoader.active = true
+            } else {
+                applyDayViewState(dayItem)
             }
-            dayCollection.unSelectAll()
-            flushDayViewStatusText()
         } else if (index === 3) {
             if (allCollection.x < 0)
                 allCollection.x = rollingWidth
@@ -59,20 +66,34 @@ BaseView {
         }
     }
 
+    // Apply day view state when switching to it (requires dayItem already created).
+    function applyDayViewState(dayItem) {
+        if (dayItem.count === 0)
+            dayItem.flushView()
+        if (dayItem.x < 0)
+            dayItem.x = rollingWidth
+        if (!dayItem.visible) {
+            dayItem.visible = true
+        }
+        dayItem.unSelectAll()
+        flushDayViewStatusText()
+    }
+
     onWidthChanged: {
         if (yearCollection.x < 0)
             yearCollection.x = -rollingWidth
         if (monthCollection.x < 0)
             monthCollection.x = -rollingWidth
-        if (dayCollection.x < 0)
-            dayCollection.x = -rollingWidth
+        if (dayCollectionLoader.item && dayCollectionLoader.item.x < 0)
+            dayCollectionLoader.item.x = -rollingWidth
         if (allCollection.x < 0)
             allCollection.x = -rollingWidth
     }
 
     onVisibleChanged: {
         allCollection.clearSelecteds()
-        dayCollection.unSelectAll()
+        if (dayCollectionLoader.item)
+            dayCollectionLoader.item.unSelectAll()
 
         if (visible) {
             GStatus.selectedPaths = []
@@ -100,13 +121,44 @@ BaseView {
         show: currentViewIndex === 1
     }
 
-    DayCollection {
-        id: dayCollection
-        visible: false
+    // DayCollection deferred/lazy-loaded (heavy QWidget, not involved in startup map).
+    Loader {
+        id: dayCollectionLoader
+        x: 0
         width: collecttView.width
         height: collecttView.height
-        viewType: 2
-        show: currentViewIndex === 2
+        asynchronous: false
+        active: dayReady || currentViewIndex === 2
+        sourceComponent: DayCollection {
+            id: dayCollection
+            visible: false
+            width: collecttView.width
+            height: collecttView.height
+            viewType: 2
+            show: collecttView.currentViewIndex === 2
+        }
+        onLoaded: {
+            // Exclusive visibility: only show when current view is actually day view
+            item.visible = collecttView.currentViewIndex === 2
+            if (collecttView.pendingDaySwitch) {
+                collecttView.pendingDaySwitch = false
+                collecttView.applyDayViewState(item)
+            }
+            if (collecttView.pendingMonthArgs !== undefined) {
+                var args = collecttView.pendingMonthArgs
+                collecttView.pendingMonthArgs = undefined
+                item.scrollToMonth(args.year, args.month)
+            }
+        }
+    }
+
+    // Create DayCollection after map so its embedded QWidget doesn't slow startup.
+    Timer {
+        id: dayDelayTimer
+        interval: 1
+        running: true
+        repeat: false
+        onTriggered: collecttView.dayReady = true
     }
 
     AllCollection {
@@ -135,7 +187,8 @@ BaseView {
         GStatus.currentSwitchType = Album.Types.ScaleInOUt
         setIndex(1)
         allCollection.x = -rollingWidth
-        dayCollection.x = -rollingWidth
+        if (dayCollectionLoader.item)
+            dayCollectionLoader.item.x = -rollingWidth
         monthCollection.scrollToYear(year)
     }
 
@@ -144,12 +197,17 @@ BaseView {
         GStatus.currentSwitchType = Album.Types.ScaleInOUt
         setIndex(2)
         allCollection.x = -rollingWidth
-        dayCollection.scrollToMonth(year, month)
+        var dayItem = dayCollectionLoader.item
+        if (dayItem) {
+            dayItem.scrollToMonth(year, month)
+        } else {
+            // Day view not created yet: stash jump params; setIndex(2) already activated Loader, replay onLoaded
+            pendingMonthArgs = { "year": year, "month": month }
+        }
     }
 
     Component.onCompleted: {
-        // 保证日聚合和所有照片视图互斥显示，以便列表控件全选逻辑只在显示的视图中生效
-        dayCollection.visible = currentViewIndex === 2
+        // dayCollection deferred; its exclusive visibility is set in Loader.onLoaded
         allCollection.visible = currentViewIndex === 3
 
         yearCollection.yearClicked.connect(onYearClicked)

--- a/src/qml/ThumbnailImageView/DeferredView.qml
+++ b/src/qml/ThumbnailImageView/DeferredView.qml
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import org.deepin.album 1.0 as Album
+
+// View Loader deferred until after window map (or when this view becomes current), stays loaded once created.
+// Delay logic unified in one place to avoid repetition across views.
+//   active = ready (after map) || current view is this view
+Loader {
+    // Set to true by host to signal deferral can start (after map).
+    property bool ready: false
+    // The Album.Types.View* type this Loader carries.
+    property int viewType: -1
+
+    anchors.fill: parent
+    asynchronous: false
+    active: ready || GStatus.currentViewType === viewType
+}

--- a/src/qml/ThumbnailImageView/ThumbnailImage.qml
+++ b/src/qml/ThumbnailImageView/ThumbnailImage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,43 +22,100 @@ import "./../"
 //本文件用于替代stackwidget的作用，通过改变global的0-n来切换窗口
 
 Item {
+    id: thumbView
 
-    CollecttionView{
-        id: collecttionView
-        show: GStatus.currentViewType === Album.Types.ViewCollecttion
+    // Window must map quickly: slow map triggers dock launcher timeout, causing icon flicker.
+    // Only default CollecttionView is created sync during engine.load; other 8 views all embed
+    // QWidgets (can't use async Loader), so they're deferred by viewDelayTimer until after map.
+    // interval is minimal (next event loop), just yields current frame to let window map first.
+    property bool delayedViewsReady: false
+    Timer {
+        id: viewDelayTimer
+        interval: 1
+        running: true
+        repeat: false
+        onTriggered: thumbView.delayedViewsReady = true
     }
-    HaveImportedView{
-        show: GStatus.currentViewType === Album.Types.ViewHaveImported
-    }
-    CustomAlbum{
-        show: GStatus.currentViewType === Album.Types.ViewFavorite
-    }
-    RecentlyDeletedView{
-        show: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted
-    }
-    CustomAlbum{
-        show: GStatus.currentViewType === Album.Types.ViewCustomAlbum
-    }
-    SearchView{
-        show: GStatus.currentViewType === Album.Types.ViewSearchResult
-    }
-    DeviceAlbum{
-        show: GStatus.currentViewType === Album.Types.ViewDevice
-    }
-    ClassificationView{
-        id: classificationView
-        show: GStatus.currentViewType === Album.Types.ViewClassification
 
-        onShowClassificationDetail: function(name, className) {
-            // 设置分类详情数据并切换视图
-            classificationDetailView.setClassificationData(name, className)
-            GStatus.currentViewType = Album.Types.ViewClassificationDetail
+    // Default Collection view created sync (active: true) so window map shows real thumbnails
+    // (AllCollection) immediately, eliminating "shell->content" pop-in. Its heavy DayCollection child
+    // is already split into Loader in CollecttionView.qml, keeping this light. Other 8 views still
+    // deferred by viewDelayTimer. If user clicks year/month/day before this view loads, setIndex
+    // would be lost (item is null), so use pendingCollectionIndex to stash and replay onLoaded.
+    property int pendingCollectionIndex: -1
+    Loader {
+        id: collecttionViewLoader
+        anchors.fill: parent
+        asynchronous: false
+        active: true
+        sourceComponent: CollecttionView {
+            id: collecttionView
+            show: GStatus.currentViewType === Album.Types.ViewCollecttion
+        }
+        onLoaded: {
+            if (thumbView.pendingCollectionIndex >= 0) {
+                item.setIndex(thumbView.pendingCollectionIndex)
+                thumbView.pendingCollectionIndex = -1
+            }
         }
     }
-
-    ClassificationDetailView{
-        id: classificationDetailView
-        show: GStatus.currentViewType === Album.Types.ViewClassificationDetail
+    // Other views deferred until after map (or when selected), stay loaded once created.
+    // Delay logic unified in DeferredView, not repeated per view.
+    DeferredView {
+        ready: delayedViewsReady
+        viewType: Album.Types.ViewHaveImported
+        sourceComponent: HaveImportedView { show: GStatus.currentViewType === Album.Types.ViewHaveImported }
+    }
+    DeferredView {
+        ready: delayedViewsReady
+        viewType: Album.Types.ViewFavorite
+        sourceComponent: CustomAlbum { show: GStatus.currentViewType === Album.Types.ViewFavorite }
+    }
+    DeferredView {
+        ready: delayedViewsReady
+        viewType: Album.Types.ViewRecentlyDeleted
+        sourceComponent: RecentlyDeletedView { show: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted }
+    }
+    DeferredView {
+        ready: delayedViewsReady
+        viewType: Album.Types.ViewCustomAlbum
+        sourceComponent: CustomAlbum { show: GStatus.currentViewType === Album.Types.ViewCustomAlbum }
+    }
+    DeferredView {
+        ready: delayedViewsReady
+        viewType: Album.Types.ViewSearchResult
+        sourceComponent: SearchView { show: GStatus.currentViewType === Album.Types.ViewSearchResult }
+    }
+    DeferredView {
+        ready: delayedViewsReady
+        viewType: Album.Types.ViewDevice
+        sourceComponent: DeviceAlbum { show: GStatus.currentViewType === Album.Types.ViewDevice }
+    }
+    DeferredView {
+        id: classificationViewLoader
+        ready: delayedViewsReady
+        viewType: Album.Types.ViewClassification
+        sourceComponent: ClassificationView {
+            id: classificationView
+            show: GStatus.currentViewType === Album.Types.ViewClassification
+            onShowClassificationDetail: function(name, className) {
+                classificationDetailViewLoader.active = true
+                // Loader sync-loads (asynchronous:false); guard against load failure (item null)
+                if (!classificationDetailViewLoader.item)
+                    return
+                classificationDetailViewLoader.item.setClassificationData(name, className)
+                GStatus.currentViewType = Album.Types.ViewClassificationDetail
+            }
+        }
+    }
+    DeferredView {
+        id: classificationDetailViewLoader
+        ready: delayedViewsReady
+        viewType: Album.Types.ViewClassificationDetail
+        sourceComponent: ClassificationDetailView {
+            id: classificationDetailView
+            show: GStatus.currentViewType === Album.Types.ViewClassificationDetail
+        }
     }
 
     EmptyWarningDialog {
@@ -72,7 +129,12 @@ Item {
                 return
             // 点击按钮，动画切换类型设定为翻页滚动
             GStatus.currentSwitchType = Album.Types.FlipScroll
-            collecttionView.setIndex(index)
+            if (collecttionViewLoader.item) {
+                collecttionViewLoader.item.setIndex(index)
+            } else {
+                // View not created yet: stash index, replay onLoaded once ready
+                thumbView.pendingCollectionIndex = index
+            }
         }
     }
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -89,12 +89,13 @@ ApplicationWindow {
     minimumWidth: GStatus.minWidth
     width: FileControl.getlastWidth()
     height: FileControl.getlastHeight()
+    // Bind centered coordinates at declaration time so first frame map is already centered,
+    // avoiding position jump/flicker from mapping at (0,0) then setX/setY in onCompleted.
+    x: Screen.width / 2 - width / 2
+    y: Screen.height / 2 - height / 2
 
     flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
     Component.onCompleted: {
-        setX(screen.width / 2 - width / 2);
-        setY(screen.height / 2 - height / 2);
-
         // 合集-所有项视图延迟刷新，解决其加载时会闪烁显示一张缩略图的问题
         GStatus.currentViewType = Album.Types.ViewCollecttion
         GStatus.currentDeviceName = albumControl.getDeviceName(GStatus.currentDevicePath)

--- a/src/src/imageengine/imagedataservice.cpp
+++ b/src/src/imageengine/imagedataservice.cpp
@@ -346,6 +346,9 @@ void ReadThumbnailManager::readThumbnail()
 {
     qDebug() << "Starting thumbnail read process";
     int sendCounter = 0; //刷新上层界面指示
+    int loadedCount = 0; // Total processed images for first-screen prioritized refresh
+    // Refresh every image on first screen for quick appearance; batch every 5 after to reduce overhead
+    const int kFirstScreenCount = 15;
     runningFlag = true;  //告诉外面加载队列处于激活状态
 
     while (1) {
@@ -365,8 +368,9 @@ void ReadThumbnailManager::readThumbnail()
 
         mutex.unlock();
 
+        loadedCount++;
         sendCounter++;
-        if (sendCounter == 5) { //每加载5张图，就让上层界面主动刷新一次
+        if (loadedCount <= kFirstScreenCount || sendCounter == 5) { // Each image on first screen, then every 5 loaded
             sendCounter = 0;
             emit ImageDataService::instance()->sigeUpdateListview();
         }


### PR DESCRIPTION
Fix startup flicker by splitting delay granularity: sync-create default view so content appears with window, defer heavy DayCollection via Loader, defer 8 non-default views. Extract DeferredView component. Declarative window centering. First-screen thumbnails refresh per-image.

修复启动闪烁:拆分延迟粒度,同步创建默认视图使内容随窗同现,延迟
重量级 DayCollection 和其余 8 个视图。提取 DeferredView 组件。窗口声明式 居中。首屏缩略图逐张刷新。

Log: 修复 dock 闪烁与整窗内容 pop-in
PMS: BUG-357245
Influence: 启动时窗口即显示完整内容,dock 不闪,整窗无明暗跳变,首屏内容
更快。视图切换功能正常。