### PR TITLE
fix: skip unreadable files during import to avoid false success prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ compile_commands.json
 # QtCreator local machine specific files for imported projects
 
 *creator.user*
+
+# Ai
+.omo

--- a/src/album/imageengine/imageenginethread.cpp
+++ b/src/album/imageengine/imageenginethread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -384,6 +384,22 @@ void ImportImagesThread::runDetail()
 
 void ImportImagesThread::pathCheck(QStringList *image_list, QStringList *curAlbumImportedPathList, QStringList &curAlbumImgPathList, const QString &path)
 {
+    // Check both DAC permissions (stat) and actual readability (open),
+    // because LSM-based access control (e.g. filearmor) only blocks open()
+    // but leaves stat()/access() untouched, making QFileInfo::isReadable()
+    // insufficient on its own.
+    if (!QFileInfo(path).isReadable()) {
+        qDebug() << "Skip unreadable file during import (DAC):" << path;
+        return;
+    }
+    {
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly)) {
+            qDebug() << "Skip unreadable file during import (open failed):" << path;
+            return;
+        }
+        file.close();
+    }
     if (utils::image::imageSupportRead(path)) {
         if (curAlbumImgPathList.contains(path)) {
             *curAlbumImportedPathList << path;


### PR DESCRIPTION
When a directory is made inaccessible at the system level, importing
    images from it would fail silently but the app incorrectly showed
    'Import successful'. This was because pathCheck only checked format
    support and file existence, not actual file readability.
    
    Add both DAC (isReadable) and MAC (open) checks at the start of
    pathCheck. The open() check is necessary because LSM-based access
    control (e.g. filearmor) only blocks open() while leaving stat() and
    access() untouched, making QFileInfo::isReadable() insufficient.
    
    log: fix bug
    
    bug: https://pms.uniontech.com/bug-view-294209.html

## Summary by Sourcery

Bug Fixes:
- Prevent import from falsely reporting success when files are inaccessible due to permission or access control restrictions by skipping unreadable paths early in the import check.