### PR TITLE
fix(view): reset all-items content state before title update

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -190,6 +190,7 @@ SwitchViewAnimation {
             refreshTitleModel = true
         if (updateDateRange === undefined)
             updateDateRange = true
+        GStatus.allCollectionContentResolved = false
         if (!(theViewLoader.width > 0)
                 || !(theViewLoader.height > theViewLoader.contentTopMargin))
             return false


### PR DESCRIPTION
Clear the previous all-items resolution state before updating the title. 更新标题前清除上一次全部合集的解析状态。

Log: 修复全部合集解析状态跨刷新残留
Influence: 全部合集比例按钮按当前内容状态正确显示