### PR TITLE
fix(image): ignore empty async image provider paths

### DIFF
--- a/src/src/imagedata/imageprovider.cpp
+++ b/src/src/imagedata/imageprovider.cpp
@@ -152,6 +152,10 @@ void AsyncImageResponse::run()
     QString tempPath;
     int frameIndex;
     parseProviderID(providerId, tempPath, frameIndex);
+    if (tempPath.isEmpty()) {
+        emit finished();
+        return;
+    }
 
     // 判断缓存中是否存在图片
     image = provider->imageCache.get(tempPath, frameIndex);


### PR DESCRIPTION
Skip image decoding when the parsed provider path is empty. 解析后的图片 Provider 路径为空时跳过解码。

Log: 避免异步图片请求打开空文件名
Influence: 异步图片加载异常路径