### PR TITLE
feat(accessibility): add AT-SPI names to dialog and control QML

### DIFF
--- a/src/qml/Control/FilterComboBox.qml
+++ b/src/qml/Control/FilterComboBox.qml
@@ -25,6 +25,8 @@ ComboBox {
     }
 
     delegate: MenuItem {
+        Accessible.name: "FilterComboBoxItem"
+        Accessible.role: Accessible.MenuItem
         useIndicatorPadding: true
         width: parent.width
         text: comboBox.textRole ? (Array.isArray(comboBox.model) ? modelData[comboBox.textRole] : model[comboBox.textRole]) : modelData

--- a/src/qml/Control/FlickableScrollBar.qml
+++ b/src/qml/Control/FlickableScrollBar.qml
@@ -8,6 +8,7 @@ import QtQuick.Controls
 // 适用于纯 QML Flickable/ListView 的 ScrollBar 封装
 // 内置绑定循环防护和拖拽冲突处理
 ScrollBar {
+        Accessible.name: "Control"
     id: control
 
     required property Flickable flickable

--- a/src/qml/Control/ListView/RightMenuItem.qml
+++ b/src/qml/Control/ListView/RightMenuItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,5 +8,7 @@ import QtQuick.Controls 2.4
 import org.deepin.dtk 1.0
 
 MenuItem {
+        Accessible.name: "RightMenuItem_MenuItem_3"
+        Accessible.role: Accessible.MenuItem
     height: visible ? GStatus.rightMenuItemHeight : 0
 }

--- a/src/qml/PreviewImageViewer/Dialog/RemoveDialog.qml
+++ b/src/qml/PreviewImageViewer/Dialog/RemoveDialog.qml
@@ -92,6 +92,8 @@ DialogWindow {
             spacing: 10
 
             Button {
+                Accessible.name: "Cancel"
+                Accessible.role: Accessible.Button
                 height: 36
                 text: qsTr("Cancel")
                 width: 185


### PR DESCRIPTION
feat(accessibility): add AT-SPI names to dialog and control QML

Add Accessible.name/role to FilterComboBox item, FlickableScrollBar,
RightMenuItem (list view), and RemoveDialog button.

Elements: FilterComboBoxItem, Control, RightMenuItem_MenuItem_3, Cancel

Log: 增加对话框和控制QML元素的AT-SPI可访问名称
Issue: V-2243

## Summary by Sourcery

Add AT-SPI accessibility names and roles to key QML dialog and control elements to improve screen reader support.

New Features:
- Provide Accessible.name and Accessible.role for the FilterComboBox control and its menu item delegate.
- Annotate RightMenuItem list view entries with appropriate Accessible metadata.
- Expose an accessible name and role for the Cancel button in the RemoveDialog window.
- Assign an accessible name to the FlickableScrollBar control used with Flickable/ListView components.

Enhancements:
- Update SPDX copyright years for FilterComboBox.qml to reflect coverage through 2026.