### PR TITLE
perf(qml): lazy-load startup dialogs and background blur

### DIFF
--- a/src/qml/MainAlbumView.qml
+++ b/src/qml/MainAlbumView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,12 +19,55 @@ FadeInoutAnimation {
     property int lastWidth: 0
 
     //rename窗口
-    NewAlbumDialog {
+    Loader {
         id: newAlbum
+        active: false
+        property bool isChangeView: false
+        property bool importSelected: false
 
-        Component.onCompleted: {
-            GStatus.loading = false
+        sourceComponent: NewAlbumDialog {
+            isChangeView: newAlbum.isChangeView
+            importSelected: newAlbum.importSelected
+            onSigCreateAlbumDone: newAlbum.sigCreateAlbumDone()
         }
+
+        signal sigCreateAlbumDone()
+
+        function ensureDialog() {
+            active = true
+            return item
+        }
+
+        function setNormalEdit(num) {
+            var dialog = ensureDialog()
+            if (dialog)
+                dialog.setNormalEdit(num)
+        }
+
+        function getDefaultName() {
+            var dialog = ensureDialog()
+            return dialog ? dialog.defaultName : ""
+        }
+
+        function setX(value) {
+            var dialog = ensureDialog()
+            if (dialog)
+                dialog.setX(value)
+        }
+
+        function setY(value) {
+            var dialog = ensureDialog()
+            if (dialog)
+                dialog.setY(value)
+        }
+
+        function show() {
+            var dialog = ensureDialog()
+            if (dialog)
+                dialog.show()
+        }
+
+        Component.onCompleted: GStatus.loading = false
     }
 
     // 侧边导航栏

--- a/src/qml/SideBar/Sidebar.qml
+++ b/src/qml/SideBar/Sidebar.qml
@@ -173,7 +173,10 @@ ScrollView {
         var numSet = new Set();
 
         // 正则表达式来匹配 defaultName 后面的数字
-        var regex = new RegExp("^" + newAlbum.defaultName + "(\\d*)$");
+        var baseName = newAlbum.getDefaultName();
+        // Escape regex metacharacters to prevent injection or parse errors
+        var escapedBaseName = baseName.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+        var regex = new RegExp("^" + escapedBaseName + "(\\d*)$");
 
         for (var i = 0; i < customListModel.count; i++) {
             var displayName = customListModel.get(i).displayName;
@@ -536,8 +539,25 @@ ScrollView {
     }
 
     //删除相册确认弹窗
-    RemoveAlbumDialog {
+    Loader {
         id: removeAlbumDialog
+        active: false
+        property int deleteType: 0
+
+        sourceComponent: RemoveAlbumDialog {
+            deleteType: removeAlbumDialog.deleteType
+            onSigDoRemoveAlbum: function(type) {
+                removeAlbumDialog.sigDoRemoveAlbum(type)
+            }
+        }
+
+        signal sigDoRemoveAlbum(int type)
+
+        function show() {
+            active = true
+            if (item)
+                item.show()
+        }
     }
 
     //删除相册执行函数

--- a/src/qml/StackControl.qml
+++ b/src/qml/StackControl.qml
@@ -50,18 +50,78 @@ Item {
         id: menuItemStates
     }
 
-    EmptyWarningDialog {
+    Loader {
         id: emptyWarningDig
+        active: false
+        sourceComponent: EmptyWarningDialog {
+        }
+
+        function show() {
+            active = true
+            if (item)
+                item.show()
+        }
     }
 
     //delete窗口
-    DeleteDialog {
+    Loader {
         id: deleteDialog
+        active: false
+        sourceComponent: DeleteDialog {
+            onSigDoDeleteImg: deleteDialog.sigDoDeleteImg()
+            onSigDoAllDeleteImg: deleteDialog.sigDoAllDeleteImg()
+        }
+
+        signal sigDoDeleteImg()
+        signal sigDoAllDeleteImg()
+
+        function ensureDialog() {
+            active = true
+            return item
+        }
+
+        function setDisplay(deltype, count) {
+            var dialog = ensureDialog()
+            if (dialog)
+                dialog.setDisplay(deltype, count)
+        }
+
+        function show() {
+            var dialog = ensureDialog()
+            if (dialog)
+                dialog.show()
+        }
+
+        function deleteDirectly() {
+            var dialog = ensureDialog()
+            if (dialog)
+                dialog.deleteDirectly()
+        }
     }
 
     //export窗口
-    ExportDialog {
+    Loader {
         id: exportdig
+        active: false
+        sourceComponent: ExportDialog {
+        }
+
+        function ensureDialog() {
+            active = true
+            return item
+        }
+
+        function setParameter(path, toId) {
+            var dialog = ensureDialog()
+            if (dialog)
+                dialog.setParameter(path, toId)
+        }
+
+        function show() {
+            var dialog = ensureDialog()
+            if (dialog)
+                dialog.show()
+        }
     }
 
     //info的窗口
@@ -83,8 +143,17 @@ Item {
     }
 
     //视频info窗口
-    VideoInfoDialog{
+    Loader {
         id: videoInfomationDig
+        active: false
+        sourceComponent: VideoInfoDialog {
+        }
+
+        function show() {
+            active = true
+            if (item)
+                item.show()
+        }
     }
 
     //相册界面启动幻灯片（和看图界面启动有区别）

--- a/src/qml/ThumbnailImageView/ThumbnailImage.qml
+++ b/src/qml/ThumbnailImageView/ThumbnailImage.qml
@@ -118,8 +118,17 @@ Item {
         }
     }
 
-    EmptyWarningDialog {
+    Loader {
         id: emptyWarningDig
+        active: false
+        sourceComponent: EmptyWarningDialog {
+        }
+
+        function show() {
+            active = true
+            if (item)
+                item.show()
+        }
     }
 
     Connections {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -18,6 +18,7 @@ ApplicationWindow {
     id: window
 
     property bool isFullScreen: window.visibility === Window.FullScreen
+    property bool backgroundBlurReady: false
 
     // Bug fix: 使用 ListView 替换 PathView 时，出现内部的 mouseArea 鼠标操作会被 DWindow 截取
     // 导致 flicking 时拖动窗口，此处使用此标志禁用此行为
@@ -41,19 +42,23 @@ ApplicationWindow {
         color: "transparent"
         Row {
             anchors.fill: parent
-            BehindWindowBlur {
+            Loader {
                 id: leftBgArea
                 width: GStatus.sideBarWidth
                 height: parent.height
                 anchors.top: parent.top
-                blendColor: DTK.themeType === ApplicationHelper.LightType ? "#eaf7f7f7"
-                                                                          : "#ee252525"
-                Rectangle {
-                    width: 1
-                    height: parent.height
-                    anchors.right: parent.right
-                    color: DTK.themeType === ApplicationHelper.LightType ? "#eee7e7e7"
-                                                                         : "#11a2a2a2"
+                active: window.backgroundBlurReady && GStatus.stackControlCurrent === 0
+                sourceComponent: BehindWindowBlur {
+                    anchors.fill: parent
+                    blendColor: DTK.themeType === ApplicationHelper.LightType ? "#eaf7f7f7"
+                                                                              : "#ee252525"
+                    Rectangle {
+                        width: 1
+                        height: parent.height
+                        anchors.right: parent.right
+                        color: DTK.themeType === ApplicationHelper.LightType ? "#eee7e7e7"
+                                                                             : "#11a2a2a2"
+                    }
                 }
             }
             Rectangle {
@@ -99,6 +104,9 @@ ApplicationWindow {
         // 合集-所有项视图延迟刷新，解决其加载时会闪烁显示一张缩略图的问题
         GStatus.currentViewType = Album.Types.ViewCollecttion
         GStatus.currentDeviceName = albumControl.getDeviceName(GStatus.currentDevicePath)
+        Qt.callLater(function() {
+            backgroundBlurReady = true
+        })
     }
 
     onActiveChanged: {


### PR DESCRIPTION
Wrap startup dialogs (NewAlbum/RemoveAlbum/Delete/Export/VideoInfo/ EmptyWarning) and BehindWindowBlur in Loaders with active:false, activated on demand via forwarded show()/setParameter() proxies.

将启动期弹窗与背景模糊用 Loader 包装，active:false 按需激活，通过
show()/setParameter() 转发代理调用，移出启动同步创建路径。

Log: 懒加载启动期弹窗与背景模糊
Influence: 启动时不再同步实例化弹窗及 BehindWindowBlur，降低首帧创建开销，缩短启动耗时。