### PR TITLE
fix: resolve crash when unmounting a device being parsed

### DIFF
--- a/src/src/albumControl.cpp
+++ b/src/src/albumControl.cpp
@@ -327,7 +327,41 @@ QString AlbumControl::getAllFilters()
 void AlbumControl::unMountDevice(const QString &devicePath)
 {
     qDebug() << "AlbumControl::unMountDevice - Function entry, devicePath:" << devicePath;
+    // The unmount flow runs nested event loops; repeated clicks during it would re-enter this flow, so ignore them
+    if (m_unmountingDevice)
+        return;
+    m_unmountingDevice = true;
+    // Defer until the current QML click signal handler returns: a nested event loop that destroys
+    // the view button mid-handler aborts with QML's fatal "signal handler in progress" error
+    QTimer::singleShot(0, this, [this, devicePath]() {
+        doUnmountDevice(devicePath);
+        m_unmountingDevice = false;
+    });
+}
+
+void AlbumControl::doUnmountDevice(const QString &devicePath)
+{
     QString deviceId = DeviceHelper::instance()->getDeviceIdByMountPoint(devicePath);
+    if (!deviceId.isEmpty()) {
+        // Block new reads and wait for in-flight reads to finish first, so the unmount cannot
+        // interrupt device file parsing mid-way and corrupt the parser library's heap
+        DeviceHelper::markUnmounting(devicePath, true);
+        if (!DeviceHelper::waitForReadsDone(devicePath, 1000)) {
+            qWarning() << "AlbumControl::doUnmountDevice - Active reads did not finish";
+            // Reads not drained in time, give up this unmount; the filesystem is untouched,
+            // so unblock reads and inform the user
+            DeviceHelper::markUnmounting(devicePath, false);
+            DDialog busybox;
+            busybox.setFixedWidth(400);
+            busybox.setIcon(DMessageBox::standardIcon(DMessageBox::Critical));
+            busybox.setTextFormat(Qt::AutoText);
+            busybox.setMessage(tr("Disk is busy, cannot eject now"));
+            busybox.addButton(tr("OK"), false, DDialog::ButtonNormal);
+            busybox.exec();
+            emit sigMountsChange();
+            return;
+        }
+    }
     if (!deviceId.isEmpty() && DeviceHelper::instance()->detachDevice(deviceId)) {
         qDebug() << "AlbumControl::unMountDevice - Branch: device detach initiated, waiting for completion";
         // 等待最多200ms超时
@@ -345,19 +379,23 @@ void AlbumControl::unMountDevice(const QString &devicePath)
             m_PhonePicFileMap.remove(devicePath);
         } else {
             qDebug() << "AlbumControl::unMountDevice - Branch: device still exists, showing error dialog";
+            // Unmount failed and the filesystem is still there: unblock reads early so reads
+            // from this device are not rejected while the dialog is up
+            DeviceHelper::markUnmounting(devicePath, false);
             DDialog msgbox;
             msgbox.setFixedWidth(400);
             msgbox.setIcon(DMessageBox::standardIcon(DMessageBox::Critical));
             msgbox.setTextFormat(Qt::AutoText);
             msgbox.setMessage(tr("Disk is busy, cannot eject now"));
-            msgbox.insertButton(1, tr("OK"), false, DDialog::ButtonNormal);
+            msgbox.addButton(tr("OK"), false, DDialog::ButtonNormal);
             auto ret = msgbox.exec();
             Q_UNUSED(ret);
         }
     }
 
+    DeviceHelper::markUnmounting(devicePath, false);
     emit sigMountsChange();
-    qDebug() << "AlbumControl::unMountDevice - Function exit";
+    qDebug() << "AlbumControl::doUnmountDevice - Function exit";
 }
 
 QStringList AlbumControl::getAllUrlPaths(const int &filterType)

--- a/src/src/albumControl.h
+++ b/src/src/albumControl.h
@@ -407,6 +407,7 @@ private:
     void updateBlockDeviceName(const QString &blks);
     void onUnMountedExecute(const QString &deviceKey, DeviceType type);
     bool shouldRetryVideo(const QString &path);
