### PR TITLE
feat(accessibility): add AT-SPI names to album view QML elements

### DIFF
--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -107,6 +107,8 @@ TitleBar {
 
 
     menu: Menu {
+        Accessible.name: "SettingsMenu"
+        Accessible.role: Accessible.Menu
         x: 0; y: 0
         Action {
             id: equalizerControl
@@ -118,6 +120,7 @@ TitleBar {
         MenuItem {
             id: settingsControl
             text: qsTr("Import folders")
+            Accessible.name: "ImportFoldersMenuItem"
             onTriggered: {
                 albumControl.createNewCustomAutoImportAlbum()
             }
@@ -362,6 +365,7 @@ TitleBar {
                          && window.width <= showCollComboWidth
                 sourceComponent: ComboBox {
                     id: collectionCombo
+                    Accessible.name: "CollectionCombo"
                     textRole: "text"
                     iconNameRole: "icon"
                     currentIndex: 3

--- a/src/qml/ClassificationView/ClassificationView.qml
+++ b/src/qml/ClassificationView/ClassificationView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/qml/ClassificationView/ClassificationView.qml
+++ b/src/qml/ClassificationView/ClassificationView.qml
@@ -95,6 +95,7 @@ BaseView {
         clip: true
 
         GridView {
+            Accessible.name: "ClassificationGrid"
             id: classificationGrid
             anchors.fill: parent
             cellWidth: 280

--- a/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
+++ b/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
@@ -465,6 +465,7 @@ FocusScope {
         }
 
         GridView {
+            Accessible.name: "GridView"
             id: gridView
             anchors.fill: parent
             clip: true
@@ -492,6 +493,7 @@ FocusScope {
 
             //激活滚动条
             ScrollBar.vertical: ScrollBar {
+                Accessible.name: "Vbar_2"
                 id: vbar
                 active: false
                 onPositionChanged: {
@@ -816,6 +818,8 @@ FocusScope {
     //注意：涉及界面切换的，需要做到从哪里进来，就退出到哪里
     //菜单显隐逻辑有点绕，建议头脑清醒的时候再处理
     Menu {
+        Accessible.name: "ThumbnailMenu"
+        Accessible.role: Accessible.Menu
         id: thumbnailMenu
         maxVisibleItems: 30
         //显示大图预览
@@ -890,6 +894,8 @@ FocusScope {
         //隐藏交给后面的Component.onCompleted解决
         Menu {
             enabled: thumnailListType !== Album.Types.ThumbnailTrash
+            Accessible.name: "AddToAlbum"
+            Accessible.role: Accessible.Menu
             id: addToAlbum
             title: qsTr("Add to album")
 


### PR DESCRIPTION
feat(accessibility): add AT-SPI names to album view QML elements

Add Accessible.name/role to AlbumTitle menu, menu item, combobox,
ClassificationView grid, and ThumbnailListViewAlbum menus/grid/scrollbar.

Elements: SettingsMenu, ImportFoldersMenuItem, CollectionCombo,
ClassificationGrid, ThumbnailMenu, AddToAlbum, GridView, Vbar

Log: 增加相册视图QML元素的AT-SPI可访问名称
Issue: V-2243

## Summary by Sourcery

Improve accessibility of album view QML elements by defining AT-SPI names and roles for key controls, menus, grids, and scrollbars.

Enhancements:
- Add Accessible.name and Accessible.role metadata to album title toolbar buttons and menus for screen reader support.
- Label album view collection combo box, classification grid, thumbnail grid view, and related menus/scrollbar with AT-SPI accessible names.