### PR TITLE
feat(accessibility): add AT-SPI names to preview viewer thumbnail QML

### DIFF
--- a/src/qml/PreviewImageViewer/ImageDelegate/MultiImageDelegate.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/MultiImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,6 +12,7 @@ BaseImageDelegate {
     id: multiImageDelegate
 
     ListView {
+        Accessible.name: "MultiImageView"
         id: multiImageView
 
         width: multiImageDelegate.width

--- a/src/qml/PreviewImageViewer/MultiImageListView.qml
+++ b/src/qml/PreviewImageViewer/MultiImageListView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -29,6 +29,7 @@ Item {
     height: parent.height
 
     ListView {
+        Accessible.name: "ListView"
         id: listView
         anchors.fill: parent
 

--- a/src/qml/PreviewImageViewer/ThumbnailButton.qml
+++ b/src/qml/PreviewImageViewer/ThumbnailButton.qml
@@ -6,6 +6,7 @@ import QtQuick 2.11
 import QtQuick.Controls 2.4
 
 ToolButton {
+    Accessible.name: "ThumbnailButton_ToolButton"
 
     Accessible.role: Accessible.Button
 

--- a/src/qml/PreviewImageViewer/ThumbnailDelegate/MultiThumnailDelegate.qml
+++ b/src/qml/PreviewImageViewer/ThumbnailDelegate/MultiThumnailDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -50,6 +50,7 @@ BaseThumbnailDelegate {
     ]
 
     ListView {
+        Accessible.name: "ListView_2"
         id: listView
 
         // 计算调整的 item 宽度，item 宽度允许范围内处于 10px ~ 30px, count一定 >=2


### PR DESCRIPTION
feat(accessibility): add AT-SPI names to preview viewer thumbnail QML

Add Accessible.name/role to ThumbnailButton, thumbnail delegates,
MultiImageDelegate, and MultiImageListView.

Elements: ThumbnailButton_ToolButton, ListView_2, MultiImageView, ListView

Log: 增加预览视图缩略图QML元素的AT-SPI可访问名称
Issue: V-2243

## Summary by Sourcery

Improve accessibility metadata for preview image viewer thumbnails and related list views.

Enhancements:
- Add AT-SPI Accessible.name properties to thumbnail button and multiple ListView-based preview components.
- Set explicit Accessible.role for the thumbnail tool button to ensure correct assistive technology semantics.
- Update SPDX copyright header years for ThumbnailButton QML.