### PR TITLE
fix(view): reset inactive state after right-click

### DIFF
--- a/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
+++ b/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
@@ -283,6 +283,7 @@ FocusScope {
 
         onReleased: (mouse)=> {
             if (mouse.button === Qt.RightButton) {
+                GStatus.windowDisActived = false
                 pressCanceled();
                 return;
             }


### PR DESCRIPTION
Reset the inactive marker when a right-button release completes. 右键释放完成时复位窗口失焦标记。

Log: 修复失焦后右键导致首次空白点击无法取消选中
Influence: 缩略图列表右键菜单后的空白点击可正常取消选中