### PR TITLE
feat(accessibility): add AT-SPI names to main menu actions

### DIFF
--- a/src/qml/AlbumTitle.qml
+++ b/src/qml/AlbumTitle.qml
@@ -113,6 +113,7 @@ TitleBar {
         Action {
             id: equalizerControl
             text: qsTr("New album")
+            Accessible.name: "NewAlbumMenuItem"
             onTriggered: {
                 showNewAlbumDialog()
             }
@@ -128,8 +129,11 @@ TitleBar {
         MenuSeparator { }
         ThemeMenu { }
         MenuSeparator { }
-        HelpAction { }
+        HelpAction {
+            Accessible.name: "HelpMenuItem"
+        }
         AboutAction {
+            Accessible.name: "AboutMenuItem"
             aboutDialog: AboutDialog {
                 productName: qsTr("Album")
                 productIcon: "deepin-album"
@@ -140,6 +144,7 @@ TitleBar {
             }
         }
         QuitAction {
+            Accessible.name: "QuitMenuItem"
             onTriggered: {
                 forceExit();
             }


### PR DESCRIPTION
Add Accessible.name to QML Action items in the title bar menu so AT-SPI automation tools can locate them by name:

- `NewAlbumMenuItem` for 'New album' Action
- `HelpMenuItem` for HelpAction
- `AboutMenuItem` for AboutAction
- `QuitMenuItem` for QuitAction

`ImportFoldersMenuItem` already set via MenuItem.

## Summary by Sourcery

New Features:
- Add accessible names to the New album, Help, About, and Quit title bar menu actions for AT-SPI automation.