### PR TITLE
fix: defer AlbumControl monitor start to event loop

### DIFF
--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -158,7 +158,8 @@ AlbumControl *AlbumControl::instance()
     if (!m_instance) {
         // qDebug() << "AlbumControl::instance - Branch: creating new AlbumControl singleton instance";
         m_instance = new AlbumControl();
-        m_instance->startMonitor();
+        // Defer to the event loop: startMonitor's DB/FS scans must not block first paint
+        QTimer::singleShot(0, m_instance, &AlbumControl::startMonitor);
     }
     // qDebug() << "AlbumControl::instance - Function exit";
     return m_instance;


### PR DESCRIPTION
Move startMonitor() out of AlbumControl::instance() into a zero-delay timer so DB/FS scans run after first paint instead of gating QML load.

将 AlbumControl 的路径监控启动推迟到事件循环，DB/文件系统扫描不再
阻塞 QML 加载和首帧绘制。

Log: 启动优化，AlbumControl 监控改为事件循环后执行
Influence: 相册启动时首帧不再被监控初始化的 DB 与文件系统扫描阻塞，自定义自动导入与 inotify 监听在事件循环起来后正常生效，行为等价。

## Summary by Sourcery

Enhancements:
- Schedule AlbumControl::startMonitor to run via a zero-delay QTimer instead of during singleton construction, ensuring database and filesystem scans occur after the UI first paint.