### PR TITLE
fix(album): show search box and enable search for recently deleted view

### DIFF
--- a/src/album/albumview/albumview.cpp
+++ b/src/album/albumview/albumview.cpp
@@ -1041,7 +1041,7 @@ void AlbumView::updateRightView()
     } else if (COMMON_STR_TRASH == m_currentType) {
         updateRightTrashView();
         setAcceptDrops(false);
-        emit sigSearchEditIsDisplay(false);
+        emit sigSearchEditIsDisplay(true);
     } else if (COMMON_STR_CLASS == m_currentType) {
         m_bHasClassified = false;
         updateRightClassView();

--- a/src/album/mainwindow.cpp
+++ b/src/album/mainwindow.cpp
@@ -1291,6 +1291,8 @@ void MainWindow::onSearchEditFinished()
                 emit dApp->signalM->sigSendKeywordsIntoALLPic(keywords, COMMON_STR_FAVORITES, DBManager::SpUID::u_Favorite);
             } else if (COMMON_STR_CUSTOM == m_pAlbumview->m_pLeftListView->getItemCurrentType()) {
                 emit dApp->signalM->sigSendKeywordsIntoALLPic(keywords, m_pAlbumview->m_pLeftListView->getItemCurrentName(), m_pAlbumview->m_pLeftListView->getItemCurrentUID());
+            } else if (COMMON_STR_TRASH == m_pAlbumview->m_pLeftListView->getItemCurrentType()) {
+                emit dApp->signalM->sigSendKeywordsIntoALLPic(keywords, COMMON_STR_TRASH);
             }
 
             m_pAlbumview->m_pRightStackWidget->setCurrentIndex(5);
@@ -2245,9 +2247,8 @@ void MainWindow::onButtonClicked(int id)
             createAlbumView();
         }
         albumBtnClicked();
-        // 如果是最近删除或者移动设备,则搜索框不显示
-        if (2 == m_pAlbumview->m_pRightStackWidget->currentIndex()
-                || 6 == m_pAlbumview->m_pRightStackWidget->currentIndex()
+        // 如果是移动设备或分类封面,则搜索框不显示
+        if (6 == m_pAlbumview->m_pRightStackWidget->currentIndex()
                 || (3 == m_pAlbumview->m_pRightStackWidget->currentIndex() && m_pAlbumview->m_currentType == COMMON_STR_CLASS)) {
             m_pSearchEdit->setVisible(false);
         } else {


### PR DESCRIPTION
# 修复最近删除视图缺少搜索框（PMS BUG-231713）

## 根因分析（强根因，已通过独立复核）

进入「相册 → 最近删除」视图后标题栏搜索框不出现，用户无法搜索回收站。后端 `DBManager::getTrashInfosForKeyword` 及 `SearchView` 的 `COMMON_STR_TRASH` 分支早已就绪，但前端两处遗漏 trash 类型，导致功能断链：

- **A1**：`AlbumView::updateRightView()` 的 `COMMON_STR_TRASH` 分支 `emit sigSearchEditIsDisplay(false)` 主动隐藏搜索框（用户左栏点击进入最近删除的主路径）。
- **A2**：`MainWindow::onButtonClicked` 在右栈 index 2（最近删除）时冗余 `m_pSearchEdit->setVisible(false)`。
- **B**：`MainWindow::onSearchEditFinished` 的 `VIEW_ALBUM` 分支 if-else 链缺 `COMMON_STR_TRASH`，输入关键词不 emit 任何 `sigSendKeywordsIntoALLPic`，切到空白搜索页。

A 与 B 互锁：只修可见性则分发缺失搜不到；只修分发则控件不可见无法输入。两端必同修。

## 修复方案

- A1：trash 分支 `emit sigSearchEditIsDisplay(false)` → `true`（设备分支保持 false 不变）。
- A2：`onButtonClicked` 隐藏条件去掉 `2 == currentIndex()` 析取项，保留 `6`（设备）与 `3 + COMMON_STR_CLASS`（分类封面）。
- B：`onSearchEditFinished` 的 `VIEW_ALBUM` 分支新增 `else if (COMMON_STR_TRASH == ...getItemCurrentType()) emit sigSendKeywordsIntoALLPic(keywords, COMMON_STR_TRASH);`，沿用既有 `setCurrentIndex(5)` + `restorePicNum()`。
- 后端无需改动。

## 改动安全评估

低风险：仅可见性标志翻转 + 新增 else-if 分支 + 布尔条件简化，无函数签名/公开 API 变更；不撤销任何历史修复（trash 隐藏非历史 bug 修复产物；分类封面/设备隐藏的合理设计均保留）。受影响调用者签名不变、行为即期望行为。

## 改动范围

- `src/album/albumview/albumview.cpp`（A1，1 行）
- `src/album/mainwindow.cpp`（A2、B，共 6 行）

基线：`release/eagle` @ `b2ae745`。目标分支：`release/eagle`。

## Summary by Sourcery

Enable the Recently Deleted view to display and use the album search box.

New Features:
- Enable searching within the Recently Deleted album view.

Bug Fixes:
- Restore the search box when viewing Recently Deleted items and route entered keywords to the existing trash search flow.