### PR TITLE
fix: preserve literal percent signs in trash restore/delete paths

### DIFF
--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -65,6 +65,19 @@ static std::initializer_list<std::pair<QString, QString>> opticalmediakeys {
 static QVector<std::pair<QString, QString>> opticalmediakv(opticalmediakeys);
 static QMap<QString, QString> opticalmediamap(opticalmediakeys);
 
+// QML passes recent-deleted selections as either file URLs or raw paths. Keep
+// absolute raw paths unchanged: constructing a QUrl from a filename containing
+// literal percent escapes (for example, "%CF") changes the path and its hash.
+QString trashOperationPath(const QString &path)
+{
+    if (QDir::isAbsolutePath(path)) {
+        return path;
+    }
+
+    const QUrl url(path);
+    return url.isLocalFile() ? url.toLocalFile() : path;
+}
+
 } //namespace
 
 AlbumControl *AlbumControl::m_instance = nullptr;
@@ -1777,14 +1790,8 @@ QStringList AlbumControl::recoveryImgFromTrash(const QStringList &paths)
 {
     qDebug() << "AlbumControl::recoveryImgFromTrash - Function entry, paths count:" << paths.size();
     QStringList localPaths;
-    for (QUrl path : paths) {
-        if (path.isLocalFile()) {
-            // qDebug() << "AlbumControl::recoveryImgFromTrash - Branch: processing local file:" << path;
-            localPaths << url2localPath(path);
-        } else {
-            // qDebug() << "AlbumControl::recoveryImgFromTrash - Branch: processing non-local URL:" << path;
-            localPaths << path.toString();
-        }
+    for (const QString &path : paths) {
+        localPaths << trashOperationPath(path);
     }
     qDebug() << "AlbumControl::recoveryImgFromTrash - Function exit, returning" << localPaths.size() << "paths";
     return DBManager::instance()->recoveryImgFromTrash(localPaths);
@@ -1793,15 +1800,9 @@ QStringList AlbumControl::recoveryImgFromTrash(const QStringList &paths)
 void AlbumControl::deleteImgFromTrash(const QStringList &paths)
 {
     qDebug() << "AlbumControl::deleteImgFromTrash - Function entry, paths count:" << paths.size();
-    QStringList localPaths ;
-    for (QUrl path : paths) {
-        if (path.isLocalFile()) {
-            // qDebug() << "AlbumControl::deleteImgFromTrash - Branch: processing local file:" << path;
-            localPaths << url2localPath(path);
-        } else {
-            // qDebug() << "AlbumControl::deleteImgFromTrash - Branch: processing non-local URL:" << path;
-            localPaths << path.toString();
-        }
+    QStringList localPaths;
+    for (const QString &path : paths) {
+        localPaths << trashOperationPath(path);
     }
     DBManager::instance()->removeTrashImgInfos(localPaths);
     qDebug() << "AlbumControl::deleteImgFromTrash - Function exit";


### PR DESCRIPTION
1. added trashOperationPath() helper that returns absolute local paths verbatim, avoiding implicit QUrl construction;
2. changed recoveryImgFromTrash to iterate QString via trashOperationPath instead of for (QUrl path : paths);
3. changed deleteImgFromTrash the same way via trashOperationPath;
4. kept QUrl-parsing fallback for non-absolute inputs (e.g. file:// URL strings) for backward compatibility;

1. 新增 trashOperationPath() 辅助函数，对绝对本地路径原样返回，避免隐式构造 QUrl;
2. recoveryImgFromTrash 中将 for (QUrl path : paths) 改为遍历 QString 并调用 trashOperationPath;
3. deleteImgFromTrash 同样改为遍历 QString 并调用 trashOperationPath;
4. 保留非绝对路径（如 file:// URL 字符串）回退走 QUrl 解析的兼容分支;

PMS: BUG-312959
Log: 修复最近删除中文件名含字面 %xx 百分号序列的图片无法恢复也无法删除的问题，普通路径与 file:// URL 入参行为不变
