### PR TITLE
feat(view): replace C++ FilterWidget with QML FilterComboBox overlay

### DIFF
--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -34,6 +34,22 @@ BaseView {
             anchors.rightMargin: GStatus.verticalScrollBarWidth
             focus: false
             viewType: Album.Types.WidgetImportedView
+            hideBuiltinFilter: true
+        }
+
+        // QML FilterComboBox overlay, replaces the builtin C++ filter widget
+        FilterComboBox {
+            id: filterCombo
+            anchors {
+                top: timeline.top
+                topMargin: 36
+                right: timeline.right
+                rightMargin: 6
+            }
+            width: 115
+            height: 30
+            currentIndex: timeline.filterType
+            onActivated: timeline.filterType = currentIndex
         }
 
         WidgetScrollBar {

--- a/src/src/qmlWidget.cpp
+++ b/src/src/qmlWidget.cpp
@@ -100,6 +100,27 @@ int QmlWidget::filterType()
     return m_filterType;
 }
 
+void QmlWidget::setHideBuiltinFilter(bool hide)
+{
+    if (m_hideBuiltinFilter == hide)
+        return;
+
+    m_hideBuiltinFilter = hide;
+
+    // Forward to the concrete view (built lazily by initWidget)
+    if (m_view) {
+        if (TimeLineView *view = dynamic_cast<TimeLineView *>(m_view))
+            view->setHideBuiltinFilter(hide);
+        else if (ImportTimeLineView *view = dynamic_cast<ImportTimeLineView *>(m_view))
+            view->setHideBuiltinFilter(hide);
+    }
+}
+
+bool QmlWidget::hideBuiltinFilter() const
+{
+    return m_hideBuiltinFilter;
+}
+
 void QmlWidget::initWidget()
 {
     if (nullptr == m_view) {
@@ -117,6 +138,15 @@ void QmlWidget::initWidget()
         m_view->setAutoFillBackground(true);
         m_view->setVisible(true);
         connectScrollSignals();
+
+        // Replay any hideBuiltinFilter value set before the view existed
+        // (QML may evaluate hideBuiltinFilter before viewType triggers init)
+        if (m_hideBuiltinFilter) {
+            if (TimeLineView *view = dynamic_cast<TimeLineView *>(m_view))
+                view->setHideBuiltinFilter(true);
+            else if (ImportTimeLineView *view = dynamic_cast<ImportTimeLineView *>(m_view))
+                view->setHideBuiltinFilter(true);
+        }
     }
 }
 

--- a/src/src/qmlWidget.h
+++ b/src/src/qmlWidget.h
@@ -36,6 +36,7 @@ class QmlWidget : public QQuickPaintedItem
 
     Q_PROPERTY(int viewType READ viewType WRITE setViewType NOTIFY viewTypeChanged)
     Q_PROPERTY(int filterType READ filterType WRITE setFilterType NOTIFY filterTypeChanged)
+    Q_PROPERTY(bool hideBuiltinFilter READ hideBuiltinFilter WRITE setHideBuiltinFilter)
     Q_PROPERTY(qreal scrollPosition READ scrollPosition NOTIFY scrollPositionChanged)
     Q_PROPERTY(qreal contentRatio READ contentRatio NOTIFY contentRatioChanged)
 public:
@@ -47,6 +48,10 @@ public:
 
     void setFilterType(int filterType);
     int filterType();
+
+    // Hide the builtin C++ filter widget; a QML FilterComboBox overlays it
+    void setHideBuiltinFilter(bool hide);
+    bool hideBuiltinFilter() const;
 
     qreal scrollPosition() const;
     qreal contentRatio() const;
@@ -90,6 +95,7 @@ protected slots:
 private:
     int m_viewType = Types::WidgetViewUnknown; //0:日视图 1:已导入视图
     int m_filterType = Types::All; // 0:所有 1:照片 2:视频
+    bool m_hideBuiltinFilter = false; // hide builtin C++ FilterWidget (QML overlay mode)
     bool m_disableHoverEvent {false}; // 日视图和已导入视图在刷新时，鼠标悬停事件路由不能执行，否则会访问之前已析构的QWidget控件，导致程序崩溃
 };
 

