### PR TITLE
feat(accessibility): add AT-SPI names to preview viewer item QML

### DIFF
--- a/src/qml/PreviewImageViewer/InformationDialog/PropertyItem.qml
+++ b/src/qml/PreviewImageViewer/InformationDialog/PropertyItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,6 +18,7 @@ ColumnLayout {
     width: 280
 
     ItemDelegate {
+        Accessible.name: "TitleBar_2"
         id: titleBar
 
         property Palette titleTextColor: Palette {
@@ -52,6 +53,7 @@ ColumnLayout {
     }
 
     ListView {
+        Accessible.name: "Info_2"
         id: info
 
         Layout.fillWidth: true

--- a/src/qml/PreviewImageViewer/PropertyItem.qml
+++ b/src/qml/PreviewImageViewer/PropertyItem.qml
@@ -1,5 +1,5 @@
-// Copyright (C) 2022 UnionTech Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2022-2026 UnionTech Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,6 +14,7 @@ ColumnLayout {
     default property alias content: itemModel.children
 
     ItemDelegate {
+        Accessible.name: "TitleBar"
         id: titleBar
         Layout.fillWidth: true; Layout.preferredHeight: 24
         text: title
@@ -30,6 +31,7 @@ ColumnLayout {
         }
     }
     ListView {
+        Accessible.name: "Info"
         id: info
         Layout.fillWidth: true
         Layout.preferredHeight: contentHeight

--- a/src/qml/PreviewImageViewer/RightMenuItem.qml
+++ b/src/qml/PreviewImageViewer/RightMenuItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,5 +8,7 @@ import QtQuick.Controls 2.4
 import org.deepin.dtk 1.0
 
 MenuItem {
+        Accessible.name: "RightMenuItem_MenuItem"
+        Accessible.role: Accessible.MenuItem
     height: visible ?GStatus.rightMenuItemHeight:0
 }

--- a/src/qml/PreviewImageViewer/Utils/RightMenuItem.qml
+++ b/src/qml/PreviewImageViewer/Utils/RightMenuItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,5 +9,7 @@ import org.deepin.dtk 1.0
 import org.deepin.image.viewer 1.0 as IV
 
 MenuItem {
+        Accessible.name: "RightMenuItem_MenuItem_2"
+        Accessible.role: Accessible.MenuItem
     height: visible ? GStatus.rightMenuItemHeight : 0
 }


### PR DESCRIPTION
feat(accessibility): add AT-SPI names to preview viewer item QML

Add Accessible.name/role to PropertyItem, RightMenuItem, and their variants.

Elements: TitleBar, Info, TitleBar_2, Info_2, RightMenuItem_MenuItem,
RightMenuItem_MenuItem_2

Log: 增加预览视图项目QML元素的AT-SPI可访问名称
Issue: V-2243

## Summary by Sourcery

Add accessibility metadata to preview image viewer QML items to improve screen reader support.

New Features:
- Provide AT-SPI accessible names for title bar and information list elements in preview image viewer dialogs.
- Expose accessible names and roles for right-click menu items in the preview image viewer.