### PR TITLE
fix(preview): debounce navigation and defer neighbor loading

### DIFF
--- a/src/qml/PreviewImageViewer/ImageDelegate/ViewDelegateLoader.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/ViewDelegateLoader.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -28,7 +28,7 @@ Loader {
         if (PathView.isCurrentItem) {
             return true;
         }
-        return PathView.onPath;
+        return PathView.onPath && PathView.view.preloadNeighbors;
     }
     asynchronous: true
     enabled: PathView.isCurrentItem

--- a/src/qml/PreviewImageViewer/ImageViewer.qml
+++ b/src/qml/PreviewImageViewer/ImageViewer.qml
@@ -442,6 +442,12 @@ Item {
         }
         // 用于限制拖拽方向(处于头尾时)
         property real previousOffset: 0
+        property bool preloadNeighbors: false
+
+        function scheduleNeighborPreload() {
+            preloadNeighbors = false;
+            neighborPreloadTimer.restart();
+        }
 
         // WARNING: 目前 ListView 组件屏蔽输入处理，窗口拖拽依赖底层的 ApplicationWindow
         // 因此不允许 ListView 的区域超过标题栏，图片缩放超过显示区域无妨。
@@ -545,13 +551,27 @@ Item {
             }
         }
 
+        Timer {
+            id: neighborPreloadTimer
+
+            interval: 300
+            repeat: false
+
+            onTriggered: {
+                view.preloadNeighbors = true;
+            }
+        }
+
         Component.onCompleted: {
             // 首次进入(退出缩略图后创建)重置当前显示的索引
             GStatus.viewFlicking = true;
             currentIndex = GControl.viewModel.currentIndex;
             GStatus.viewFlicking = false;
+            neighborPreloadTimer.start();
         }
         onCurrentIndexChanged: {
+            scheduleNeighborPreload();
+
             var curIndex = view.currentIndex;
             var previousIndex = GControl.viewModel.currentIndex;
             var lastIndex = view.count - 1;

--- a/src/src/globalcontrol.cpp
+++ b/src/src/globalcontrol.cpp
@@ -14,6 +14,7 @@
 #include <QApplication>
 
 static const int sc_SubmitInterval = 200;  // 图片变更提交定时间隔 200ms
+static const int sc_ViewModelSyncInterval = 200;  // Main image view-model synchronization debounce interval.
 
 /**
    @class GlobalControl
@@ -487,6 +488,9 @@ void GlobalControl::timerEvent(QTimerEvent *event)
         // qDebug() << "Branch: submitTimer.timerId() == event->timerId()";
         submitTimer.stop();
         submitImageChangeImmediately();
+    } else if (viewModelSyncTimer.timerId() == event->timerId()) {
+        viewModelSyncTimer.stop();
+        viewSourceModel->setCurrentSourceIndex(curIndex, curFrameIndex);
     }
     // qDebug() << "GlobalControl::timerEvent - Function exit";
 }
@@ -553,7 +557,7 @@ void GlobalControl::setIndexAndFrameIndex(int index, int frameIndex)
 
     checkSwitchEnable();
 
-    // 更新视图模型
-    viewSourceModel->setCurrentSourceIndex(curIndex, curFrameIndex);
+    // 快速导航时仅同步最终索引，避免解码中间图片。
+    viewModelSyncTimer.start(sc_ViewModelSyncInterval, this);
     qDebug() << "GlobalControl::setIndexAndFrameIndex - Function exit";
 }

--- a/src/src/globalcontrol.h
+++ b/src/src/globalcontrol.h
@@ -103,6 +103,7 @@ private:
 
     int imageRotation = 0;    // 当前图片旋转角度
     QBasicTimer submitTimer;  // 图片变更提交定时器
+    QBasicTimer viewModelSyncTimer;  // Main image view-model synchronization debounce timer.
 };
 
 #endif  // GLOBALCONTROL_H


### PR DESCRIPTION
Debounce PathView model synchronization and preload neighbors after idle.

对大图导航模型同步进行防抖，并在停止切换后延迟预加载邻图。

Log: 降低快速切图时的并发解码数量

Influence: 连续切图时仅同步最终位置，减少中间图片解码与内存峰值。

## Summary by Sourcery

Debounce main image view-model synchronization and delay neighbor image loading after navigation stops to reduce unnecessary decoding and memory usage.

New Features:
- Introduce a deferred neighbor image preload mechanism in the preview PathView, triggered after a short idle period following index changes.

Enhancements:
- Debounce synchronization of the main image view model so that rapid navigation only updates to the final index, reducing intermediate image decoding.
- Gate off-path delegate loading on a PathView-level preload flag to avoid eagerly creating neighbor views.
- Update the ViewDelegateLoader file copyright header years.