### PR TITLE
fix(title): enable ratio control before status text is ready

### DIFF
--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -50,6 +50,11 @@ TitleBar {
     property int layoutLeftMargin_AlignLeft: showHideleftSidebarButton.x + showHideleftSidebarButton.width // 显示比例按钮向标题左侧对齐时的布局留白宽度
     property int layoutLeftMargin_AlignRight: GStatus.sideBarWidth + 10 // 显示比例按钮向标题右侧对齐时的布局留白宽度
     property bool collectionComboEverNarrow: false
+    // Do not wait for the asynchronously populated status text to render the
+    // ratio button. Once a view has supplied status text, that text remains
+    // the authoritative availability state for subsequent view changes.
+    property bool initialRatioContentAvailable: albumControl.getAllCount() > 0
+    property bool ratioContentStateResolved: false
 
     property int lastWidth: 0
     onWidthChanged: {
@@ -81,6 +86,18 @@ TitleBar {
         }
 
         lastWidth = width
+    }
+
+    Connections {
+        target: GStatus
+        function onStatusBarNumTextChanged() {
+            if (GStatus.statusBarNumText !== "")
+                title.ratioContentStateResolved = true
+        }
+    }
+
+    Component.onCompleted: {
+        ratioContentStateResolved = GStatus.statusBarNumText !== ""
     }
 
     // 显示比例按钮向左对齐动画
@@ -220,7 +237,13 @@ TitleBar {
                 id: range1Button
                 Layout.preferredWidth: iconSize
                 Layout.preferredHeight: iconSize
-                enabled: GStatus.statusBarNumText !== "" && !(GStatus.currentViewType === Album.Types.ViewCollecttion && GStatus.currentCollecttionViewIndex === 0)
+                enabled: !(GStatus.currentViewType === Album.Types.ViewCollecttion
+                           && GStatus.currentCollecttionViewIndex === 0)
+                         && (GStatus.statusBarNumText !== ""
+                             || (!title.ratioContentStateResolved
+                                 && GStatus.currentViewType === Album.Types.ViewCollecttion
+                                 && GStatus.currentCollecttionViewIndex === 3
+                                 && title.initialRatioContentAvailable))
                 ToolTip.visible: hovered
                 ToolTip.text: icon.name === "range1" ? qsTr("Original ratio") : qsTr("Square thumbnails")
                 icon {


### PR DESCRIPTION
Keep the ratio control available for a nonempty all-items collection. 在异步状态文本填充前，为非空的全部合集保持比例按钮可用。

Log: 修复首屏比例按钮延迟可用的问题
Influence: 全部合集首屏的原始比例和方形缩略图切换