### PR TITLE
fix(filter-combobox): unify icon size and width

### DIFF
--- a/src/qml/Control/FilterComboBox.qml
+++ b/src/qml/Control/FilterComboBox.qml
@@ -8,6 +8,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQml
 import org.deepin.dtk 1.0
+import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
 
 ComboBox {
@@ -17,6 +18,47 @@ ComboBox {
     textRole: "text"
     iconNameRole: "icon"
     flat: true
+
+    // 隐藏文本，用于测量各选项文字宽度
+    Text { id: _measure; visible: false }
+
+    // 选中项：图标 16x16、文字左对齐、超长省略号截断并显示 Tooltip
+    contentItem: RowLayout {
+        spacing: 6
+        D.DciIcon {
+            sourceSize: Qt.size(16, 16)
+            name: comboBox.model.get(comboBox.currentIndex)
+                  ? comboBox.model.get(comboBox.currentIndex)[comboBox.iconNameRole]
+                  : ""
+            palette: comboBox.D.DTK.makeIconPalette(comboBox.palette)
+            mode: comboBox.D.ColorSelector.controlState
+            theme: comboBox.D.ColorSelector.controlTheme
+            Layout.alignment: Qt.AlignVCenter
+        }
+        Label {
+            text: comboBox.currentText
+            elide: Text.ElideRight
+            horizontalAlignment: Text.AlignLeft
+            verticalAlignment: Qt.AlignVCenter
+            font: comboBox.font
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            ToolTip.text: text
+            ToolTip.visible: truncated && comboBox.hovered
+            ToolTip.delay: 500
+        }
+    }
+
+    // 以最长选项确定按钮宽度，切换选项时宽度保持一致，上限 140px
+    Component.onCompleted: {
+        _measure.font = comboBox.font
+        var maxTextW = 0
+        for (var i = 0; i < count; i++) {
+            _measure.text = model.get(i)[textRole]
+            maxTextW = Math.max(maxTextW, _measure.implicitWidth)
+        }
+        width = Math.max(width, Math.min(16 + 6 + maxTextW + leftPadding + rightPadding, 140))
+    }
 
     model: ListModel {
         ListElement { text: qsTr("All"); icon: "selectall" }
@@ -28,6 +70,9 @@ ComboBox {
         useIndicatorPadding: true
         width: parent.width
         text: comboBox.textRole ? (Array.isArray(comboBox.model) ? modelData[comboBox.textRole] : model[comboBox.textRole]) : modelData
+        // 下拉项图标与选中项保持一致 16x16
+        icon.width: 16
+        icon.height: 16
         icon.name: (comboBox.iconNameRole && model[comboBox.iconNameRole] !== undefined) ? model[comboBox.iconNameRole] : null
         highlighted: comboBox.highlightedIndex === index
         hoverEnabled: comboBox.hoverEnabled
@@ -35,4 +80,3 @@ ComboBox {
         checked: comboBox.currentIndex === index
     }
 }
-


### PR DESCRIPTION
## 问题

筛选下拉框（FilterComboBox，用于选择 All / Photos / Videos）存在以下 UI 问题：

1. **图标大小不一致**：选中项图标和下拉菜单项图标大小不统一，下拉菜单项图标默认为 14x14，偏小。
2. **按钮宽度不一致**：切换 All / Photos / Videos 时按钮宽度随文字长度变化，导致界面抖动。
3. **长文本溢出**：其他语言下长文本无法截断，也没有 Tooltip 显示全文。

## 修复（单文件：`src/qml/Control/FilterComboBox.qml`）

1. **选中项 contentItem**：自定义 `RowLayout`，`D.DciIcon` 设为 16x16，`Label` 支持 `elide: Text.ElideRight` 省略号截断，截断时 hover 显示 `ToolTip` 全文。
2. **按钮宽度**：`Component.onCompleted` 测量所有选项文字宽度，取最长项确定按钮宽度（上限 140px），切换选项时宽度保持一致。
3. **下拉菜单项 delegate**：新增 `icon.width: 16` / `icon.height: 16`，使下拉项图标与选中项一致。
4. **图标配色**：通过 `D.DTK.makeIconPalette` 和 `D.ColorSelector` 使图标颜色跟随文字颜色，适配各主题。

## PMS

[PMS: BUG-375301](https://pms.uniontech.com/bug-view-375301.html)

## Summary by Sourcery

Improve FilterComboBox consistency by standardizing icon presentation, stabilizing its width, and handling long labels gracefully.

Bug Fixes:
- Unify FilterComboBox icon sizing and prevent control width changes when switching between filter options.
- Prevent long localized filter labels from overflowing by eliding text and showing the full value in a tooltip when hovered.

Enhancements:
- Ensure filter icons follow the control's text color and theme styling.