### PR TITLE
fix(preview): load images at display resolution

### DIFF
--- a/src/deepin-album.qrc
+++ b/src/deepin-album.qrc
@@ -30,6 +30,7 @@
         <file>qml/PreviewImageViewer/InformationDialog/PropertyItemDelegate.qml</file>
         <file>qml/PreviewImageViewer/ImageDelegate/BaseImageDelegate.qml</file>
         <file>qml/PreviewImageViewer/ImageDelegate/NormalImageDelegate.qml</file>
+        <file>qml/PreviewImageViewer/ImageDelegate/SourceSizeOptimizer.qml</file>
         <file>qml/PreviewImageViewer/ImageDelegate/SvgImageDelegate.qml</file>
         <file>qml/PreviewImageViewer/ImageDelegate/DynamicImageDelegate.qml</file>
         <file>qml/PreviewImageViewer/ImageDelegate/NonexistImageDelegate.qml</file>

--- a/src/qml/PreviewImageViewer/ImageDelegate/NormalImageDelegate.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/NormalImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023~2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,8 +10,31 @@ BaseImageDelegate {
     id: delegate
 
     property bool rotationRunning: false
+    property bool sourceUpdatePending: false
+    readonly property int neighborPreviewMaxDimension: 960
+
+    function previewSize(maxDimension) {
+        if (delegate.width <= 0 || delegate.height <= 0) {
+            return Qt.size(maxDimension, maxDimension)
+        }
+
+        var longestEdge = Math.max(delegate.width, delegate.height)
+        if (longestEdge <= maxDimension) {
+            return Qt.size(delegate.width, delegate.height)
+        }
+
+        var scale = maxDimension / longestEdge
+        return Qt.size(Math.round(delegate.width * scale), Math.round(delegate.height * scale))
+    }
+
+    function neighborPreviewSize() {
+        return previewSize(neighborPreviewMaxDimension)
+    }
 
     function resetSource() {
+        // check if source rename
+        updateSource();
+
         // 加载完成，触发动画效果
         var temp = image.source;
         image.source = "";
@@ -21,10 +44,14 @@ BaseImageDelegate {
     }
 
     function updateSource() {
+        sourceSizeOptimizer.resetSourceSize()
         if (delegate.source != "") {
+            // Do not retain the old texture while changing images; retain it only for same-image scale upgrades.
+            sourceUpdatePending = true
             // 由于会 resetSource() 破坏绑定，因此重新设置源数据
             image.source = "image://ImageLoad/" + delegate.source + "#frame_" + delegate.frameIndex;
         } else {
+            sourceUpdatePending = false
             image.source = "";
         }
     }
@@ -47,12 +74,54 @@ BaseImageDelegate {
         scale: 1.0
         smooth: true
         source: "image://ImageLoad/" + delegate.source + "#frame_" + delegate.frameIndex
+        sourceSize: delegate.isCurrentImage ? sourceSizeOptimizer.optimizedSourceSize
+                                             : delegate.neighborPreviewSize()
         width: delegate.width
+        // debounced (scroll wheel): retain old texture for smooth transition
+        // immediate (large jump): no retain, use snapshot instead
+        retainWhileLoading: !delegate.sourceUpdatePending && !sourceSizeOptimizer.immediateUpgrade
+
+        onScaleChanged: {
+            sourceSizeOptimizer.requestUpdate()
+        }
 
         onStatusChanged: {
+            if (Image.Ready === image.status || Image.Error === image.status) {
+                sourceUpdatePending = false
+            }
             if (Image.Ready === image.status && !rotationRunning) {
                 rotateAnimationLoader.active = false;
+                if (upgradeSnapshotLoader.active) {
+                    upgradeSnapshotLoader.active = false
+                }
             }
+        }
+    }
+
+    SourceSizeOptimizer {
+        id: sourceSizeOptimizer
+        targetImage: image
+        imageInfo: targetImageInfo
+        delegateWidth: delegate.width
+        delegateHeight: delegate.height
+    }
+
+    // Snapshot for immediate mode: shows old texture while new texture loads
+    Loader {
+        id: upgradeSnapshotLoader
+        active: sourceSizeOptimizer.showUpgradeSnapshot
+        anchors.fill: parent
+
+        sourceComponent: ShaderEffectSource {
+            anchors.centerIn: parent
+            width: image.width
+            height: image.height
+            sourceItem: image
+            live: false
+            hideSource: true
+            scale: image.scale
+            mipmap: true
+            smooth: true
         }
     }
 
@@ -69,7 +138,7 @@ BaseImageDelegate {
             property real previousRealWidth: 0
 
             function calcAnimation() {
-                rotationAnimation.to = GControl.currentRotation;
+                rotationAnimation.to = IV.GControl.currentRotation;
                 // 初始化缩放比后再允许动画
                 imageProxy.scale = image.scale;
                 imageScaleBehavior.enabled = true;
@@ -110,7 +179,7 @@ BaseImageDelegate {
                     NumberAnimation {
                         id: scaleAnimation
 
-                        duration: GStatus.animationDefaultDuration - delayUpdate.interval
+                        duration: IV.GStatus.animationDefaultDuration - delayUpdate.interval
                         easing.type: Easing.OutExpo
                     }
                 }
@@ -154,13 +223,13 @@ BaseImageDelegate {
                     id: rotationAnimation
 
                     direction: RotationAnimation.Shortest
-                    duration: GStatus.animationDefaultDuration
+                    duration: IV.GStatus.animationDefaultDuration
                     easing.type: Easing.OutExpo
                     target: imageProxy
                 }
 
                 NumberAnimation {
-                    duration: GStatus.animationDefaultDuration
+                    duration: IV.GStatus.animationDefaultDuration
                     easing.type: Easing.OutExpo
                     properties: "x, y"
                     target: imageProxy
@@ -174,7 +243,7 @@ BaseImageDelegate {
         id: imageInput
 
         anchors.fill: parent
-        isRotatable: FileControl.isRotatable(delegate.source.toString())
+        isRotatable: IV.FileControl.isRotatable(delegate.source)
         targetImage: image.status === Image.Ready ? image : null
     }
 
@@ -182,13 +251,13 @@ BaseImageDelegate {
         function onChangeRotationCacheBegin() {
             // Note: 确保缓存中的数据已刷新后更新界面
             // 0 为复位，缓存中的数据已转换，无需再次加载
-            if (0 !== GControl.currentRotation) {
+            if (0 !== IV.GControl.currentRotation) {
                 // 激活旋转动画加载器
                 rotateAnimationLoader.active = true;
             }
         }
 
         enabled: isCurrentImage
-        target: GControl
+        target: IV.GControl
     }
 }

--- a/src/qml/PreviewImageViewer/ImageDelegate/SourceSizeOptimizer.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/SourceSizeOptimizer.qml
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2023~2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Window
+
+// Dynamic sourceSize optimization during zoom.
+// Two upgrade modes:
+//   - Debounced (scroll wheel): Timer-delayed upgrade with retainWhileLoading
+//   - Immediate (imageInfo loaded while zoomed): instant upgrade with snapshot transition
+// Once upgraded, high-res sourceSize is kept until the image source changes.
+Item {
+    id: optimizer
+
+    property Image targetImage: null
+    property var imageInfo: null
+    property real delegateWidth: 0
+    property real delegateHeight: 0
+    property int maxDimension: 15000
+    // 225M pixels * 4 bytes = ~900MB GPU memory cap
+    property int maxTotalPixels: 225 * 1000 * 1000
+    // Skip upgrade if original pixel count is below this factor of display pixels.
+    property real upgradeThreshold: 2.0
+    // Debounce delay (ms) for scroll-wheel zoom before upgrading sourceSize.
+    property int debounceInterval: 400
+
+    property real zoomedWidth: 0
+    property real zoomedHeight: 0
+    readonly property bool isUpgraded: zoomedWidth > 0
+    // True when upgrade was triggered by imageInfo change; consumer should use
+    // snapshot transition instead of retainWhileLoading.
+    readonly property bool immediateUpgrade: immediateUpgradeFlag
+    property bool immediateUpgradeFlag: false
+    // Convenience: true during Loading after an immediate upgrade; consumer can
+    // bind this to a snapshot Loader's active property.
+    readonly property bool showUpgradeSnapshot: immediateUpgradeFlag && targetImage && targetImage.status === Image.Loading
+
+    property size optimizedSourceSize: zoomedWidth > 0 ? Qt.size(zoomedWidth, zoomedHeight) : Qt.size(delegateWidth, delegateHeight)
+
+    function resetSourceSize() {
+        sourceSizeUpdateTimer.stop()
+        zoomedWidth = 0
+        zoomedHeight = 0
+        immediateUpgradeFlag = false
+    }
+
+    function requestUpdate() {
+        if (!optimizer.targetImage || optimizer.targetImage.scale <= 1.0) {
+            sourceSizeUpdateTimer.stop()
+            return
+        }
+
+        sourceSizeUpdateTimer.restart()
+    }
+
+    function applyUpgrade() {
+        var actualWidth = optimizer.imageInfo ? optimizer.imageInfo.width : 0
+        var actualHeight = optimizer.imageInfo ? optimizer.imageInfo.height : 0
+
+        if (actualWidth <= 0 || actualHeight <= 0) {
+            actualWidth = optimizer.targetImage.width
+            actualHeight = optimizer.targetImage.height
+        }
+
+        if (actualWidth <= 0 || actualHeight <= 0) {
+            return
+        }
+
+        var devicePixelRatio = Screen.devicePixelRatio
+        var requiredWidth = Math.max(1, Math.ceil(optimizer.delegateWidth * optimizer.targetImage.scale * devicePixelRatio))
+        var requiredHeight = Math.max(1, Math.ceil(optimizer.delegateHeight * optimizer.targetImage.scale * devicePixelRatio))
+        if (actualWidth * actualHeight <= requiredWidth * requiredHeight * optimizer.upgradeThreshold) {
+            return
+        }
+
+        var scaleFactor = Math.min(1, requiredWidth / actualWidth, requiredHeight / actualHeight)
+        var w = Math.max(1, Math.round(actualWidth * scaleFactor))
+        var h = Math.max(1, Math.round(actualHeight * scaleFactor))
+        if (zoomedWidth >= w && zoomedHeight >= h) {
+            return
+        }
+
+        var ratio = actualWidth / actualHeight
+
+        if (w > optimizer.maxDimension || h > optimizer.maxDimension) {
+            if (w >= h) {
+                w = optimizer.maxDimension
+                h = Math.max(1, Math.round(optimizer.maxDimension / ratio))
+            } else {
+                h = optimizer.maxDimension
+                w = Math.max(1, Math.round(optimizer.maxDimension * ratio))
+            }
+        }
+
+        if (optimizer.maxTotalPixels > 0) {
+            var totalPixels = w * h
+            if (totalPixels > optimizer.maxTotalPixels) {
+                var shrinkFactor = Math.sqrt(optimizer.maxTotalPixels / totalPixels)
+                w = Math.max(1, Math.round(w * shrinkFactor))
+                h = Math.max(1, Math.round(h * shrinkFactor))
+            }
+        }
+
+        optimizer.zoomedWidth = w
+        optimizer.zoomedHeight = h
+    }
+
+    Connections {
+        target: optimizer.imageInfo
+        ignoreUnknownSignals: true
+
+        function onWidthChanged() { tryApplyImmediate() }
+        function onHeightChanged() { tryApplyImmediate() }
+
+        function tryApplyImmediate() {
+            if (optimizer.imageInfo.width > 0 && optimizer.imageInfo.height > 0
+                    && optimizer.targetImage && optimizer.targetImage.scale > 1.0) {
+                immediateUpgradeFlag = true
+                applyUpgrade()
+            }
+        }
+    }
+
+    Timer {
+        id: sourceSizeUpdateTimer
+        interval: optimizer.debounceInterval
+        repeat: false
+
+        onTriggered: {
+            if (!optimizer.targetImage || !optimizer.targetImage.source) {
+                optimizer.zoomedWidth = 0
+                optimizer.zoomedHeight = 0
+                return
+            }
+
+            if (optimizer.targetImage.scale <= 1.0) {
+                return
+            }
+
+            optimizer.immediateUpgradeFlag = false
+            optimizer.applyUpgrade()
+        }
+    }
+}

--- a/src/src/imagedata/imageinfo.cpp
+++ b/src/src/imagedata/imageinfo.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -184,8 +184,8 @@ void LoadImageInfoRunnable::run()
         data->size = image.size();
         data->frameCount = reader.imageCount();
         qDebug() << "Multi-page image loaded successfully:" << loadPath << "size:" << data->size << "total frames:" << data->frameCount;
-        // 保存图片比例缩放
-        image = image.scaled(100, 100, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+        // 保持缩略图比例，确保预览占位图与原图尺寸一致
+        image = image.scaled(100, 100, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         // 缓存缩略图信息
         ThumbnailCache::instance()->add(data->path, frameIndex, image);
 
@@ -227,8 +227,8 @@ bool LoadImageInfoRunnable::loadImage(QImage &image, QSize &sourceSize) const
     if (ret) {
         sourceSize = image.size();
         qDebug() << "Static image loaded successfully:" << loadPath << "size:" << sourceSize;
-        // 保存图片比例缩放
-        image = image.scaled(100, 100, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+        // 保持缩略图比例，确保预览占位图与原图尺寸一致
+        image = image.scaled(100, 100, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     } else {
         qWarning() << "Failed to load static image:" << loadPath << "error:" << error;
     }

--- a/src/src/imagedata/imageprovider.cpp
+++ b/src/src/imagedata/imageprovider.cpp
@@ -64,6 +64,45 @@ static QImage readNormalImageScaled(const QString &imagePath, const QSize &targe
     reader.setAllocationLimit(2048);
     const QSize orig = reader.size();
 
+    // RAW handlers can report sensor dimensions that differ from decoded pixels.
+    // Use the bounded UnionImage result to obtain the display aspect ratio before
+    // requesting the final RAW decode, so large RAW files are not fully decoded first.
+    if (reader.format().compare(QLatin1String("raw"), Qt::CaseInsensitive) == 0) {
+        QImage aspectProbe = readNormalImage(imagePath);
+        if (aspectProbe.isNull()) {
+            return aspectProbe;
+        }
+
+        if (!targetSize.isValid()) {
+            return aspectProbe;
+        }
+
+        QSize scaledSize = aspectProbe.size();
+        scaledSize.scale(targetSize, Qt::KeepAspectRatio);
+        if (scaledSize.width() > orig.width() || scaledSize.height() > orig.height()) {
+            return aspectProbe;
+        }
+
+        if (scaledSize.width() > 15000 || scaledSize.height() > 15000) {
+            scaledSize.scale(15000, 15000, Qt::KeepAspectRatio);
+        }
+        if (scaledSize.width() * scaledSize.height() > s_maxTotalPixels) {
+            const double factor = std::sqrt(double(s_maxTotalPixels) / (scaledSize.width() * scaledSize.height()));
+            scaledSize.setWidth(qMax(1, int(scaledSize.width() * factor)));
+            scaledSize.setHeight(qMax(1, int(scaledSize.height() * factor)));
+        }
+
+        reader.setScaledSize(scaledSize);
+        QImage image = reader.read();
+        if (image.isNull()) {
+            // Some RAW files expose only an embedded TIFF preview to Qt/libraw.
+            // Keep the main image consistent with the preview placeholder in that case.
+            qWarning() << "RAW decoder failed, using embedded preview:" << imagePath;
+            return aspectProbe;
+        }
+        return image;
+    }
+
     bool needsDownscale = targetSize.isValid() && orig.isValid()
         && targetSize.width() <= orig.width() && targetSize.height() <= orig.height();
 
@@ -242,8 +281,8 @@ void ProviderCache::rotateImageCached(int angle, const QString &imagePath, int f
         // 更新图片缓存
         imageCache.add(imagePath, frameIndex, image);
 
-        // 同样更新缩略图缓存
-        QImage tmpImage = image.scaled(100, 100, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+        // 保持缩略图比例，避免预览占位图与原图尺寸不一致
+        QImage tmpImage = image.scaled(100, 100, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         ThumbnailCache::instance()->add(imagePath, frameIndex, tmpImage);
     } else {
         qWarning() << "Failed to rotate image - image is null:" << imagePath;
@@ -458,8 +497,8 @@ QImage ThumbnailProvider::requestImage(const QString &id, QSize *size, const QSi
     } else {
         image = readNormalImage(tempPath);
     }
-    // 不存在缩略图信息，缓存图片
-    QImage tmpImage = image.scaled(100, 100, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+    // 不存在缩略图信息，缓存保持比例的缩略图
+    QImage tmpImage = image.scaled(100, 100, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     ThumbnailCache::instance()->add(tempPath, frameIndex, tmpImage);
 
     if (size) {


### PR DESCRIPTION
Decode previews at display resolution and preserve RAW and thumbnail ratios.

按显示尺寸解码预览图，并保持 RAW 与缩略图的显示比例一致。

Log: 修复预览图清晰度和显示尺寸不一致

Influence: 降低大图解码内存，修复 RAW 比例错误，并在 RAW 解码失败时回退内嵌预览。

## Summary by Sourcery

Optimize preview image decoding and zoom behavior to match display resolution while preserving RAW and thumbnail aspect ratios and reducing memory usage.

New Features:
- Optimize preview image loading to decode at display resolution with dynamic source sizing during zoom.

Bug Fixes:
- Ensure RAW image previews use correct aspect ratio and fall back to embedded previews when RAW decoding fails.
- Align thumbnail aspect ratios with their original images to avoid inconsistent preview placeholders.

Enhancements:
- Improve preview transition behavior by retaining or snapshotting existing textures based on zoom and navigation patterns.
- Scope global controls for rotation and animation through the IV namespace to clarify usage.