### PR TITLE
fix(device): initialize album count text

### DIFF
--- a/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
+++ b/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
@@ -20,7 +20,7 @@ BaseView {
     property string deviceName: GStatus.currentDeviceName
     property int filterType: 0
     property int currentImportIndex: 0
-    property var numLabelText
+    property string numLabelText: ""
     property string selectedText: getSelectedText(selectedPaths)
     property alias selectedPaths: theView.selectedPaths
 


### PR DESCRIPTION
Initialize the device album count text with an empty string. 将设备相册数量文本初始化为空字符串。

Log: 修复设备相册标题文本的未定义赋值告警
Influence: 设备相册标题文本显示

## Summary by Sourcery

Bug Fixes:
- Prevent undefined assignment warnings for the device album title text by initializing the album count label string.