### PR TITLE
fix: fix month-view count badge position and add blur background

### DIFF
--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -165,12 +165,50 @@ SwitchViewAnimation {
                 }
             }
 
+            // 数量角标毛玻璃背景：模糊底层缩略图后裁成药丸形，
+            // 与同文件 opacityMask 一致地复用 image 作为特效源。
+            Item {
+                id: badgeBlurSource
+                anchors.fill: image
+                visible: false
+
+                FastBlur {
+                    anchors.fill: parent
+                    source: image
+                    radius: 24
+                }
+            }
+
+            Rectangle {
+                id: badgeMask
+                visible: false
+                width: 60
+                height: 30
+                radius: 20
+
+                anchors {
+                    right: image.right
+                    rightMargin: 10
+                    bottom: image.bottom
+                    bottomMargin: 10
+                }
+            }
+
+            OpacityMask {
+                id: itemCountBlur
+                anchors.fill: image
+                source: badgeBlurSource
+                maskSource: badgeMask
+                visible: itemCount > 6
+                antialiasing: true
+                smooth: true
+            }
+
             Rectangle {
                 id: itemCountLabel
                 visible: itemCount > 6
-                color: "#000000"
+                color: Qt.rgba(0, 0, 0, 0.30)
                 radius: 20
-                opacity: 0.7
                 width: 60
                 height: 30
 
@@ -181,9 +219,9 @@ SwitchViewAnimation {
                 }
 
                 anchors {
-                    right: parent.right
+                    right: image.right
                     rightMargin: 10
-                    bottom: parent.bottom
+                    bottom: image.bottom
                     bottomMargin: 10
                 }
             }


### PR DESCRIPTION
## 根因分析

相册月份合集视图（`MonthCollection.qml`）的「N+」数量角标存在两个 UI 缺陷，结论为强根因：

1. **位置**：角标 `anchors.right/bottom` 锚到了代理项 `delegateMain`，而非可见缩略图 `image`。`delegateMain` 比 `image` 高 `collectionTopMargin=25`（`globalstatus.cpp:27`）且 `image` 垂直居中，导致角标相对缩略图右下角右偏 1px、底边超出 2.5px，未落在「距右/下各 10px」的预期位置。该锚定由 commit `5cda503a2`（规范 anchor 布局）改写为 `parent.right/parent.bottom` 时引入参照系错误。
2. **背景**：角标背景为纯色半透明矩形（`color:"#000000"; opacity:0.7`），无任何模糊，与设计「补充模糊效果」不符。

## 修复方案

在 `MonthCollection.qml` 的 `theDelegate` 内：

- **位置**：`itemCountLabel` 的 `anchors.right/bottom` 由 `parent` 改为 `image`，`rightMargin/bottomMargin` 保持 `10` → 距缩略图右/下各 10px。
- **模糊**：新增 `FastBlur`（`source: image`，`radius: 24`）模糊底层缩略图，经 `OpacityMask`（`maskSource` 为药丸形 `Rectangle`，定位到 `image.right/bottom` 各 10px）裁出药丸形毛玻璃背景；原 `itemCountLabel` 改为轻量深色叠层（`Qt.rgba(0,0,0,0.30)`）+ 白色文字，保证可读性。

复用文件已 `import` 的 `Qt5Compat.GraphicalEffects`，写法与同文件既有 `opacityMask`（`source: image` + `OpacityMask` 裁剪）一致，不新增 import、不切分支、不改 C++/数据逻辑。

## 改动安全评估

低风险：仅修改单个 QML delegate 的样式与锚定，无函数签名/数据逻辑变更，无外部调用者。`image` 作为 `FastBlur`/`OpacityMask` 源沿用了同文件 `opacityMask` 已验证的「`image.visible:false` 仍可作特效源」模式。

## 关联

- PMS: BUG-323505（https://pms.uniontech.com/bug-view-323505.html）

## Summary by Sourcery

Adjust the month collection thumbnail count badge to align with the image corner and add a frosted glass background effect when the item count is high.

New Features:
- Add a blurred, pill-shaped frosted glass background behind the month view item count badge for large collections.

Enhancements:
- Update the month view item count badge styling to use a semi-transparent dark overlay with improved positioning relative to the thumbnail image.