### PR TITLE
feat(accessibility): add AT-SPI names to collection and toolbar QML

### DIFF
--- a/src/qml/PreviewImageViewer/ToolBarThumbnailListView.qml
+++ b/src/qml/PreviewImageViewer/ToolBarThumbnailListView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -292,6 +292,7 @@ Item {
 
 
     ListView {
+        Accessible.name: "BottomthumbnaillistView_2"
         id: bottomthumbnaillistView
 
         // 使用范围模式，允许高亮缩略图在preferredHighlightBegin~End的范围外，使缩略图填充空白区域

--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -66,6 +66,7 @@ SwitchViewAnimation {
     }
 
     ListView {
+        Accessible.name: "TheView_6"
         property double displayFlushHelper: 0
 
         id: theView

--- a/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
@@ -42,6 +42,7 @@ SwitchViewAnimation {
     }
 
     ListView {
+        Accessible.name: "TheView_5"
         property double displayFlushHelper: 0
 
         id: theView


### PR DESCRIPTION
feat(accessibility): add AT-SPI names to collection and toolbar QML

Add Accessible.name/role to MonthCollection list, YearCollection list,
and ToolBarThumbnailListView.

Elements: TheView_6, TheView_5, BottomthumbnaillistView_2

Log: 增加集合视图和工具栏QML元素的AT-SPI可访问名称
Issue: V-2243

## Summary by Sourcery

Add AT-SPI accessible names to thumbnail toolbar and month/year collection list views to improve screen reader support.

New Features:
- Expose distinct Accessible.name properties for the bottom thumbnail list view and month/year collection list views for AT-SPI consumers.

Enhancements:
- Update SPDX copyright years for the toolbar thumbnail list view QML file.