### PR TITLE
fix(view): QML filter overlay change handler

### DIFF
--- a/src/src/widgets/importtimelineview/importtimelineview.cpp
+++ b/src/src/widgets/importtimelineview/importtimelineview.cpp
@@ -179,19 +179,24 @@ void ImportTimeLineView::setHideBuiltinFilter(bool hide)
     m_ToolButton->setVisible(!hide);
 
     // In overlay mode filter changes come from QmlWidget::filterTypeChanged
-    // (written by the QML FilterComboBox); connect it to the existing handler
-    if (hide && m_qquickContainer) {
-        connect(m_qquickContainer, &QmlWidget::filterTypeChanged, this, [this]() {
+    // (written by the QML FilterComboBox). Apply only the side effects the
+    // overlay needs — sltCurrentFilterChanged also drives the builtin button
+    // (count + enable/visible), which is hidden here, so bypass it.
+    if (hide && m_qquickContainer && !m_filterTypeConn) {
+        m_filterTypeConn = connect(m_qquickContainer, &QmlWidget::filterTypeChanged, this, [this]() {
+            ItemType type = ItemType::ItemTypeNull;
             int filterType = m_qquickContainer->filterType();
-            ExpansionPanel::FilteData data;
             if (filterType == Types::Video)
-                data.type = ItemType::ItemTypeVideo;
+                type = ItemType::ItemTypeVideo;
             else if (filterType == Types::Picture)
-                data.type = ItemType::ItemTypePic;
-            else
-                data.type = ItemType::ItemTypeNull;
-            sltCurrentFilterChanged(data);
+                type = ItemType::ItemTypePic;
+            m_importTimeLineListView->showAppointTypeItem(type);
+            clearAllSelection();
+            m_importTimeLineListView->setFocus();
         });
+    } else if (!hide && m_filterTypeConn) {
+        disconnect(m_filterTypeConn);
+        m_filterTypeConn = QMetaObject::Connection();
     }
 }
 

--- a/src/src/widgets/importtimelineview/importtimelineview.h
+++ b/src/src/widgets/importtimelineview/importtimelineview.h
@@ -109,6 +109,8 @@ private:
     // When true the builtin FilterWidget is hidden and filter changes are
     // driven by QmlWidget::filterTypeChanged (QML FilterComboBox overlay)
     bool m_hideBuiltinFilter = false;
+    // Guarded so a true->false->true toggle doesn't stack duplicate connections
+    QMetaObject::Connection m_filterTypeConn;
 };
 
 #endif // IMPORTTIMELINEVIEW_H

--- a/src/src/widgets/timelineview/timelineview.cpp
+++ b/src/src/widgets/timelineview/timelineview.cpp
@@ -70,19 +70,24 @@ void TimeLineView::setHideBuiltinFilter(bool hide)
     m_ToolButton->setVisible(!hide);
 
     // In overlay mode filter changes come from QmlWidget::filterTypeChanged
-    // (written by the QML FilterComboBox); connect it to the existing handler
-    if (hide && m_qquickContainer) {
-        connect(m_qquickContainer, &QmlWidget::filterTypeChanged, this, [this]() {
+    // (written by the QML FilterComboBox). Apply only the side effects the
+    // overlay needs — sltCurrentFilterChanged also drives the builtin button
+    // (count + enable/visible), which is hidden here, so bypass it.
+    if (hide && m_qquickContainer && !m_filterTypeConn) {
+        m_filterTypeConn = connect(m_qquickContainer, &QmlWidget::filterTypeChanged, this, [this]() {
+            ItemType type = ItemType::ItemTypeNull;
             int filterType = m_qquickContainer->filterType();
-            ExpansionPanel::FilteData data;
             if (filterType == Types::Video)
-                data.type = ItemType::ItemTypeVideo;
+                type = ItemType::ItemTypeVideo;
             else if (filterType == Types::Picture)
-                data.type = ItemType::ItemTypePic;
-            else
-                data.type = ItemType::ItemTypeNull;
-            sltCurrentFilterChanged(data);
+                type = ItemType::ItemTypePic;
+            m_timeLineThumbnailListView->showAppointTypeItem(type);
+            clearAllSelection();
+            m_timeLineThumbnailListView->setFocus();
         });
+    } else if (!hide && m_filterTypeConn) {
+        disconnect(m_filterTypeConn);
+        m_filterTypeConn = QMetaObject::Connection();
     }
 }
 

--- a/src/src/widgets/timelineview/timelineview.h
+++ b/src/src/widgets/timelineview/timelineview.h
@@ -94,6 +94,8 @@ public:
     // When true the builtin FilterWidget is hidden and filter changes are
     // driven by QmlWidget::filterTypeChanged (QML FilterComboBox overlay)
     bool m_hideBuiltinFilter = false;
+    // Guarded so a true->false->true toggle doesn't stack duplicate connections
+    QMetaObject::Connection m_filterTypeConn;
 };
 
 #endif // TIMELINEVIEW_H


### PR DESCRIPTION
The overlay lambda mapped Types to ItemType then called sltCurrentFilterChanged which mapped them back, re-wrote the same filterType to m_qquickContainer, and walked the list to update a button hidden in overlay mode. Replace with the 3 direct side effects the overlay needs and guard the connection against duplicate stacking on true->false->true toggles.

QML FilterComboBox 覆盖层的 filterTypeChanged 处理原先经过
Types->ItemType->Types 往返转换，重复写回 filterType 并为隐藏的
内置按钮遍历列表计数。改为直接调用 showAppointTypeItem +
clearAllSelection + setFocus，并用 QMetaObject::Connection 防止 true->false->true 切换时叠加重复连接。

Log: 简化 QML 过滤覆盖层处理逻辑并修复重复连接
PMS: BUG-365397
Influence: 覆盖层过滤切换行为不变，减少冗余计算与潜在重复信号触发。

## Summary by Sourcery

Simplify QML overlay filter handling in timeline views and prevent duplicate signal connections when toggling the overlay filter visibility.

Bug Fixes:
- Prevent stacking duplicate QML filterTypeChanged connections when the builtin filter overlay is toggled on and off.

Enhancements:
- Streamline overlay filter change handling in timeline views to perform only the necessary side effects without updating the hidden builtin filter controls.