### PR TITLE
fix(import): canonicalize symlink targets before import

### DIFF
--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -847,7 +847,8 @@ void AlbumControl::startMonitor()
         QFileInfoList infos = LibUnionImage_NameSpace::getImagesAndVideoInfo(eachItem, false);
         QStringList currentPaths;
         std::transform(infos.begin(), infos.end(), std::back_inserter(currentPaths), [](const QFileInfo & info) {
-            return info.isSymLink() ? info.readSymLink() : info.absoluteFilePath();
+            const QString canonical = info.canonicalFilePath();
+            return canonical.isEmpty() ? info.absoluteFilePath() : canonical;
         });
 
         //3.1获取已不存在的路径

--- a/src/src/fileMonitor/fileinotify.cpp
+++ b/src/src/fileMonitor/fileinotify.cpp
@@ -205,7 +205,8 @@ void FileInotify::getAllPicture(bool isFirst)
     //提取文件路径
     QStringList filePaths;
     std::transform(list.begin(), list.end(), std::back_inserter(filePaths), [](const QFileInfo & info) {
-        return info.isSymLink() ? info.readSymLink() : info.absoluteFilePath();
+        const QString canonical = info.canonicalFilePath();
+        return canonical.isEmpty() ? info.absoluteFilePath() : canonical;
     });
 
     //获取当前已导入的全部文件

--- a/src/src/imageengine/imageenginethread.cpp
+++ b/src/src/imageengine/imageenginethread.cpp
@@ -108,6 +108,11 @@ void ImportImagesThread::runDetail()
     QStringList tempPaths;
     QStringList filePaths;
     DBImgInfoList dbInfos;
+    // Resolve symlinks to canonical paths so links to the same target share one record.
+    const auto importPath = [](const QFileInfo &info) {
+        const QString canonical = info.canonicalFilePath();
+        return canonical.isEmpty() ? info.absoluteFilePath() : canonical;
+    };
     //判断是否含有目录
     for (const QString &path : m_paths) {
         //是目录，向下遍历,得到所有文件
@@ -115,14 +120,28 @@ void ImportImagesThread::runDetail()
             qDebug() << "Processing directory:" << path;
             QFileInfoList infos = LibUnionImage_NameSpace::getImagesAndVideoInfo(path, true);
 
-            std::transform(infos.begin(), infos.end(), std::back_inserter(tempPaths), [](const QFileInfo & info) {
-                return info.absoluteFilePath();
-            });
+            std::transform(infos.begin(), infos.end(), std::back_inserter(tempPaths), importPath);
             qDebug() << "Found" << infos.size() << "files in directory";
         } else {//非目录
             qDebug() << "Processing file:" << path;
-            tempPaths << path;
+            tempPaths << importPath(QFileInfo(path));
         }
+    }
+
+    // De-duplicate canonical paths before the database lookup.
+    {
+        QSet<QString> seen;
+        QStringList deduped;
+        deduped.reserve(tempPaths.size());
+        for (const QString &p : tempPaths) {
+            if (!seen.contains(p)) {
+                seen.insert(p);
+                deduped << p;
+            }
+        }
+        if (deduped.size() != tempPaths.size())
+            qDebug() << "Removed" << (tempPaths.size() - deduped.size()) << "duplicate paths after symlink resolution";
+        tempPaths = std::move(deduped);
     }
 
     //针对候选路径查询ImageTable3中已存在的路径，避免全表加载


### PR DESCRIPTION
Use canonical target paths for manual and monitored imports. 手动导入、默认监控和自动导入统一使用规范目标路径。

De-duplicate paths resolving to the same target before database lookup. 数据库查询前去重指向同一真实文件的路径。

Log: 修复软链接导入路径不一致及重复记录问题
PMS: BUG-351631
Influence: 相同真实文件的不同软链接只生成一条相册记录，
删除时处理真实目标文件。

## Summary by Sourcery

Canonicalize imported and monitored file paths and de-duplicate symlink targets before database lookup to avoid inconsistent and duplicate album records.

Bug Fixes:
- Ensure manual and monitored imports treat different symlinks to the same file as a single album record.
- Prevent duplicate database entries caused by multiple import paths resolving to the same underlying file.

Enhancements:
- Standardize path resolution across import, album monitoring, and inotify file monitoring using canonical file paths.