### PR TITLE
fix(memory): release large image buffers through mmap

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,12 +40,23 @@
 #include <QQmlContext>
 #include <QIcon>
 
+#ifdef Q_OS_LINUX
+#include <malloc.h>
+#endif
+
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 
 int main(int argc, char *argv[])
 {
+#ifdef Q_OS_LINUX
+    constexpr int imageBufferMmapThreshold = 128 * 1024;
+    if (!mallopt(M_MMAP_THRESHOLD, imageBufferMmapThreshold)) {
+        qWarning() << "Failed to set image buffer mmap threshold";
+    }
+#endif
+
     //qputenv("QML_DISABLE_DISK_CACHE", "1");
     qputenv("D_POPUP_MODE", "embed");
     if (qEnvironmentVariableIsEmpty("XDG_CURRENT_DESKTOP")) {


### PR DESCRIPTION
Use glibc mmap allocation for large image buffers on Linux.

在 Linux 上使用 glibc mmap 分配大图缓冲，改善释放后的内存回落。

Log: 改善大图浏览后的进程内存回收

Influence: 大图缓冲释放后更容易归还给系统，降低持续浏览时的 RSS。

## Summary by Sourcery

Enhancements:
- Set a Linux-specific mmap threshold for large image buffers at application startup to reduce RSS after freeing large images.