### PR TITLE
chore: update version to 6.0.64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-album (6.0.64) unstable; urgency=medium
+
+  * fix: preserve literal percent signs in trash restore/delete paths
+  * feat(accessibility): add AT-SPI accessible names to C++ / QML widgets
+  * fix(import): canonicalize symlink targets before import
+  * [skip CI] Translate deepin-album.ts in pt_BR
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 13 Aug 2026 19:07:01 +0800
+
 deepin-album (6.0.63) unstable; urgency=medium
 
   * chore: Update version to 6.0.63

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.63.1
+  version: 6.0.64.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
- bump version to 6.0.64

Log : bump version to 6.0.64

## Summary by Sourcery

Build:
- Update linglong package metadata to reference version 6.0.64.1.