### PR TITLE
fix: bump actions/checkout to v7 and allow unsafe PR checkout

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Upgrade actions/checkout from v3 to v7 and enable unsafe PR checkout.

升级 actions/checkout 至 v7。

Log: 升级 checkout 动作版本
Influence: cppcheck CI 检出行为更新，需关注后续 CI 运行结果.

## Summary by Sourcery

Update cppcheck CI workflow to use the latest checkout action and support unsafe pull request checkouts.

CI:
- Bump actions/checkout in the cppcheck workflow from v3 to v7.
- Enable allow-unsafe-pr-checkout in the cppcheck workflow to allow checking out pull request heads safely within CI.