### PR TITLE
fix(view): lazily create nondefault thumbnail views

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
@@ -17,12 +17,12 @@ BaseView {
     property int currentViewIndex: 3
     property int rollingWidth: collecttView.width + 20
 
-    // DayCollection contains heavy QWidget(TimeLineView) that slows window map.
-    // Defer creation via Loader until after map or when switching to day view (index===2).
-    // Once dayReady is true, loading is locked (active implies status===Loader.Ready).
-    property bool dayReady: false
+    // DayCollection contains heavy QWidget(TimeLineView); create it only when
+    // the user switches to the day view (index===2).
     // Stash day/month switch requests before Loader is ready, replay in onLoaded.
     property bool pendingDaySwitch: false
+    // Keep the heavy day view after its first explicit selection.
+    property bool dayLoadedOnce: false
     property var pendingMonthArgs: undefined
 
     // 通知日视图刷新状态栏提示信息
@@ -47,7 +47,7 @@ BaseView {
             if (!dayItem) {
                 // Day view not created yet: stash request, activate Loader, replay onLoaded
                 pendingDaySwitch = true
-                dayCollectionLoader.active = true
+                dayLoadedOnce = true
             } else {
                 applyDayViewState(dayItem)
             }
@@ -128,7 +128,7 @@ BaseView {
         width: collecttView.width
         height: collecttView.height
         asynchronous: false
-        active: dayReady || currentViewIndex === 2
+        active: currentViewIndex === 2 || dayLoadedOnce
         sourceComponent: DayCollection {
             id: dayCollection
             visible: false
@@ -150,15 +150,6 @@ BaseView {
                 item.scrollToMonth(args.year, args.month)
             }
         }
-    }
-
-    // Create DayCollection after map so its embedded QWidget doesn't slow startup.
-    Timer {
-        id: dayDelayTimer
-        interval: 1
-        running: true
-        repeat: false
-        onTriggered: collecttView.dayReady = true
     }
 
     AllCollection {

--- a/src/qml/ThumbnailImageView/DeferredView.qml
+++ b/src/qml/ThumbnailImageView/DeferredView.qml
@@ -5,16 +5,14 @@
 import QtQuick
 import org.deepin.album 1.0 as Album
 
-// View Loader deferred until after window map (or when this view becomes current), stays loaded once created.
-// Delay logic unified in one place to avoid repetition across views.
-//   active = ready (after map) || current view is this view
+// View Loader created only when this view becomes current, then stays loaded.
 Loader {
-    // Set to true by host to signal deferral can start (after map).
-    property bool ready: false
     // The Album.Types.View* type this Loader carries.
     property int viewType: -1
+    property bool loadedOnce: false
 
     anchors.fill: parent
     asynchronous: false
-    active: ready || GStatus.currentViewType === viewType
+    active: loadedOnce || GStatus.currentViewType === viewType
+    onLoaded: loadedOnce = true
 }

--- a/src/qml/ThumbnailImageView/ThumbnailImage.qml
+++ b/src/qml/ThumbnailImageView/ThumbnailImage.qml
@@ -24,24 +24,14 @@ import "./../"
 Item {
     id: thumbView
 
-    // Window must map quickly: slow map triggers dock launcher timeout, causing icon flicker.
-    // Only default CollecttionView is created sync during engine.load; other 8 views all embed
-    // QWidgets (can't use async Loader), so they're deferred by viewDelayTimer until after map.
-    // interval is minimal (next event loop), just yields current frame to let window map first.
-    property bool delayedViewsReady: false
-    Timer {
-        id: viewDelayTimer
-        interval: 1
-        running: true
-        repeat: false
-        onTriggered: thumbView.delayedViewsReady = true
-    }
+    // Window must map quickly: only the default collection view is created at
+    // startup. Other views are created when first selected.
 
     // Default Collection view created sync (active: true) so window map shows real thumbnails
     // (AllCollection) immediately, eliminating "shell->content" pop-in. Its heavy DayCollection child
-    // is already split into Loader in CollecttionView.qml, keeping this light. Other 8 views still
-    // deferred by viewDelayTimer. If user clicks year/month/day before this view loads, setIndex
-    // would be lost (item is null), so use pendingCollectionIndex to stash and replay onLoaded.
+    // is already split into Loader in CollecttionView.qml, keeping this light. Other views load on
+    // first selection. If user clicks year/month/day before this view loads, setIndex would be lost
+    // (item is null), so use pendingCollectionIndex to stash and replay onLoaded.
     property int pendingCollectionIndex: -1
     Loader {
         id: collecttionViewLoader
@@ -59,41 +49,33 @@ Item {
             }
         }
     }
-    // Other views deferred until after map (or when selected), stay loaded once created.
-    // Delay logic unified in DeferredView, not repeated per view.
+    // Other views are loaded on first selection and stay loaded afterwards.
     DeferredView {
-        ready: delayedViewsReady
         viewType: Album.Types.ViewHaveImported
         sourceComponent: HaveImportedView { show: GStatus.currentViewType === Album.Types.ViewHaveImported }
     }
     DeferredView {
-        ready: delayedViewsReady
         viewType: Album.Types.ViewFavorite
         sourceComponent: CustomAlbum { show: GStatus.currentViewType === Album.Types.ViewFavorite }
     }
     DeferredView {
-        ready: delayedViewsReady
         viewType: Album.Types.ViewRecentlyDeleted
         sourceComponent: RecentlyDeletedView { show: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted }
     }
     DeferredView {
-        ready: delayedViewsReady
         viewType: Album.Types.ViewCustomAlbum
         sourceComponent: CustomAlbum { show: GStatus.currentViewType === Album.Types.ViewCustomAlbum }
     }
     DeferredView {
-        ready: delayedViewsReady
         viewType: Album.Types.ViewSearchResult
         sourceComponent: SearchView { show: GStatus.currentViewType === Album.Types.ViewSearchResult }
     }
     DeferredView {
-        ready: delayedViewsReady
         viewType: Album.Types.ViewDevice
         sourceComponent: DeviceAlbum { show: GStatus.currentViewType === Album.Types.ViewDevice }
     }
     DeferredView {
         id: classificationViewLoader
-        ready: delayedViewsReady
         viewType: Album.Types.ViewClassification
         sourceComponent: ClassificationView {
             id: classificationView
@@ -110,7 +92,6 @@ Item {
     }
     DeferredView {
         id: classificationDetailViewLoader
-        ready: delayedViewsReady
         viewType: Album.Types.ViewClassificationDetail
         sourceComponent: ClassificationDetailView {
             id: classificationDetailView


### PR DESCRIPTION
Create nondefault thumbnail views on first selection and keep them loaded. 仅在首次选择时创建非默认缩略图视图，并在之后保持加载。

Log: 延后非默认缩略图视图与日视图的创建
Influence: 应用启动时间和首次切换各缩略图视图