### PR TITLE
feat(accessibility): add AT-SPI names to preview viewer navigation QML

### DIFF
--- a/src/qml/PreviewImageViewer/SliderShow.qml
+++ b/src/qml/PreviewImageViewer/SliderShow.qml
@@ -231,12 +231,16 @@ Item {
     }
 
     Menu {
+        Accessible.name: "SliderMenu"
+        Accessible.role: Accessible.Menu
         id: sliderMenu
 
         x: 250
         y: 600
 
         MenuItem {
+            Accessible.name: "Pause"
+            Accessible.role: Accessible.MenuItem
             text: autoRun ? qsTr("Pause") : qsTr("Play")
 
             onTriggered: {
@@ -258,6 +262,8 @@ Item {
         }
 
         MenuItem {
+            Accessible.name: "Exit"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Exit")
 
             onTriggered: outSliderShow()

--- a/src/qml/PreviewImageViewer/ThumbnailListView.qml
+++ b/src/qml/PreviewImageViewer/ThumbnailListView.qml
@@ -336,6 +336,7 @@ Control {
     }
 
     ListView {
+        Accessible.name: "BottomthumbnaillistView"
         id: bottomthumbnaillistView
 
         property bool lastIsMultiImage: false

--- a/src/qml/PreviewImageViewer/ViewRightMenu.qml
+++ b/src/qml/PreviewImageViewer/ViewRightMenu.qml
@@ -12,6 +12,8 @@ import org.deepin.album 1.0 as Album
 import "./Utils"
 
 Menu {
+    Accessible.name: "OptionMenu"
+    Accessible.role: Accessible.Menu
     id: optionMenu
 
     // 处理拷贝快捷键冲突

--- a/src/qml/PreviewImageViewer/ViewTopTitle.qml
+++ b/src/qml/PreviewImageViewer/ViewTopTitle.qml
@@ -150,6 +150,8 @@ Rectangle {
             }
         }
         menu: Menu {
+            Accessible.name: "ViewTopTitle_Menu"
+            Accessible.role: Accessible.Menu
             onVisibleChanged: {
                 titlebar.menuPopup = visible;
                 GStatus.animationBlock = visible;


### PR DESCRIPTION
Add Accessible.name/role to SliderShow menu/items, ViewRightMenu, ViewTopTitle menu, and ThumbnailListView.

Elements: SliderMenu, Pause, Exit, OptionMenu, ViewTopTitle_Menu, BottomthumbnaillistView

Log: 增加预览视图导航QML元素的AT-SPI可访问名称
Issue: V-2243

## Summary by Sourcery

Add explicit accessibility metadata to preview viewer navigation elements to improve AT-SPI support.

Enhancements:
- Define Accessible.name and Accessible.role for slider show menu and its items.
- Expose accessibility information for the right-side options menu in the preview viewer.
- Add accessibility metadata for the top title menu in the preview viewer.
- Assign an Accessible.name to the bottom thumbnail list view control.