### PR TITLE
chore: update version to 6.0.60

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-album (6.0.60) unstable; urgency=medium
+
+  * fix(startup): eliminate dock flicker and content pop-in
+  * fix(qml): fix video time label color not updating on theme switch
+  * fix(album): prevent duplicate album names on create and rename
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 04 Jun 2026 21:18:23 +0800
+
 deepin-album (6.0.59) unstable; urgency=medium
 
   * fix(import): prevent duplicate entries and wrong prompts on re-import

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.59.1
+  version: 6.0.60.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
- bump version to 6.0.60

Log : bump version to 6.0.60

## Summary by Sourcery

Build:
- Bump deepin-album package version in linglong.yaml to 6.0.60.1.