### PR TITLE
feat(view): add QML FilterComboBox overlay to DayCollection

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
@@ -52,6 +52,22 @@ SwitchViewAnimation {
             anchors.rightMargin: GStatus.verticalScrollBarWidth
             focus: false
             viewType: Album.Types.WidgetDayView
+            hideBuiltinFilter: true
+        }
+
+        // QML FilterComboBox overlay, replaces the builtin C++ filter widget
+        FilterComboBox {
+            id: filterCombo
+            anchors {
+                top: timeline.top
+                topMargin: 36
+                right: timeline.right
+                rightMargin: 6
+            }
+            width: 115
+            height: 30
+            currentIndex: timeline.filterType
+            onActivated: timeline.filterType = currentIndex
         }
 
         WidgetScrollBar {


### PR DESCRIPTION
Replace builtin C++ filter widget with QML FilterComboBox in the day timeline view, matching other views.

在日时间线视图中使用QML FilterComboBox替换内置C++过滤控件，
与其他视图保持一致。

Log: 日视图添加QML FilterComboBox
PMS: BUG-365397
Influence: 日时间线视图的过滤控件改为QML实现，与其它视图保持一致。

## Summary by Sourcery

Replace the day timeline view’s built-in C++ filter widget with a QML-based FilterComboBox overlay wired to the existing filter type.

New Features:
- Add a QML FilterComboBox overlay to the day timeline view for selecting the filter type.

Enhancements:
- Disable the built-in filter in the day timeline view so that filtering is consistently handled via QML like other views.