### PR TITLE
fix: refresh deferred imported view on first display

### DIFF
--- a/src/qml/ThumbnailImageView/DeferredView.qml
+++ b/src/qml/ThumbnailImageView/DeferredView.qml
@@ -9,10 +9,22 @@ import org.deepin.album 1.0 as Album
 Loader {
     // The Album.Types.View* type this Loader carries.
     property int viewType: -1
-    property bool loadedOnce: false
 
     anchors.fill: parent
     asynchronous: false
-    active: loadedOnce || GStatus.currentViewType === viewType
-    onLoaded: loadedOnce = true
+    active: false
+
+    function loadCurrentView() {
+        if (!active && GStatus.currentViewType === viewType)
+            active = true
+    }
+
+    Connections {
+        target: GStatus
+        function onCurrentViewTypeChanged() {
+            loadCurrentView()
+        }
+    }
+
+    Component.onCompleted: loadCurrentView()
 }

--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -18,6 +18,8 @@ BaseView {
     property string selectedText: getSelectedText(selectedPaths)
     property var selectedPaths: GStatus.selectedPaths
     property real titleOpacity: 0.7
+    // Set after a visible refresh so first construction can fall back safely.
+    property bool initialContentInitialized: false
     property bool bShowImportTips: numLabelText === ""
                                    && filterType === 0
                                    && albumControl.getAllCount() === 0
@@ -143,6 +145,7 @@ BaseView {
         unSelectAll()
         timeline.refresh()
         getNumLabelText()
+        initialContentInitialized = true
     }
 
     function unSelectAll() {
@@ -258,5 +261,13 @@ BaseView {
 
     Component.onCompleted: {
         GStatus.sigFlushHaveImportedView.connect(flushView)
+
+        // When this view is created by DeferredView after its show binding has
+        // already become true, onVisibleChanged has no transition to refresh
+        // the timeline. Fill it once so the first imported-view click renders.
+        Qt.callLater(function() {
+            if (visible && !initialContentInitialized)
+                flushView()
+        })
     }
 }


### PR DESCRIPTION
Refresh the imported timeline when its deferred view is first created. 在延迟创建的已导入视图首次显示时刷新时间线。

Log: 修复已导入界面首次点击不显示的问题
Influence: 已导入视图首次进入和非默认视图懒加载

## Summary by Sourcery

Ensure deferred thumbnail views activate and refresh correctly when first displayed, so imported timelines render on initial entry.

Bug Fixes:
- Fix imported view not rendering its timeline on the first click when created via deferred loading.

Enhancements:
- Adjust deferred view activation to respond to current view type changes and initial completion, improving lazy-loaded non-default views behavior.