### PR TITLE
chore: Update version to 6.0.62

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+deepin-album (6.0.62) unstable; urgency=medium
+
+  * chore: Update version to 6.0.62
+  * fix: defer top shadow BoxShadow to backgroundBlurReady
+  * fix: defer MainStack/SliderShow construction to event loop
+  * fix: move single-instance check before QML engine
+  * fix: defer AlbumControl monitor start to event loop
+  * fix(view): simplify AlbumTitle setChecked and sync on GStatus change
+  * perf(qml): lazy-load AlbumTitle collectionCombo for wide-screen startup
+  * perf(qml): debounce AllCollection filter change refresh
+  * perf(qml): coalesce status-bar text updates in All/Day views
+  * perf(qml): lazy-load startup dialogs and background blur
+  * fix(view): QML filter overlay change handler
+  * feat(view): add QML FilterComboBox overlay to DayCollection
+  * feat(view): replace C++ FilterWidget with QML FilterComboBox overlay
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 09 Jul 2026 13:07:33 +0800
+
 deepin-album (6.0.61) unstable; urgency=medium
 
   * fix: remove redundant import, fix typo and hardcode in DeleteDialog

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.61.1
+  version: 6.0.62.1
   kind: app
   description: |
     album for deepin os.
@@ -16,7 +16,7 @@ command:
   - deepin-album
 
 base: org.deepin.base/25.2.2
-runtime: org.deepin.runtime.webengine/25.2.2
+runtime: org.deepin.runtime.webengine/6.7.0
 
 build: |
   # 下载和安装依赖


### PR DESCRIPTION
- update version to 6.0.62

log: update version to 6.0.62

## Summary by Sourcery

Bump deepin-album package version and update its runtime dependency.

Build:
- Update linglong package manifest to version 6.0.62.1 and switch runtime to org.deepin.runtime.webengine/6.7.0.

Chores:
- Refresh Debian packaging metadata for the 6.0.62 release.