--- a/src/src/widgets/importtimelineview/importtimelineview.cpp
+++ b/src/src/widgets/importtimelineview/importtimelineview.cpp
@@ -168,6 +168,33 @@ void ImportTimeLineView::slotNoPicOrNoVideo(bool isNoResult)
     qDebug() << "No result state changed - Exit";
 }
 
+void ImportTimeLineView::setHideBuiltinFilter(bool hide)
+{
+    if (m_hideBuiltinFilter == hide)
+        return;
+
+    m_hideBuiltinFilter = hide;
+
+    // Toggle the builtin FilterWidget visibility at runtime
+    m_ToolButton->setVisible(!hide);
+
+    // In overlay mode filter changes come from QmlWidget::filterTypeChanged
+    // (written by the QML FilterComboBox); connect it to the existing handler
+    if (hide && m_qquickContainer) {
+        connect(m_qquickContainer, &QmlWidget::filterTypeChanged, this, [this]() {
+            int filterType = m_qquickContainer->filterType();
+            ExpansionPanel::FilteData data;
+            if (filterType == Types::Video)
+                data.type = ItemType::ItemTypeVideo;
+            else if (filterType == Types::Picture)
+                data.type = ItemType::ItemTypePic;
+            else
+                data.type = ItemType::ItemTypeNull;
+            sltCurrentFilterChanged(data);
+        });
+    }
+}
+
 void ImportTimeLineView::sltCurrentFilterChanged(ExpansionPanel::FilteData &data)
 {
     qDebug() << "Filter changed to type:" << data.type;
@@ -193,10 +220,13 @@ void ImportTimeLineView::sltCurrentFilterChanged(ExpansionPanel::FilteData &data
         m_qquickContainer->setFilterType(filterType);
     }
     clearAllSelection();
-    //如果过滤会后数量<=0，则不可用
-    bool hasItems = m_importTimeLineListView->getAppointTypeItemCount(m_ToolButton->getFilteType()) > 0;
-    m_ToolButton->setEnabled(hasItems);
-    m_ToolButton->setVisible(hasItems);
+    // If filtered count <= 0 the filter button is disabled
+    bool hasItems = m_importTimeLineListView->getAppointTypeItemCount(data.type) > 0;
+    // In overlay mode the builtin filter widget stays hidden regardless of item count
+    if (!m_hideBuiltinFilter) {
+        m_ToolButton->setEnabled(hasItems);
+        m_ToolButton->setVisible(hasItems);
+    }
     qDebug() << "Filter applied, items available:" << hasItems;
     m_importTimeLineListView->setFocus();
 }
@@ -286,7 +316,12 @@ void ImportTimeLineView::initTimeLineViewWidget()
     initDropDown();
 
     hDateNumLayout->addStretch(100);
-    hDateNumLayout->addWidget(m_ToolButton);
+    // Builtin FilterWidget is only added when not hidden (QML overlay mode)
+    if (!m_hideBuiltinFilter) {
+        hDateNumLayout->addWidget(m_ToolButton);
+    } else {
+        m_ToolButton->hide();
+    }
 
     titleViewLayout->addLayout(hImportLayout);
     titleViewLayout->addLayout(hDateNumLayout);

--- a/src/src/widgets/importtimelineview/importtimelineview.h
+++ b/src/src/widgets/importtimelineview/importtimelineview.h
@@ -61,6 +61,8 @@ public:
     ThumbnailListView *getListView();
     //tab进入时清除其他所有选中
     void clearAllSelection();
+    // Hide the builtin C++ FilterWidget so a QML FilterComboBox can overlay it
+    void setHideBuiltinFilter(bool hide);
 #if 1
     QStringList selectPaths();
 #endif
@@ -104,6 +106,9 @@ private:
     QmlWidget *m_qquickContainer;
     int m_suspensionHeight = 0;
     int m_timelineTitleHeight = 0;
+    // When true the builtin FilterWidget is hidden and filter changes are
+    // driven by QmlWidget::filterTypeChanged (QML FilterComboBox overlay)
+    bool m_hideBuiltinFilter = false;
 };
 
 #endif // IMPORTTIMELINEVIEW_H

--- a/src/src/widgets/timelineview/timelineview.cpp
+++ b/src/src/widgets/timelineview/timelineview.cpp
@@ -59,6 +59,33 @@ TimeLineView::TimeLineView(QmlWidget *parent)
     qDebug() << "TimeLineView initialization completed";
 }
 
