### PR TITLE
fix(year-view): use video frame as cover to avoid corrupt image

### DIFF
--- a/src/src/thumbnailload.cpp
+++ b/src/src/thumbnailload.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -806,12 +806,20 @@ QImage CollectionPublisher::createYearImage(const QString &year)
     }
     auto picPath = paths.at(0);
 
-    //TODO: 异常处理：裂图问题
-
-    //加载原图
+    // Fix: year cover may be a video file; use video frame to avoid corrupt image.
     QImage image;
-    QString error;
-    LibUnionImage_NameSpace::loadStaticImageFromFile(picPath, image, error);
+    if (LibUnionImage_NameSpace::isVideo(picPath)) {
+        image = MovieService::instance()->getMovieCover(QUrl::fromLocalFile(picPath));
+    } else {
+        QString error;
+        if (!LibUnionImage_NameSpace::loadStaticImageFromFile(picPath, image, error)) {
+            qWarning() << "Failed to load year cover image:" << picPath << "Error:" << error;
+        }
+    }
+    if (image.isNull()) {
+        qWarning() << "Failed to create year cover image:" << picPath;
+        return image;
+    }
     image = image.scaled(outputWidth, outputHeight, Qt::KeepAspectRatioByExpanding);
 
     return image;


### PR DESCRIPTION
Year cover image may be a video file. Use MovieService to extract video frame instead of loading raw file directly.

年封面可能取到视频文件，使用视频首帧替代直接加载，避免裂图。

Log: 修复年视图封面取到视频文件时裂图问题
PMS: BUG-363169
Influence: 年视图封面不再因视频文件而显示裂图，改用视频首帧作为封面。

## Summary by Sourcery

Bug Fixes:
- Prevent corrupted year-view cover images when the selected cover file is a video by using the video’s cover frame instead of loading it as a static image.