### PR TITLE
feat(accessibility): add AT-SPI names to sidebar and device view QML

### DIFF
--- a/src/qml/SideBar/SideBarItem.qml
+++ b/src/qml/SideBar/SideBarItem.qml
@@ -1,5 +1,5 @@
-// Copyright (C) 2022 UnionTech Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2022-2026 UnionTech Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -58,6 +58,7 @@ ColumnLayout {
     }
     spacing: 10
     ListView {
+        Accessible.name: "SideListView"
         id: sideListView
         implicitHeight: contentHeight
         width: 180

--- a/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
+++ b/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
@@ -183,12 +183,16 @@ BaseView {
             }
 
             ComboBox {
+                Accessible.name: "FilterCombo"
+                Accessible.role: Accessible.ComboBox
                 id: filterCombo
                 width: 180
                 height: 36
                 displayText : currentIndex == 0?qsTr("Import") : currentIndex == 1? qsTr("New Album")  :albumControl.getAllCustomAlbumName(GStatus.albumChangeList)[currentIndex-2]
                 model: albumControl.getAllCustomAlbumId(GStatus.albumChangeList).length+2
                 delegate: MenuItem {
+                    Accessible.name: "Import"
+                    Accessible.role: Accessible.MenuItem
                     text: index == 0?qsTr("Import") : index == 1? qsTr("New Album")  :albumControl.getAllCustomAlbumName(GStatus.albumChangeList)[index-2]
                     onTriggered:{
                         if(index == 0 ){

--- a/src/qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -101,6 +101,7 @@ Item {
 
     //已导入列表本体
     ListView {
+        Accessible.name: "TheView_7"
         id: theView
         clip: true
         interactive: false //禁用原有的交互逻辑，重新开始定制
@@ -119,6 +120,7 @@ Item {
 
         //激活滚动条
         ScrollBar.vertical: ScrollBar {
+            Accessible.name: "Vbar"
             id: vbar
             active: true
 
@@ -374,6 +376,8 @@ Item {
             }
 
             CheckBox {
+                Accessible.name: "ImportedCheckBox"
+                Accessible.role: Accessible.CheckBox
                 id: importedCheckBox
                 height: importedListView.importCheckboxHeight
                 visible: selectedPaths.length > 0 && index > 0

--- a/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
+++ b/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
@@ -206,6 +206,8 @@ BaseView {
         }
 
         Button {
+            Accessible.name: "RestoreSelectedBtn"
+            Accessible.role: Accessible.Button
             id: restoreSelectedBtn
             anchors {
                 top: recentDelLabel.bottom


### PR DESCRIPTION
feat(accessibility): add AT-SPI names to sidebar and device view QML

Add Accessible.name/role to SideBarItem list, DeviceAlbum combo/menu,
ImportedlListView list/scrollbar/checkbox, and RecentlyDeletedView button.

Elements: SideListView, FilterCombo, Import, TheView_7, Vbar,
ImportedCheckBox, RestoreSelectedBtn

Log: 增加侧边栏和设备视图QML元素的AT-SPI可访问名称
Issue: V-2243

## Summary by Sourcery

Add explicit AT-SPI accessibility names and roles to key QML controls in the sidebar and device views to improve screen-reader support.

Enhancements:
- Assign Accessible.name and role metadata to the device album filter combo box and its import menu item.
- Label the imported items list view and its vertical scrollbar with AT-SPI Accessible.name identifiers.
- Expose the imported items selection checkbox and the recently deleted restore button with appropriate Accessible.name and role values.
- Add an AT-SPI Accessible.name to the sidebar list view for better identification by assistive technologies.