+void TimeLineView::setHideBuiltinFilter(bool hide)
+{
+    if (m_hideBuiltinFilter == hide)
+        return;
+
+    m_hideBuiltinFilter = hide;
+
+    // Toggle the builtin FilterWidget visibility at runtime
+    m_ToolButton->setVisible(!hide);
+
+    // In overlay mode filter changes come from QmlWidget::filterTypeChanged
+    // (written by the QML FilterComboBox); connect it to the existing handler
+    if (hide && m_qquickContainer) {
+        connect(m_qquickContainer, &QmlWidget::filterTypeChanged, this, [this]() {
+            int filterType = m_qquickContainer->filterType();
+            ExpansionPanel::FilteData data;
+            if (filterType == Types::Video)
+                data.type = ItemType::ItemTypeVideo;
+            else if (filterType == Types::Picture)
+                data.type = ItemType::ItemTypePic;
+            else
+                data.type = ItemType::ItemTypeNull;
+            sltCurrentFilterChanged(data);
+        });
+    }
+}
+
 void TimeLineView::initConnections()
 {
     qDebug() << "TimeLineView::themeChangeSlot - Entry";
@@ -185,7 +212,12 @@ void TimeLineView::initTimeLineViewWidget()
     initDropDown();
 
     hNumLayout->addStretch(100);
-    hNumLayout->addWidget(m_ToolButton);
+    // Builtin FilterWidget is only added when not hidden (QML overlay mode)
+    if (!m_hideBuiltinFilter) {
+        hNumLayout->addWidget(m_ToolButton);
+    } else {
+        m_ToolButton->hide();
+    }
 
     titleViewLayout->addLayout(hDateLayout);
     titleViewLayout->addLayout(hNumLayout);
@@ -262,10 +294,13 @@ void TimeLineView::sltCurrentFilterChanged(ExpansionPanel::FilteData &data)
         m_qquickContainer->setFilterType(filterType);
     }
     clearAllSelection();
-    //如果过滤会后数量<=0，则不可用
-    bool hasItems = m_timeLineThumbnailListView->getAppointTypeItemCount(m_ToolButton->getFilteType()) > 0;
-    m_ToolButton->setEnabled(hasItems);
-    m_ToolButton->setVisible(hasItems);
+    // If filtered count <= 0 the filter button is disabled
+    bool hasItems = m_timeLineThumbnailListView->getAppointTypeItemCount(data.type) > 0;
+    // In overlay mode the builtin filter widget stays hidden regardless of item count
+    if (!m_hideBuiltinFilter) {
+        m_ToolButton->setEnabled(hasItems);
+        m_ToolButton->setVisible(hasItems);
+    }
     m_timeLineThumbnailListView->setFocus();
     qDebug() << "Filter changed to type - Exit";
 }

--- a/src/src/widgets/timelineview/timelineview.h
+++ b/src/src/widgets/timelineview/timelineview.h
@@ -33,6 +33,8 @@ public:
     ThumbnailListView *getThumbnailListView();
     //tab进入时清除其他所有选中
     void clearAllSelection();
+    // Hide the builtin C++ FilterWidget so a QML FilterComboBox can overlay it
+    void setHideBuiltinFilter(bool hide);
 
 public slots:
     void on_AddLabel(QString date, QString num);
@@ -89,6 +91,9 @@ public:
     QmlWidget *m_qquickContainer;
     int m_suspensionHeight = 0;
     int m_timelineTitleHeight = 0;
+    // When true the builtin FilterWidget is hidden and filter changes are
+    // driven by QmlWidget::filterTypeChanged (QML FilterComboBox overlay)
+    bool m_hideBuiltinFilter = false;
 };
 
 #endif // TIMELINEVIEW_H


### PR DESCRIPTION
Add hideBuiltinFilter property to QmlWidget to hide the builtin C++ filter widget and let a QML FilterComboBox take over filtering.

在QmlWidget中添加hideBuiltinFilter属性，隐藏C++内置筛选控件，
由QML FilterComboBox覆盖层接管筛选功能。

Log: 用QML FilterComboBox替换C++内置筛选控件
PMS: BUG-365397
Influence: 已导入视图的筛选控件改为QML实现，功能和交互保持一致。