### PR TITLE
feat(accessibility): add AT-SPI accessible names to C++ widgets

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -64,3 +64,8 @@ Files: tests/*
 Copyright: UnionTech Software Technology Co., Ltd.
 License: GPL-3.0-or-later
 
+# at-spi scan artifacts
+Files: tests/at/spi/*
+Copyright: UnionTech Software Technology Co., Ltd.
+License: GPL-3.0-or-later
+

--- a/src/src/widgets/importtimelineview/importtimelineview.cpp
+++ b/src/src/widgets/importtimelineview/importtimelineview.cpp
@@ -37,6 +37,8 @@ ImportTimeLineView::ImportTimeLineView(QmlWidget *parent)
     , m_oe(nullptr), m_oet(nullptr), m_ctrlPress(false)
 {
     qDebug() << "Initializing ImportTimeLineView";
+    setObjectName("ImportTimeLineView");
+    setAccessibleName("ImportTimeLineView");
     m_qquickContainer = parent;
     //setAcceptDrops(true);
     QVBoxLayout *pMainBoxLayout = new QVBoxLayout(this);

--- a/src/src/widgets/thumbnail/thumbnaillistview.cpp
+++ b/src/src/widgets/thumbnail/thumbnaillistview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -61,6 +61,8 @@ ThumbnailListView::ThumbnailListView(ThumbnailDelegate::DelegateType type, int U
     :  DListView(parent), m_delegatetype(type), m_allfileslist(), updateEnableSelectionByMouseTimer(nullptr)
 {
     qDebug() << "Initializing ThumbnailListView with type:" << type << "UID:" << UID << "imageType:" << imgtype;
+    setObjectName("ThumbnailListView");
+    setAccessibleName("ThumbnailListView");
     m_model = new QStandardItemModel(this);
     m_imageType = imgtype;
     m_currentUID = UID;

--- a/src/src/widgets/thumbnail/timelinedatewidget.cpp
+++ b/src/src/widgets/thumbnail/timelinedatewidget.cpp
@@ -22,6 +22,8 @@ TimeLineDateWidget::TimeLineDateWidget(QStandardItem *item, const QString &time,
     :  m_chooseBtn(nullptr), m_pDate(nullptr), m_pNumCheckBox(nullptr), m_currentItem(item)
 {
     qDebug() << "Creating TimeLineDateWidget - time:" << time << "num:" << num;
+    setObjectName("TimeLineDateWidget");
+    setAccessibleName("TimeLineDateWidget");
     this->setContentsMargins(0, 0, 0, 0);
 
     //时间线日期
@@ -162,6 +164,8 @@ importTimeLineDateWidget::importTimeLineDateWidget(QStandardItem *item, const QS
     : m_chooseBtn(nullptr), m_pDateandNumCheckBox(nullptr), m_currentItem(item)
 {
     qDebug() << "Creating importTimeLineDateWidget - time:" << time << "num:" << num;
+    setObjectName("ImportTimeLineDateWidget");
+    setAccessibleName("ImportTimeLineDateWidget");
     this->setContentsMargins(6, 0, 0, 0);
 
     //时间+照片数量

--- a/src/src/widgets/timelineview/timelineview.cpp
+++ b/src/src/widgets/timelineview/timelineview.cpp
@@ -38,6 +38,8 @@ TimeLineView::TimeLineView(QmlWidget *parent)
     , m_selPicNum(0)
 {
     qDebug() << "Creating TimeLineView";
+    setObjectName("TimeLineView");
+    setAccessibleName("TimeLineView");
     m_qquickContainer = parent;
     //setAcceptDrops(true);
     QVBoxLayout *pMainBoxLayout = new QVBoxLayout(this);

--- a/src/src/widgets/widgtes/expansionmenu.cpp
+++ b/src/src/widgets/widgtes/expansionmenu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,8 @@
 FilterWidget::FilterWidget(QWidget *parent): QWidget(parent)
 {
     qDebug() << "Creating FilterWidget";
+    setObjectName("FilterWidget");
+    setAccessibleName("FilterWidget");
     QHBoxLayout *hb = new QHBoxLayout(this);
     hb->setSpacing(4);
     hb->setContentsMargins(0, 0, 0, 0);
@@ -209,6 +211,8 @@ void ExpansionMenu::setDefaultFilteData(ExpansionPanel::FilteData &data)
 
 FilterLabel::FilterLabel(QWidget *parent)
 {
+    setObjectName("FilterLabel");
+    setAccessibleName("FilterLabel");
     // qDebug() << "Creating FilterLabel";
 }
 

--- a/src/src/widgets/widgtes/expansionpanel.cpp
+++ b/src/src/widgets/widgtes/expansionpanel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,6 +16,8 @@ ExpansionPanel::ExpansionPanel(QWidget *parent)
     : DBlurEffectWidget(parent)
 {
     qDebug() << "ExpansionPanel::ExpansionPanel - Entry";
+    setObjectName("ExpansionPanel");
+    setAccessibleName("ExpansionPanel");
     //wayland背景透明问题
     DPalette imgInfoDlgPl = this->palette();
     QColor imgInfoDlgColor("#F7F7F7");

--- a/src/src/widgets/widgtes/noresultwidget.cpp
+++ b/src/src/widgets/widgtes/noresultwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,6 +15,8 @@
 NoResultWidget::NoResultWidget(QWidget *parent): QWidget(parent)
 {
     qDebug() << "NoResultWidget::NoResultWidget - Entry";
+    setObjectName("NoResultWidget");
+    setAccessibleName("NoResultWidget");
     initNoSearchResultView();
 
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &NoResultWidget::changeTheme);

--- a/src/src/widgets/widgtes/toolbutton.cpp
+++ b/src/src/widgets/widgtes/toolbutton.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,6 +12,8 @@
 
 ToolButton::ToolButton(QWidget *parent) : DPushButton(parent)
 {
+    setObjectName("ToolButton");
+    setAccessibleName("ToolButton");
     // qDebug() << "ToolButton::ToolButton - Entry";
     setMinimumSize(200, 11);
     // qDebug() << "ToolButton::ToolButton - Exit";

--- a/tests/at/spi/at-spi-implementation-checklist.md
+++ b/tests/at/spi/at-spi-implementation-checklist.md
@@ -1,0 +1,35 @@
+# deepin-album AT-SPI Implementation Checklist
+
+## Gap Summary
+
+| Gap ID | File | Class | Line | Action | Priority |
+|--------|------|-------|------|--------|----------|
+| G1 | src/src/widgets/timelineview/timelineview.cpp | TimeLineView (DWidget) | ~48 | Add setObjectName + setAccessibleName | Required |
+| G2 | src/src/widgets/importtimelineview/importtimelineview.cpp | ImportTimeLineView (DWidget) | ~35 | Add setObjectName + setAccessibleName | Required |
+| G3 | src/src/widgets/thumbnail/thumbnaillistview.cpp | ThumbnailListView (DListView) | ~88 | Add setObjectName + setAccessibleName | Required |
+| G4 | src/src/widgets/widgtes/noresultwidget.cpp | NoResultWidget (QWidget) | ~12 | Add setObjectName + setAccessibleName | Required |
+| G5 | src/src/widgets/widgtes/expansionmenu.cpp | FilterWidget (QWidget) | ~28 | Add setObjectName + setAccessibleName | Required |
+| G6 | src/src/widgets/widgtes/expansionmenu.cpp | FilterLabel (QLabel) | ~14 | Add setObjectName + setAccessibleName | Required |
+| G7 | src/src/widgets/widgtes/toolbutton.cpp | ToolButton (DPushButton) | ~12 | Add setObjectName + setAccessibleName | Required |
+| G8 | src/src/widgets/widgtes/expansionpanel.cpp | ExpansionPanel (DBlurEffectWidget) | ~30 | Add setObjectName + setAccessibleName | Required |
+| G9 | src/src/widgets/thumbnail/timelinedatewidget.cpp | TimeLineDateWidget (DWidget) | ~17 | Add setObjectName + setAccessibleName | Required |
+| G10 | src/src/widgets/thumbnail/timelinedatewidget.cpp | importTimeLineDateWidget (DWidget) | ~150 | Add setObjectName + setAccessibleName | Required |
+
+## Implementation Notes
+
+Each gap requires adding the following lines **immediately after the constructor
+body begins**, before any child widget creation:
+
+```cpp
+setObjectName("ClassName");
+setAccessibleName("ClassName");
+```
+
+For QWidget subclasses both calls are required.  
+Not needed for: QQuickPaintedItem (QQuickItem subclasses — use QML Accessible),
+QObject subclasses, data-only classes.
+
+## Validation
+
+- Build with cmake + make (or ninja) — must compile without errors
+- libclang AST scan can verify coverage improvement from 0% to ~90%

--- a/tests/at/spi/expected-at-spi-elements.md
+++ b/tests/at/spi/expected-at-spi-elements.md
@@ -1,0 +1,36 @@
+# deepin-album Expected AT-SPI Elements
+
+## Baseline Coverage
+
+- **Total interactive C++ widget classes**: 11
+- **Existing setAccessibleName calls**: 0
+- **Existing setObjectName calls**: 0 (1 commented out)
+- **Pre-completion coverage**: 0%
+
+## Expected Names
+
+| # | AccessibleName | Role | Widget Class | File | Line (constructor) | Derivation |
+|---|---|---|---|---|---|---|
+| 1 | TimeLineView | panel | TimeLineView (DWidget) | timelineview.cpp | 48 | ClassName |
+| 2 | ImportTimeLineView | panel | ImportTimeLineView (DWidget) | importtimelineview.cpp | - | ClassName |
+| 3 | ThumbnailListView | list | ThumbnailListView (DListView) | thumbnaillistview.cpp | 88 | ClassName |
+| 4 | NoResultWidget | label | NoResultWidget (QWidget) | noresultwidget.cpp | 12 | ClassName |
+| 5 | FilterWidget | panel | FilterWidget (QWidget) | expansionmenu.cpp | 28 | ClassName |
+| 6 | FilterLabel | label | FilterLabel (QLabel) | expansionmenu.cpp | 14 | ClassName |
+| 7 | ToolButton | push button | ToolButton (DPushButton) | toolbutton.cpp | 12 | ClassName |
+| 8 | ExpansionPanel | panel | ExpansionPanel (DBlurEffectWidget) | expansionpanel.cpp | 30 | ClassName |
+| 9 | TimeLineDateWidget | panel | TimeLineDateWidget (DWidget) | timelinedatewidget.cpp | 17 | ClassName |
+| 10 | ImportTimeLineDateWidget | panel | importTimeLineDateWidget (DWidget) | timelinedatewidget.cpp | 150 | ClassName |
+
+## Notes
+
+- All names follow PascalCase convention, English only, no special characters.
+- The application UI is primarily QML-based. QQuickItem (QmlWidget, RubberBand,
+  QImageItem, MouseEventListener, etc.) subclasses do NOT use QWidget's
+  `setAccessibleName()` — they use QML `Accessible` properties instead and
+  are outside the scope of this C++ AT-SPI completion pass.
+- DLabel, DCheckBox, DCommandLinkButton child widgets inside parent containers
+  are decorative/utility and do not need individual AT-SPI names per the
+  at-spi-completion guidelines (only interactive widgets).
+- Both `setObjectName()` AND `setAccessibleName()` are added for QWidget
+  subclasses. QWidget subclasses only — QAction/QShortcut/QObject are excluded.

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -1,0 +1,74 @@
+# Expected AT-SPI names — deepin-album
+# Auto-generated from manual code analysis
+# Version: 1.0
+
+widgets:
+  - accessible_name: "TimeLineView"
+    object_name: "TimeLineView"
+    class: "TimeLineView"
+    file: "src/src/widgets/timelineview/timelineview.cpp"
+    line: 41
+    role: "panel"
+
+  - accessible_name: "ImportTimeLineView"
+    object_name: "ImportTimeLineView"
+    class: "ImportTimeLineView"
+    file: "src/src/widgets/importtimelineview/importtimelineview.cpp"
+    line: 40
+    role: "panel"
+
+  - accessible_name: "ThumbnailListView"
+    object_name: "ThumbnailListView"
+    class: "ThumbnailListView"
+    file: "src/src/widgets/thumbnail/thumbnaillistview.cpp"
+    line: 64
+    role: "list"
+
+  - accessible_name: "NoResultWidget"
+    object_name: "NoResultWidget"
+    class: "NoResultWidget"
+    file: "src/src/widgets/widgtes/noresultwidget.cpp"
+    line: 18
+    role: "label"
+
+  - accessible_name: "FilterWidget"
+    object_name: "FilterWidget"
+    class: "FilterWidget"
+    file: "src/src/widgets/widgtes/expansionmenu.cpp"
+    line: 24
+    role: "panel"
+
+  - accessible_name: "FilterLabel"
+    object_name: "FilterLabel"
+    class: "FilterLabel"
+    file: "src/src/widgets/widgtes/expansionmenu.cpp"
+    line: 214
+    role: "label"
+
+  - accessible_name: "ToolButton"
+    object_name: "ToolButton"
+    class: "ToolButton"
+    file: "src/src/widgets/widgtes/toolbutton.cpp"
+    line: 15
+    role: "push button"
+
+  - accessible_name: "ExpansionPanel"
+    object_name: "ExpansionPanel"
+    class: "ExpansionPanel"
+    file: "src/src/widgets/widgtes/expansionpanel.cpp"
+    line: 19
+    role: "panel"
+
+  - accessible_name: "TimeLineDateWidget"
+    object_name: "TimeLineDateWidget"
+    class: "TimeLineDateWidget"
+    file: "src/src/widgets/thumbnail/timelinedatewidget.cpp"
+    line: 25
+    role: "panel"
+
+  - accessible_name: "ImportTimeLineDateWidget"
+    object_name: "ImportTimeLineDateWidget"
+    class: "importTimeLineDateWidget"
+    file: "src/src/widgets/thumbnail/timelinedatewidget.cpp"
+    line: 167
+    role: "panel"

--- a/tests/at/spi/ui-map.md
+++ b/tests/at/spi/ui-map.md
@@ -1,0 +1,77 @@
+# deepin-album UI Map (AT-SPI)
+
+## Architecture Overview
+
+deepin-album is a **QML-first** application with embedded C++ widgets. The main
+window is defined in QML (`qrc:/qml/main.qml`). C++ DWidget/QWidget subclasses
+are embedded inside `QmlWidget` (a `QQuickPaintedItem`) and rendered via
+`render()` in `paint()`. These C++ widgets implement the thumbnail grid, timeline
+headers, filter dropdown, and empty-state views.
+
+## Component Tree (C++ Widgets Only)
+
+```
+DApplication
+ └─ QQmlApplicationEngine (QML main.qml)
+     └─ QmlWidget (QQuickPaintedItem)
+         ├─ TimeLineView (DWidget) [day view]
+         │   ├─ DWidget (m_timeLineViewWidget) [container]
+         │   │   ├─ ThumbnailListView (DListView) [thumbnail grid]
+         │   │   │   └─ TimeLineDateWidget (DWidget) [timeline section header] *
+         │   │   │   └─ importTimeLineDateWidget (DWidget) [import section header] *
+         │   │   └─ NoResultWidget (QWidget) [empty state]
+         │   └─ DWidget (m_dateNumItemWidget) [floating title bar]
+         │       ├─ DLabel (m_dateLabel) [date text]
+         │       ├─ DCheckBox (m_numCheckBox) [select all checkbox]
+         │       ├─ DLabel (m_numLabel) [count text]
+         │       └─ FilterWidget (m_ToolButton) [filter dropdown button]
+         │           └─ FilterLabel(s) [filter options]
+         │               └─ ToolButton(s) (DPushButton) [filter items in ExpansionPanel]
+         │
+         └─ ImportTimeLineView (DWidget) [imported view]
+             ├─ DWidget (m_timeLineViewWidget) [container]
+             │   ├─ ThumbnailListView (m_importTimeLineListView) [thumbnail grid]
+             │   └─ NoResultWidget (m_noResultWidget) [empty state]
+             └─ DWidget (m_importTitleItem) [floating title bar]
+                 ├─ DLabel (m_importLabel) [import date label]
+                 ├─ DLabel (m_dateNumLabel) [date+count label]
+                 ├─ DCheckBox (m_dateNumCheckBox) [select all checkbox]
+                 └─ FilterWidget (m_ToolButton) [filter dropdown button]
+```
+
+> * `TimeLineDateWidget` / `importTimeLineDateWidget` are created dynamically
+>   per timeline section via the ThumbnailDelegate (painted as list items).
+
+## Interactive Controls
+
+| Widget | Class | Type | Accessible Path |
+|--------|-------|------|-----------------|
+| Day view container | TimeLineView | DWidget | timeline/day |
+| Imported view container | ImportTimeLineView | DWidget | timeline/imported |
+| Thumbnail grid (day) | ThumbnailListView | DListView | thumbnail/grid-day |
+| Thumbnail grid (imported) | ThumbnailListView | DListView | thumbnail/grid-imported |
+| Empty state | NoResultWidget | QWidget | generic/no-result |
+| Floating date label | DLabel | DLabel | timeline/date-label |
+| Select-all checkbox | DCheckBox | DCheckBox | timeline/select-all |
+| Count label | DLabel | DLabel | timeline/count-label |
+| Filter button | FilterWidget | QWidget | timeline/filter-button |
+| Filter panel | ExpansionPanel | DBlurEffectWidget | timeline/filter-panel |
+| Filter "All" button | ToolButton | DPushButton | timeline/filter-all |
+| Filter "Photos" button | ToolButton | DPushButton | timeline/filter-photos |
+| Filter "Videos" button | ToolButton | DPushButton | timeline/filter-videos |
+| Filter label (each) | FilterLabel | QLabel | timeline/filter-label |
+| Timeline section header | TimeLineDateWidget | DWidget | timeline/section-header |
+| Import section header | importTimeLineDateWidget | DWidget | timeline/import-section-header |
+
+## File Index
+
+| File | Lines | Content |
+|------|-------|---------|
+| src/src/widgets/timelineview/timelineview.cpp | 1- | TimeLineView implementation |
+| src/src/widgets/importtimelineview/importtimelineview.cpp | 1- | ImportTimeLineView implementation |
+| src/src/widgets/thumbnail/thumbnaillistview.cpp | 1- | ThumbnailListView implementation |
+| src/src/widgets/widgtes/expansionmenu.cpp | 1- | FilterWidget, FilterLabel, ExpansionMenu |
+| src/src/widgets/widgtes/expansionpanel.cpp | 1- | ExpansionPanel, ToolButton creation |
+| src/src/widgets/widgtes/toolbutton.cpp | 1- | ToolButton implementation |
+| src/src/widgets/widgtes/noresultwidget.cpp | 1- | NoResultWidget implementation |
+| src/src/widgets/thumbnail/timelinedatewidget.cpp | 1- | TimeLineDateWidget, importTimeLineDateWidget |


### PR DESCRIPTION
## Summary

Add setObjectName() and setAccessibleName() calls to all interactive C++ widget classes that were missing AT-SPI identifiers. This enables AT tools (Orca, dogtail, YouQu) to locate UI elements by name.

## Changes

- **TimeLineView**, **ImportTimeLineView**: timeline container panels
- **ThumbnailListView**: thumbnail grid list
- **NoResultWidget**: empty-state result widget
- **FilterWidget**, **FilterLabel**, **ToolButton**, **ExpansionPanel**: filter dropdown
- **TimeLineDateWidget**, **importTimeLineDateWidget**: timeline section headers

All names follow PascalCase convention with English-only identifiers.

## Coverage

| Metric | Before | After |
|--------|--------|-------|
| Widgets with AT-SPI names | 0% | ~90% |

**Note:** This is a QML-first application. QQuickItem subclasses (QmlWidget, RubberBand, QImageItem, etc.) use QML Accessible properties and are outside this C++ AT-SPI completion scope.

---

Issue: V-1351

## Summary by Sourcery

Add AT-SPI-friendly object and accessible names to key C++ UI widgets and document the resulting accessibility coverage for assistive tools.

New Features:
- Expose stable AT-SPI names for timeline, thumbnail, filter, and empty-state C++ widgets via QWidget object and accessible names.

Enhancements:
- Document the C++ widget hierarchy and expected AT-SPI elements in new UI mapping and checklist docs to guide accessibility tooling and validation.

Tests:
- Add expected-name metadata files to validate that key C++ widgets expose the correct AT-SPI object and accessible names.