### PR TITLE
fix: defer MainStack/SliderShow construction to event loop

### DIFF
--- a/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
+++ b/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
@@ -125,9 +125,12 @@ FocusScope {
     // 日视图/已导入视图，双击打开图片时，需要传入坐标，映射到点击Item上，才能准确显示大图预览动画初始位置
     function viewImageFromOuterDbClick(x,y) {
         var item = gridView.itemAt(x, y)
-        var c = item.mapToItem(mainStack, 0, 0)
-        console.log("c.x:", c.x, "c.y:", c.y)
-        ThumbnailTools.executeViewImage(c.x, c.y, item.widht, item.height)
+        if (!mainStack.item) {
+            ThumbnailTools.executeViewImage(0, 0, item.width, item.height)
+            return
+        }
+        var c = item.mapToItem(mainStack.item, 0, 0)
+        ThumbnailTools.executeViewImage(c.x, c.y, item.width, item.height)
     }
 
    // 提供给合集日视图和已导入视图使用，用来刷新
@@ -310,8 +313,12 @@ FocusScope {
 
             // 单击模式点击/双击模式双击打开图片
             if (Qt.styleHints.singleClickActivation || bDbClicked || mouse.source === Qt.MouseEventSynthesizedByQt) {
-                var c = clickedItem.mapToItem(mainStack, 0, 0)
-                ThumbnailTools.executeViewImage(c.x, c.y, clickedItem.width, clickedItem.height)
+                if (!mainStack.item) {
+                    ThumbnailTools.executeViewImage(0, 0, clickedItem.width, clickedItem.height)
+                } else {
+                    var c = clickedItem.mapToItem(mainStack.item, 0, 0)
+                    ThumbnailTools.executeViewImage(c.x, c.y, clickedItem.width, clickedItem.height)
+                }
             }
             else {
                 bDbClicked = true;

--- a/src/qml/MainAlbumView.qml
+++ b/src/qml/MainAlbumView.qml
@@ -406,7 +406,7 @@ FadeInoutAnimation {
             } else if (FileControl.isImage(tempPath)){
                 GControl.setImageFiles(paths, tempPath)
                 FileControl.resetImageFiles(paths);
-                mainStack.switchImageView()
+                stackControl.switchMainStackView()
                 GStatus.stackControlCurrent = 1
             }
         }

--- a/src/qml/MenuItemStates.qml
+++ b/src/qml/MenuItemStates.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -72,7 +72,7 @@ Item {
             } else {
                 GControl.setImageFiles(allUrls, url)
                 FileControl.resetImageFiles(allUrls);
-                mainStack.switchImageView()
+                stackControl.switchMainStackView()
                 GStatus.stackControlCurrent = 1
             }
         }
@@ -93,7 +93,7 @@ Item {
         if (window.visibility !== Window.FullScreen && selectedUrls.length > 0) {
             GControl.setImageFiles(allUrls, url)
             FileControl.resetImageFiles(allUrls);
-            mainStack.switchImageView()
+            stackControl.switchMainStackView()
             GStatus.stackControlLastCurrent = GStatus.stackControlCurrent
             GStatus.stackControlCurrent = 1
             GStatus.showFullScreen = true

--- a/src/qml/StackControl.qml
+++ b/src/qml/StackControl.qml
@@ -12,23 +12,42 @@ import org.deepin.album 1.0 as Album
 Item {
     anchors.fill: parent
     //本文件用于替代stackwidget的作用，通过改变GStatus的0-n来切换窗口
+
+    // Defer MainStack/SliderShow to the next event-loop tick so they don't gate first paint
+    property bool deferredStackReady: false
+    Timer {
+        id: deferredStackTimer
+        interval: 1
+        running: true
+        repeat: false
+        onTriggered: deferredStackReady = true
+    }
+
     MainAlbumView{
         id: mainAlbumView
         idName: "mainAlbumView"
         show: GStatus.stackControlCurrent === 0
     }
-    MainStack{
+    Loader {
         id: mainStack
-        idName: "mainStack"
         anchors.fill: parent
-        show: GStatus.stackControlCurrent === 1
-        iconName: "deepin-album"
+        active: deferredStackReady
+        sourceComponent: MainStack {
+            idName: "mainStack"
+            anchors.fill: parent
+            show: GStatus.stackControlCurrent === 1
+            iconName: "deepin-album"
+        }
     }
-    SliderShow{
+    Loader {
         id: mainSliderShow
-        idName: "albumview"
         anchors.fill: parent
-        visible: GStatus.stackControlCurrent === 2
+        active: deferredStackReady
+        sourceComponent: SliderShow {
+            idName: "albumview"
+            anchors.fill: parent
+            visible: GStatus.stackControlCurrent === 2
+        }
     }
 
     //全屏动画
@@ -156,17 +175,27 @@ Item {
         }
     }
 
+    // Switch the deferred MainStack into image-view mode; no-op until the Loader finishes.
+    function switchMainStackView() {
+        if (mainStack.item)
+            mainStack.item.switchImageView()
+    }
+
     //相册界面启动幻灯片（和看图界面启动有区别）
     //images: 图片路径 startIndex: 启动后一个图的下标索引
     function startMainSliderShow(images, startIndex) {
+        // Bail if deferred views aren't loaded yet; otherwise state would flip
+        // to slideshow (stackControlCurrent=2) with a blank screen.
+        if (!mainStack.item || !mainSliderShow.item)
+            return
         showfullAnimation.start()
         showFullScreen()
         GControl.setImageFiles(images, images[startIndex])
         FileControl.resetImageFiles(images);
-        mainStack.switchImageView()
-        mainSliderShow.autoRun = true
-        mainSliderShow.source = "image://ImageLoad/" + GControl.currentSource + "#frame_" + GControl.currentFrameIndex;
-        mainSliderShow.restart()
+        switchMainStackView()
+        mainSliderShow.item.autoRun = true
+        mainSliderShow.item.source = "image://ImageLoad/" + GControl.currentSource + "#frame_" + GControl.currentFrameIndex;
+        mainSliderShow.item.restart()
         GStatus.stackControlCurrent = 2
         mainAlbumView.visible = false
     }


### PR DESCRIPTION
Wrap MainStack and SliderShow in Loaders activated by a 1ms timer, so their visual trees build after first paint instead of gating startup. Add StackControl.switchMainStackView() helper to centralize the null guard; update all callers (mapToItem uses .item directly).

将 MainStack 与 SliderShow 包入 Loader，由 1ms 定时器在事件循环
启动后再构建，避免其视觉树阻塞首帧。新增 switchMainStackView
辅助集中空值守护，调用方一并更新。

Log: 延迟加载看图器与幻灯片，减少首帧阻塞
Influence: 相册启动时不再为启动期不可见的看图器/幻灯片构建整棵 QML 视觉树，首帧更早出现；用户进入看图或幻灯片时二者已就绪，行为等价。