+    void doUnmountDevice(const QString &devicePath); // actual unmount handling, invoked deferred by unMountDevice
 
 signals:
     void sigRefreshAllCollection();
@@ -488,6 +489,7 @@ private :
     QMap<QString, DeviceInfoPtr> m_PhonePicFileMap;   // 外部设备及其全部图片路径
     std::atomic_bool m_couldRun;
     bool m_bneedstop = false;
+    bool m_unmountingDevice = false; // unmount-in-progress flag, prevents re-entry from repeated clicks during nested event loops
     QMutex m_mutex;
 };
 

--- a/src/src/imagedata/imageinfo.cpp
+++ b/src/src/imagedata/imageinfo.cpp
@@ -7,6 +7,7 @@
 #include "thumbnailcache.h"
 #include "unionimage/unionimage.h"
 #include "globalcontrol.h"
+#include "utils/devicehelper.h"
 
 #include <QSet>
 #include <QSize>
@@ -139,6 +140,15 @@ void LoadImageInfoRunnable::run()
     qDebug() << "Loading image info for:" << loadPath << "frame:" << frameIndex;
     ImageInfoData::Ptr data(new ImageInfoData);
     data->path = loadPath;
+
+    DeviceReadGuard readGuard(loadPath);
+    if (!readGuard.isActive()) {
+        qDebug() << "Device is unmounting, skip image info:" << loadPath;
+        data->type = Types::NullImage;
+        notifyFinished(data->path, frameIndex, data);
+        return;
+    }
+
     data->exist = QFileInfo::exists(loadPath);
 
     QFileInfo info(loadPath);

--- a/src/src/imagedata/imageprovider.cpp
+++ b/src/src/imagedata/imageprovider.cpp
@@ -5,6 +5,7 @@
 #include "imageprovider.h"
 #include "unionimage/unionimage.h"
 #include "imagedata/thumbnailcache.h"
+#include "utils/devicehelper.h"
 
 #include <QThread>
 #include <QThreadPool>
@@ -192,6 +193,13 @@ void AsyncImageResponse::run()
     int frameIndex;
     parseProviderID(providerId, tempPath, frameIndex);
     if (tempPath.isEmpty()) {
+        emit finished();
+        return;
+    }
+
+    DeviceReadGuard readGuard(tempPath);
+    if (!readGuard.isActive()) {
+        qDebug() << "Device is unmounting, skip async image:" << tempPath;
         emit finished();
         return;
     }
