### PR TITLE
fix: move single-instance check before QML engine

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 ~ 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -77,13 +77,14 @@ int main(int argc, char *argv[])
                    .arg(app.applicationVersion());
     qDebug() << "LogFile:" << DLogManager::getlogFilePath();
 
-    QQmlApplicationEngine engine;
-    qDebug() << "Initializing QML engine";
-
+    // Reject duplicate instances before constructing the QML engine
     if (!DGuiApplicationHelper::instance()->setSingleInstance(app.applicationName(), DGuiApplicationHelper::UserScope)) {
         qWarning() << "Application instance already running, exiting";
         exit(0);
     }
+
+    QQmlApplicationEngine engine;
+    qDebug() << "Initializing QML engine";
 
     // 配置文件加载
     qDebug() << "Loading application configuration";


### PR DESCRIPTION
Run setSingleInstance before constructing QQmlApplicationEngine so a duplicate instance exits without paying for engine + QML load.

将单实例检查前移到 QQmlApplicationEngine 构造之前，重复实例直接退出，
不再触发 QML 引擎构造与 engine.load 开销。

Log: 单实例检查前移，重复实例不再加载 QML
Influence: 启动时遇到已运行实例，第二实例不再构造 QML 引擎与加载 QML；首实例启动顺序与行为不变。

## Summary by Sourcery

Bug Fixes:
- Prevent unnecessary QML engine construction and loading when a second application instance is started.