### PR TITLE
fix(view): defer visible date range refresh

### DIFF
--- a/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
+++ b/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
@@ -105,6 +105,18 @@ FocusScope {
         ThumbnailTools.executeDelete()
     }
 
+    // Coalesce scroll and layout changes before querying the visible date range.
+    function scheduleTimeScope() {
+        timeScopeTimer.restart()
+    }
+
+    Timer {
+        id: timeScopeTimer
+        interval: 16
+        repeat: false
+        onTriggered: totalTimeScope()
+    }
+
     //统计当前页面的缩略图时间范围
     function totalTimeScope() {
         if(thumnailListType === Album.Types.ThumbnailAllCollection &&
@@ -116,7 +128,7 @@ FocusScope {
                 var url2 = thumbnailModel.data(visilbeIndexs[visilbeIndexs.length - 1], "url")
                 var str = albumControl.getFileTime(url1, url2)
                 timeChanged(str)
-            } else {
+            } else if (thumbnailModel.rowCount() === 0) {
                 timeChanged("")
             }
         }
@@ -475,7 +487,7 @@ FocusScope {
                 id: vbar
                 active: false
                 onPositionChanged: {
-                    totalTimeScope()
+                    scheduleTimeScope()
                 }
             }
 
@@ -1124,7 +1136,7 @@ FocusScope {
     }
 
     onRealCellWidthChanged: {
-        totalTimeScope()
+        scheduleTimeScope()
     }
 
 }


### PR DESCRIPTION
Coalesce viewport changes and avoid clearing dates before layout is ready. 合并视口变化，并避免在布局完成前错误清空日期。

Log: 修复合集可见日期范围刷新异常
Influence: 合集滚动和缩略图尺寸变化时的标题日期显示

## Summary by Sourcery

Defer and coalesce visible date range updates in the album thumbnail list view to avoid incorrect clearing during scrolling or layout changes.

Bug Fixes:
- Prevent the album title date range from being cleared when thumbnails are present during scroll and layout updates.

Enhancements:
- Introduce a short debounce timer to coalesce scroll and layout changes before recomputing the visible thumbnail date range.