### PR TITLE
fix(album): move sidebar palette setup out of paintEvent to fix flicker

### DIFF
--- a/src/album/albumview/leftlistwidget.cpp
+++ b/src/album/albumview/leftlistwidget.cpp
@@ -9,12 +9,20 @@
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QAbstractItemView>
+#include <DApplicationHelper>
+#include <DPalette>
 #include "widgets/albumlefttabitem.h"
 
 LeftListWidget::LeftListWidget()
 {
     setViewportMargins(8, 0, 8, 0);
     setAcceptDrops(true);
+
+    // 让背景色适合主题颜色：仅在构造和主题变更时设置一次调色板，
+    // 不在 paintEvent 中反复设置，避免删除/恢复相册时界面闪烁
+    updateItemBackgroundPalette();
+    connect(DApplicationHelper::instance(), &DApplicationHelper::themeTypeChanged,
+            this, &LeftListWidget::updateItemBackgroundPalette);
 }
 
 void LeftListWidget::mouseMoveEvent(QMouseEvent *e)
@@ -61,15 +69,13 @@ void LeftListWidget::dragEnterEvent(QDragEnterEvent *event)
     }
 }
 
-void LeftListWidget::paintEvent(QPaintEvent *event)
+void LeftListWidget::updateItemBackgroundPalette()
 {
-    // 让背景色适合主题颜色
-    DPalette pa;
-    pa = DApplicationHelper::instance()->palette(this);
+    // 先重置自定义调色板缓存，使 palette() 能按当前主题重新解析
+    DApplicationHelper::instance()->resetPalette(this);
+    DPalette pa = DApplicationHelper::instance()->palette(this);
     pa.setBrush(DPalette::ItemBackground, pa.brush(DPalette::Base));
     DApplicationHelper::instance()->setPalette(this, pa);
-
-    DListWidget::paintEvent(event);
 }
 
 void LeftListWidget::mousePressEvent(QMouseEvent *e)

--- a/src/album/albumview/leftlistwidget.h
+++ b/src/album/albumview/leftlistwidget.h
@@ -31,8 +31,10 @@ protected:
 
     void dragEnterEvent(QDragEnterEvent *event) override;
 
-    /**@brief:事件重写*/
-    void paintEvent(QPaintEvent *event) override;
+private slots:
+    // 让侧边栏列表项背景色与主题一致：仅在构造和主题变更时设置一次，
+    // 避免在 paintEvent 中反复 setPalette 导致删除/恢复相册时界面闪烁
+    void updateItemBackgroundPalette();
 
 signals:
     void signalDropEvent(QModelIndex index);


### PR DESCRIPTION
## 根因分析

删除/恢复相册"项目"（自定义相册）时界面闪烁，根因为 `LeftListWidget::paintEvent`（`leftlistwidget.cpp:64-73`）中调用 `DApplicationHelper::setPalette(this, pa)`，在绘制事件中修改控件调色板——Qt 反模式。`setPalette()` 触发 `QEvent::PaletteChange` 并向所有子控件（`AlbumLeftTabItem`）传播调色板、调度重绘，形成绘制→调色板传播→子控件重绘→再绘制的反馈循环。删除/恢复时列表密集重绘（`delete item` / `clear()`+重建 / `setFixedHeight`），反馈被放大为可见闪烁。

关键证据：
- 回归提交 `86d7d7cc`（首次进入 tag 5.10.15）引入该 `paintEvent` 反模式，位于正常版本 5.10.13 与回归版本 5.10.20 之间，版本边界吻合。
- 5.10.13（正常版本）无此 `paintEvent` 代码，同样存在 delete/restore 重建路径却不闪烁。

结论级别：强根因（根因复核已通过）。

## 修复方案

将 `ItemBackground` 调色板设置从 `paintEvent` 移至：
- 构造函数中调用一次（`updateItemBackgroundPalette()`）
- 连接 `DApplicationHelper::themeTypeChanged` 信号在主题变更时重新设置

`updateItemBackgroundPalette()` 先 `resetPalette(this)` 清除缓存使 `palette()` 按当前主题重新解析，再设置 `ItemBackground = Base` 色并 `setPalette`。

**不恢复** `DStyledItemDelegate::NoBackground`（协同因素 1）——恢复会导致原 PMS #194199（hover 样式）回归。当前方案保留 NoBackground 移除（hover 仍生效），仅消除 setPalette 反模式。
**不改动** `AlbumLeftTabItem::paintEvent` 的 `setEnabled`（协同因素 2）——`setEnabled(true)` 在值未变时为 no-op，非闪烁主因。

## 改动安全评估

风险等级：低风险。仅移除 `paintEvent` 虚函数重写（无外部调用者）+ 新增私有槽 `updateItemBackgroundPalette()`（构造函数和信号调用）。无签名变更、无公开 API 变更。`LeftListWidget` 的实例化点不受影响。

## 运行时验证建议

修复后建议验证：删除/恢复相册时无闪烁；浅色/深色主题切换后 item 背景色正确；hover 样式正常（原 PMS #194199 不回归）；窗口未激活时图标置灰正常（原 PMS #156983 不回归）。

## Summary by Sourcery

Move sidebar album list background palette handling out of the paint event to prevent UI flicker when albums are deleted or restored.

Bug Fixes:
- Eliminate flickering in the album sidebar when deleting or restoring custom albums by avoiding palette changes during paint events.

Enhancements:
- Ensure the album sidebar item background stays consistent with the current theme by initializing and updating its palette only on construction and theme changes.