### PR TITLE
perf(qml): debounce AllCollection filter change refresh

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -58,7 +58,15 @@ SwitchViewAnimation {
 
     // 筛选类型改变处理事件
     onFilterTypeChanged: {
-        flushAllCollectionView()
+        filterRefreshTimer.restart()
+    }
+
+    // Filter changes can arrive in quick succession; coalesce them before rebuilding the proxy model.
+    Timer {
+        id: filterRefreshTimer
+        interval: 100
+        repeat: false
+        onTriggered: flushAllCollectionView()
     }
 
     // 清空已选内容


### PR DESCRIPTION
Coalesce rapid onFilterTypeChanged emissions via a 100ms timer before rebuilding the proxy model, avoiding redundant full refreshes.

筛选类型变更经 100ms 定时器防抖后再刷新代理模型，避免连续变更触发
冗余的完整模型重建。

Log: 筛选变更防抖合并刷新
Influence: AllCollection视图筛选下拉框快速连续切换时，合并为一次模型刷新，减少UI线程阻塞。

## Summary by Sourcery

Enhancements:
- Introduce a 100ms debounce timer for AllCollection filter changes before triggering a view refresh to reduce UI thread blocking.