### PR TITLE
perf(qml): coalesce status-bar text updates in All/Day views

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -20,13 +20,40 @@ SwitchViewAnimation {
 
     property int filterType: filterCombo.currentIndex // 筛选类型，默认所有
     property string numLabelText:""
-    property string selectedText: getSelectedNum(selectedPaths)
+    // Cached property: drop auto-binding so selectedPaths/numLabelText no longer each trigger a C++ count
+    property string selectedText: ""
     property alias count: theView.count
-    property var selectedPaths: GStatus.selectedPaths
     property int totalItemCount: 0
+    // Coalesce flag: multiple schedules in the same frame run doUpdateSelectedText only once
+    property bool updateSelectedTextPending: false
 
     function setDateRange(str) {
         dateRangeLabel.text = str
+    }
+
+    // Visibility gate: hidden views are not woken by selectedPathsChanged to do a type count
+    function shouldUpdateSelectedText() {
+        return visible && GStatus.currentCollecttionViewIndex === 3
+    }
+
+    // Schedule update: coalesce same-frame sources (selectedPathsChanged/flush/numLabelText change)
+    function scheduleUpdateSelectedText() {
+        if (!shouldUpdateSelectedText() || updateSelectedTextPending)
+            return
+        updateSelectedTextPending = true
+        Qt.callLater(doUpdateSelectedText)
+    }
+
+    // Actual update: read latest selectedPaths + numLabelText, count only once
+    function doUpdateSelectedText() {
+        updateSelectedTextPending = false
+        if (!shouldUpdateSelectedText())
+            return
+        var paths = GStatus.selectedPaths || []
+        selectedText = paths.length === 0
+                ? numLabelText
+                : GStatus.getSelectedNumText(paths, numLabelText)
+        GStatus.statusBarNumText = selectedText
     }
 
     // 筛选类型改变处理事件
@@ -38,8 +65,8 @@ SwitchViewAnimation {
     function clearSelecteds()
     {
         theView.selectAll(false)
-        selectedPaths = []
-        GStatus.selectedPaths = selectedPaths
+        GStatus.selectedPaths = []
+        scheduleUpdateSelectedText()
     }
 
     // 刷新所有项目视图内容
@@ -49,6 +76,8 @@ SwitchViewAnimation {
             return
         GStatus.selectedPaths = theView.selectedUrls
         getNumLabelText()
+        // numLabelText change does not auto-trigger an update, schedule explicitly
+        scheduleUpdateSelectedText()
         totalTimepScopeTimer.start()
     }
 
@@ -94,12 +123,12 @@ SwitchViewAnimation {
         }
     }
 
-    // 刷新选择项数标签
-    function getSelectedNum(paths) {
-        var selectedNumText = GStatus.getSelectedNumText(paths, numLabelText)
-        if (visible && GStatus.currentCollecttionViewIndex === 3)
-            GStatus.statusBarNumText = selectedNumText
-        return selectedNumText
+    // Unified selection entry: C++ setSelectedPaths also converges through this signal
+    Connections {
+        target: GStatus
+        function onSelectedPathsChanged() {
+            scheduleUpdateSelectedText()
+        }
     }
 
     Connections {

--- a/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
@@ -30,9 +30,11 @@ SwitchViewAnimation {
     // property var dayHeights: []
 
     property int filterType: timeline.filterType
-    property var selectedPaths: GStatus.selectedPaths
     property string numLabelText: "" //总数标签显示内容
-    property string selectedText: getSelectedText(selectedPaths)
+    // Cached property: drop auto-binding so selectedPaths/numLabelText no longer each trigger a C++ count
+    property string selectedText: ""
+    // Coalesce flag: multiple schedules in the same frame run doUpdateSelectedText only once
+    property bool updateSelectedTextPending: false
     property bool bShowImportTips: GStatus.currentViewType === Album.Types.ViewCollecttion
                                    && GStatus.currentCollecttionViewIndex === 2
                                    && numLabelText === ""
@@ -141,6 +143,31 @@ SwitchViewAnimation {
         }
     }
 
+    // Visibility gate: hidden views are not woken by selectedPathsChanged to do a type count
+    function shouldUpdateSelectedText() {
+        return visible && GStatus.currentCollecttionViewIndex === 2
+    }
+
+    // Schedule update: coalesce same-frame sources (selectedPathsChanged/filter/flush/external refresh)
+    function scheduleUpdateSelectedText() {
+        if (!shouldUpdateSelectedText() || updateSelectedTextPending)
+            return
+        updateSelectedTextPending = true
+        Qt.callLater(doUpdateSelectedText)
+    }
+
+    // Actual update: read latest selectedPaths + numLabelText, count only once
+    function doUpdateSelectedText() {
+        updateSelectedTextPending = false
+        if (!shouldUpdateSelectedText())
+            return
+        var paths = GStatus.selectedPaths || []
+        selectedText = paths.length === 0
+                ? numLabelText
+                : GStatus.getSelectedNumText(paths, numLabelText)
+        GStatus.statusBarNumText = selectedText
+    }
+
     onVisibleChanged: {
         // 窗口显示时，重置显示内容
         if (visible) {
@@ -150,8 +177,11 @@ SwitchViewAnimation {
 
     // 筛选类型改变处理事件
     onFilterTypeChanged: {
-        if (visible)
+        if (visible) {
             getNumLabelText()
+            // numLabelText change does not auto-trigger an update, schedule explicitly
+            scheduleUpdateSelectedText()
+        }
     }
 
     function flushView() {
@@ -159,6 +189,7 @@ SwitchViewAnimation {
             return
         timeline.refresh()
         getNumLabelText()
+        scheduleUpdateSelectedText()
     }
 
     function unSelectAll() {
@@ -175,10 +206,12 @@ SwitchViewAnimation {
         target: collecttionView
         function onFlushDayViewStatusText() {
             if (visible) {
-                if (selectedPaths.length > 0)
-                    getSelectedText(selectedPaths)
-                else
+                if (GStatus.selectedPaths.length > 0)
+                    getSelectedText(GStatus.selectedPaths)
+                else {
                     getNumLabelText()
+                    scheduleUpdateSelectedText()
+                }
             }
         }
     }
@@ -224,15 +257,10 @@ SwitchViewAnimation {
         }
     }
 
-    // 刷新选中项目标签内容
+    // Refresh selected-item label (wrapper: forwards to the coalesced entry; param kept for call compat)
     function getSelectedText(paths) {
-        if (!visible)
-            return "";
-
-        var selectedNumText = GStatus.getSelectedNumText(paths, numLabelText)
-        if (visible)
-            GStatus.statusBarNumText = selectedNumText
-        return selectedNumText
+        scheduleUpdateSelectedText()
+        return selectedText
     }
 
     //月视图切日视图
@@ -242,6 +270,11 @@ SwitchViewAnimation {
 
     Connections {
         target: GStatus
+
+        // Unified selection entry: C++ setSelectedPaths also converges through this signal
+        function onSelectedPathsChanged() {
+            scheduleUpdateSelectedText()
+        }
 
         function onSigSelectAll(sel) {
             if (visible) {


### PR DESCRIPTION
Drop the selectedText auto-binding and route updates through a single Qt.callLater-coalesced entry gated on visibility, so a flush no longer triggers duplicate C++ type counts from selectedPaths/numLabelText.

去掉 selectedText 自动绑定，改为经 Qt.callLater 合并的单一调度入口并加
可见性 gate，避免一次刷新被 selectedPaths 与 numLabelText 各触发一次 C++ 类型统计；同时删除冗余的本地 selectedPaths 中转属性。

Log: 合并相册/日视图状态栏文本更新，减少重复 C++ 统计
Influence: 切换筛选或选择图片时，状态栏选中数量统计由每帧最多两次降为一次，降低热路径开销；隐藏视图不再被选中变化唤醒做统计。

## Summary by Sourcery

Coalesce and centralize status-bar selection text updates in All and Day collection QML views to reduce redundant C++ counting and avoid work when the views are hidden.

Bug Fixes:
- Avoid duplicate status-bar selection count updates from Day and All views by routing all changes through a single coalesced updater.

Enhancements:
- Coalesce status-bar selection text updates in Day and All collection views using a deferred, visibility-gated updater to reduce hot-path work and prevent hidden views from doing selection counts.
- Remove redundant local selectedPaths state in favor of reading from the shared GStatus selection source.