### PR TITLE
fix: defer top shadow BoxShadow to backgroundBlurReady

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -61,21 +61,23 @@ ApplicationWindow {
                     }
                 }
             }
-            Rectangle {
-                id: rightBgArea
+            Loader {
+                active: window.backgroundBlurReady
                 width: parent.width
                 height: 50
-                anchors.top: parent.top
-                color: Qt.rgba(0, 0, 0, 0.01)
-                BoxShadow {
-                    anchors.fill: rightBgArea
-                    shadowOffsetX: 0
-                    shadowOffsetY: 4
-                    shadowColor: Qt.rgba(0, 0, 0, 0.05)
-                    shadowBlur: 10
-                    cornerRadius: rightBgArea.radius
-                    spread: 0
-                    hollow: true
+                sourceComponent: Rectangle {
+                    anchors.fill: parent
+                    color: Qt.rgba(0, 0, 0, 0.01)
+                    BoxShadow {
+                        anchors.fill: parent
+                        shadowOffsetX: 0
+                        shadowOffsetY: 4
+                        shadowColor: Qt.rgba(0, 0, 0, 0.05)
+                        shadowBlur: 10
+                        cornerRadius: parent.radius
+                        spread: 0
+                        hollow: true
+                    }
                 }
             }
         }


### PR DESCRIPTION
Wrap the right-top shadow Rectangle in a Loader sharing the existing backgroundBlurReady flag, so its BoxShadow blur is not computed during first paint but on the next event-loop tick alongside the left blur.

将顶部阴影 Rectangle 包入 Loader，复用已有的 backgroundBlurReady 标志，BoxShadow 的模糊计算不再在首帧进行，与左侧背景模糊一起
在事件循环起来后构建。

Log: 顶部阴影延迟构建，减少首帧模糊计算
Influence: 相册首帧不再立即计算顶部阴影的高斯模糊纹理，启动更轻；阴影晚几十毫秒出现，与左侧背景模糊体验一致，用户基本无感知。