### PR TITLE
fix(view): prevent About dialog details from being clipped

### DIFF
--- a/src/qml/PreviewImageViewer/ViewTopTitle.qml
+++ b/src/qml/PreviewImageViewer/ViewTopTitle.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -190,7 +190,6 @@ Rectangle {
                     version: Qt.application.version
                     websiteName:DTK.deepinWebsiteName
                     websiteLink:DTK.deepinWebsiteLink
-                    license:qsTr("%1 is released under %2.").arg(productName).arg("GPLV3")
                 }
             }
 


### PR DESCRIPTION
Remove explicit license text to keep the details pane visible. 移除显式许可证文本，保持详情区域可见。

Log: 修复打开图片页关于信息显示不全
PMS: BUG-371735
Influence: 打开图片页的关于弹窗可正常显示版本、主页和描述

## Summary by Sourcery

Bug Fixes:
- Fix clipping of version, homepage, and description information in the image preview About dialog by omitting the explicit license text.