@@ -403,6 +411,12 @@ QImage ImageProvider::requestImage(const QString &id, QSize *size, const QSize &
     int frameIndex;
     parseProviderID(id, tempPath, frameIndex);
 
+    DeviceReadGuard readGuard(tempPath);
+    if (!readGuard.isActive()) {
+        qDebug() << "Device is unmounting, skip image:" << tempPath;
+        return QImage();
+    }
+
     // 判断缓存中是否存在图片
     QImage image = imageCache.get(tempPath, frameIndex);
     if (image.isNull()) {
@@ -483,6 +497,12 @@ QImage ThumbnailProvider::requestImage(const QString &id, QSize *size, const QSi
     QString tempPath;
     int frameIndex;
     parseProviderID(id, tempPath, frameIndex);
+
+    DeviceReadGuard readGuard(tempPath);
+    if (!readGuard.isActive()) {
+        qDebug() << "Device is unmounting, skip thumbnail:" << tempPath;
+        return QImage();
+    }
 
     // 判断缓存中是否存在缩略图
     if (ThumbnailCache::instance()->contains(tempPath, frameIndex)) {

--- a/src/src/imageengine/imagedataservice.cpp
+++ b/src/src/imageengine/imagedataservice.cpp
@@ -25,6 +25,7 @@
 #include "dbmanager/dbmanager.h"
 #include "configsetter.h"
 #include "movieservice.h"
+#include "utils/devicehelper.h"
 #include <QDebug>
 
 #include <QMetaType>
@@ -377,6 +378,16 @@ void ReadThumbnailManager::readThumbnail()
 
         if (!QFileInfo(path).exists()) {
             qWarning() << "File no longer exists:" << path;
+            DBManager::m_fileMutex.unlock();
+            continue;
+        }
+
+        // Atomically check device state and register the in-flight read, to avoid racing unmount with reads
+        // Note: the guard takes s_unmountMutex while we hold the m_fileMutex read lock (lock order m_fileMutex→s_unmountMutex);
+        // the unmount flow must not call waitForReadsDone while holding m_fileMutex, or a circular wait results
+        DeviceReadGuard readGuard(path);
+        if (!readGuard.isActive()) {
+            qDebug() << "Device is unmounting, skip loading:" << path;
             DBManager::m_fileMutex.unlock();
             continue;
         }

--- a/src/src/imageengine/movieservice.cpp
+++ b/src/src/imageengine/movieservice.cpp
@@ -5,6 +5,7 @@
 
 #include "movieservice.h"
 #include "unionimage/unionimage.h"
+#include "utils/devicehelper.h"
 #include <QMetaType>
 #include <QDirIterator>
 #include <QStandardPaths>
@@ -146,7 +147,7 @@ MovieService *MovieService::instance(QObject *parent)
 MovieInfo MovieService::getMovieInfo(const QUrl &url)
 {
     qDebug() << "Getting movie info for URL:" << url.toString();
-    MovieInfo result;
+    MovieInfo result{};
 
     m_bufferMutex.lock();
     auto iter = std::find_if(m_movieInfoBuffer.begin(), m_movieInfoBuffer.end(), [url](const std::pair<QUrl, MovieInfo> &data) {
@@ -154,8 +155,10 @@ MovieInfo MovieService::getMovieInfo(const QUrl &url)
     });
     if (iter != m_movieInfoBuffer.end()) {
         qDebug() << "Found movie info in cache for URL:" << url.toString();
+        // Copy before unlocking; a pop_front by another thread after unlock would invalidate the iterator
+        MovieInfo cached = iter->second;
         m_bufferMutex.unlock();
-        return iter->second;
+        return cached;
     }
     m_bufferMutex.unlock();
 
@@ -163,14 +166,21 @@ MovieInfo MovieService::getMovieInfo(const QUrl &url)
         QFileInfo fi(LibUnionImage_NameSpace::localPath(url));
 
         if (fi.exists()) {
+            DeviceReadGuard readGuard(fi.filePath());
+            if (!readGuard.isActive()) {
+                qDebug() << "Device is unmounting, skip movie info:" << fi.filePath();
+                return result;
+            }
             qDebug() << "Parsing movie info from file:" << fi.filePath();
-            auto filePath = fi.filePath();
             result = parseFromFile(fi);
         } else {
             qWarning() << "File does not exist:" << fi.filePath();
         }
     }
 
+
+    // Cache invalid results too, so unparseable videos are not re-parsed on every call;
+    // the unmount-race path above returns early and is never cached
     m_bufferMutex.lock();
     m_movieInfoBuffer.push_back(std::make_pair(url, result));
     if (m_movieInfoBuffer.size() > 30) {
@@ -218,6 +228,14 @@ QImage MovieService::getMovieCover(const QUrl &url)
     m_video_thumbnailer->thumbnail_size = static_cast<int>(THUMBNAIL_SIZE);
     m_image_data = m_mvideo_thumbnailer_create_image_data();
     QString file = QFileInfo(LibUnionImage_NameSpace::localPath(url)).absoluteFilePath();
+    // Atomically check device state and register the in-flight read, to avoid racing unmount with reads
+    DeviceReadGuard readGuard(file);
+    if (!readGuard.isActive()) {
+        qDebug() << "Device is unmounting, skip generating thumbnail:" << file;
+        m_mvideo_thumbnailer_destroy_image_data(m_image_data);
+        m_image_data = nullptr;
+        return QImage();
+    }
     qDebug() << "Generating thumbnail for file:" << file;
     m_mvideo_thumbnailer_generate_thumbnail_to_buffer(m_video_thumbnailer, file.toUtf8().data(), m_image_data);
     QImage img = QImage::fromData(m_image_data->image_data_ptr, static_cast<int>(m_image_data->image_data_size), "png");
@@ -230,6 +248,9 @@ QImage MovieService::getMovieCover(const QUrl &url)
 MovieInfo MovieService::parseFromFile(const QFileInfo &fi)
 {
     qDebug() << "Parsing movie file:" << fi.filePath();
+    // Serialize with getMovieCover: both paths enter libav (directly or via ffmpegthumbnailer),
+    // and concurrent libav use corrupts the heap on some platforms (e.g. sw_64)
+    QMutexLocker locker(&m_queuqMutex);
     struct MovieInfo mi;
     mi.valid = false;
     AVFormatContext *av_ctx = nullptr;

--- a/src/src/thumbnailload.cpp
+++ b/src/src/thumbnailload.cpp
@@ -7,6 +7,7 @@
 #include "configsetter.h"
 #include "imageengine/movieservice.h"
 #include "dbmanager/dbmanager.h"
+#include "utils/devicehelper.h"
 #include <QPainter>
 
 const QString SETTINGS_GROUP = "Thumbnail";
@@ -723,6 +724,12 @@ QImage ImagePublisher::requestImage(const QString &id, QSize *size, const QSize 
     QString localPath = LibUnionImage_NameSpace::localPath(url);
 
     qDebug() << "Requesting image:" << localPath << "Requested size:" << requestedSize;
+    // Atomically check device state and register the in-flight read, to avoid racing unmount with reads
+    DeviceReadGuard readGuard(localPath);
+    if (!readGuard.isActive()) {
+        qDebug() << "Device is unmounting, skip loading image:" << localPath;
+        return QImage();
+    }
     QString error;
     QImage image;
     LibUnionImage_NameSpace::loadStaticImageFromFile(localPath, image, error);
@@ -805,6 +812,11 @@ QImage CollectionPublisher::createYearImage(const QString &year)
         return QImage();
     }
     auto picPath = paths.at(0);
+    DeviceReadGuard readGuard(picPath);
+    if (!readGuard.isActive()) {
+        qDebug() << "Device is unmounting, skip year cover:" << picPath;
+        return QImage();
+    }
 
     // Fix: year cover may be a video file; use video frame to avoid corrupt image.
     QImage image;
@@ -844,6 +856,11 @@ QImage CollectionPublisher::createMonthCellImage(const QString &path, const Coll
         requestSize = QSize(outputWidth / 5, static_cast<int>(outputHeight * (1 - 0.618)));
 
     //1.加载原图
+    DeviceReadGuard readGuard(path);
+    if (!readGuard.isActive()) {
+        qDebug() << "Device is unmounting, skip month cover:" << path;
+        return QImage();
+    }
     QImage image;
     QString error;
     if (LibUnionImage_NameSpace::isVideo(path))
@@ -911,6 +928,13 @@ void AsyncImageResponseAlbum::run()
     QString localPath = LibUnionImage_NameSpace::localPath(url);
 
     qDebug() << "Processing async image:" << localPath;
+    // Atomically check device state and register the in-flight read, to avoid racing unmount with reads
+    DeviceReadGuard readGuard(localPath);
+    if (!readGuard.isActive()) {
+        qDebug() << "Device is unmounting, skip loading image:" << localPath;
+        emit finished();
+        return;
+    }
     QString error;
     LibUnionImage_NameSpace::loadStaticImageFromFile(localPath, m_image, error);
     if (!error.isEmpty()) {

--- a/src/src/unionimage/unionimage.cpp
+++ b/src/src/unionimage/unionimage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,6 +25,7 @@
 #endif
 
 #include "unionimage/imageutils.h"
+#include "utils/devicehelper.h"
 
 #include <cstring>
 
@@ -380,6 +381,15 @@ QString PrivateDetectImageFormat(const QString &filepath);
 UNIONIMAGESHARED_EXPORT bool loadStaticImageFromFile(const QString &path, QImage &res, QString &errorMsg, const QString &format_bar)
 {
     qDebug() << "Loading static image from file:" << path;
+    // Register the in-flight read centrally here, covering all static image load entry points,
+    // to avoid racing unmount with reads
+    DeviceReadGuard readGuard(path);
+    if (!readGuard.isActive()) {
+        qWarning() << "Device is unmounting, skip loading image:" << path;
+        res = QImage();
+        errorMsg = "device unmounting!";
+        return false;
+    }
     QFileInfo file_info(path);
     if (file_info.size() == 0) {
         qWarning() << "File is empty:" << path;

--- a/src/src/utils/devicehelper.cpp
+++ b/src/src/utils/devicehelper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,12 +8,20 @@
 #include <DSysInfo>
 
 #include <QDBusReply>
+#include <QFileInfo>
 #include <QDebug>
+#include <QElapsedTimer>
+
+#include <algorithm>
 #include <QRegularExpression>
 
 DCORE_USE_NAMESPACE
 
 DeviceHelper *DeviceHelper::m_instance = nullptr;
+QMutex DeviceHelper::s_unmountMutex;
+QWaitCondition DeviceHelper::s_readCondition;
+QStringList DeviceHelper::s_unmountingPaths;
+QStringList DeviceHelper::s_activeReads;
 using namespace dfmmount;
 
 /*!
@@ -49,6 +57,93 @@ DeviceHelper::DeviceHelper(QObject *parent)
 DeviceHelper::~DeviceHelper()
 {
     qDebug() << "Destroying DeviceHelper";
+}
+
+namespace {
+QString normalizedPath(const QString &path)
+{
+    if (path.isEmpty()) {
+        return {};
+    }
+    return QDir::cleanPath(QFileInfo(path).absoluteFilePath());
+}
+
+bool pathUnderMountPoint(const QString &path, const QString &mountPoint)
+{
+    return path == mountPoint || path.startsWith(mountPoint + QLatin1Char('/'));
+}
+}
+
+void DeviceHelper::markUnmounting(const QString &mountPoint, bool unmounting)
+{
+    const QString normalizedMountPoint = normalizedPath(mountPoint);
+    if (normalizedMountPoint.isEmpty()) {
+        return;
+    }
+
+    QMutexLocker locker(&s_unmountMutex);
+    if (unmounting) {
+        if (!s_unmountingPaths.contains(normalizedMountPoint)) {
+            s_unmountingPaths.append(normalizedMountPoint);
+        }
+    } else {
+        s_unmountingPaths.removeAll(normalizedMountPoint);
+    }
+}
+
+bool DeviceHelper::tryBeginRead(const QString &path)
+{
+    const QString normalized = normalizedPath(path);
+    if (normalized.isEmpty()) {
+        return false;
+    }
+
+    QMutexLocker locker(&s_unmountMutex);
+    const bool unmounting = std::any_of(
+        s_unmountingPaths.cbegin(), s_unmountingPaths.cend(),
+        [&normalized](const QString &root) { return pathUnderMountPoint(normalized, root); });
+    if (unmounting) {
+        return false;
+    }
+
+    s_activeReads.append(normalized);
+    return true;
+}
+
+void DeviceHelper::endRead(const QString &path)
+{
+    const QString normalized = normalizedPath(path);
+    QMutexLocker locker(&s_unmountMutex);
+    s_activeReads.removeOne(normalized);
+    s_readCondition.wakeAll();
+}
+
+bool DeviceHelper::waitForReadsDone(const QString &mountPoint, int timeoutMs)
+{
+    const QString normalizedRoot = normalizedPath(mountPoint);
+    if (normalizedRoot.isEmpty()) {
+        return true;
+    }
+
+    auto hasActiveRead = [&normalizedRoot]() {
+        return std::any_of(s_activeReads.cbegin(), s_activeReads.cend(),
+                           [&normalizedRoot](const QString &readPath) {
+                               return pathUnderMountPoint(readPath, normalizedRoot);
+                           });
+    };
+
+    QMutexLocker locker(&s_unmountMutex);
+    QElapsedTimer timer;
+    timer.start();
+    while (hasActiveRead()) {
+        const int remaining = timeoutMs - static_cast<int>(timer.elapsed());
+        if (remaining <= 0 || !s_readCondition.wait(&s_unmountMutex, remaining)) {
+            qWarning() << "DeviceHelper::waitForReadsDone timeout, remaining reads:"
+                       << s_activeReads.size();
+            return false;
+        }
+    }
+    return true;
 }
 
 DeviceHelper *DeviceHelper::instance()

--- a/src/src/utils/devicehelper.h
+++ b/src/src/utils/devicehelper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,8 @@
 
 #include <QDBusInterface>
 #include <QDir>
+#include <QMutex>
+#include <QWaitCondition>
 #include <QObject>
 #include <QUrl>
 
@@ -50,13 +52,56 @@ public:
 
     // 判断url是否为smb网络路径
     static bool isSamba(const QUrl &url);
+
+    // Mark/clear a mount point as unmounting; while marked, parsing of files on that device is blocked
+    static void markUnmounting(const QString &mountPoint, bool unmounting);
+
+    // Atomically check a path and register one in-flight file read
+    static bool tryBeginRead(const QString &path);
+    // Unregister one in-flight read; must be given the same path passed to tryBeginRead
+    static void endRead(const QString &path);
+    // Wait for all in-flight reads under the given mount point to finish; returns false on timeout
+    // Note: the blocking wait processes no events; calling it on the main thread briefly freezes the UI (bounded by timeoutMs)
+    static bool waitForReadsDone(const QString &mountPoint, int timeoutMs);
+
 private:
     static DeviceHelper *m_instance;
+    static QMutex s_unmountMutex;
+    static QWaitCondition s_readCondition;
+    static QStringList s_unmountingPaths;
+    static QStringList s_activeReads; // normalized paths of in-flight reads (the same path may appear more than once)
 
     QStringList getProtocalDeviceIds();
 private:
     QScopedPointer<QDBusInterface> m_dfmDeviceManager; // 文管设备管理DBus服务接口
     QMap<QString, QVariantMap> m_mapDevicesInfos; // 记录所有可插拔设备信息，设备id-设备信息map表
+};
+
+// In-flight file read guard: registers/unregisters the read on construction/destruction,
+// so unmount can drain reads by mount point
+class DeviceReadGuard
+{
+    Q_DISABLE_COPY(DeviceReadGuard)
+
+public:
+    explicit DeviceReadGuard(const QString &path)
+        : m_path(path)
+        , m_active(DeviceHelper::tryBeginRead(path))
+    {
+    }
+
+    ~DeviceReadGuard()
+    {
+        if (m_active) {
+            DeviceHelper::endRead(m_path);
+        }
+    }
+
+    bool isActive() const { return m_active; }
+
+private:
+    QString m_path;
+    bool m_active = false;
 };
 
 #endif  // DEVICEHELPER_H


### PR DESCRIPTION
Serialize MovieService's two libav entry paths and add mutual exclusion between device unmount and device file reads, so parsing cannot be interrupted mid-way. Defer the unmount flow out of the QML click handler and replace the out-of-bounds DDialog::insertButton with addButton.

串行化MovieService的两条libav调用路径，并增加设备卸载与设备文件读取的
互斥，避免解析中途被打断导致堆损坏；卸载流程延迟到QML点击信号处理器
结束后执行，并将越界的DDialog::insertButton替换为addButton。

Log: 修复卸载设备时程序崩溃的问题
PMS: BUG-374513
Influence: 修复浏览含视频的U盘设备并点击卸载时程序崩溃的问题，提升设备卸载和文件浏览的稳定性。

## Summary by Sourcery

Prevent device-unmount crashes by coordinating media reads with unmount operations and serializing movie processing.

Bug Fixes:
- Prevent crashes and heap corruption when unmounting devices while media files are being parsed or loaded.
- Block new device reads and drain in-flight reads before unmounting, while skipping media requests that race with device removal.
- Defer unmount handling until the QML click handler completes and prevent re-entrant unmount requests.
- Correct the unmount error dialog button handling.

Enhancements:
- Serialize MovieService media parsing and thumbnail generation to avoid concurrent libav access.
- Cache invalid movie metadata to avoid repeatedly parsing unparseable videos.

Chores:
- Update copyright years in affected source files.