### PR TITLE
fix: set stackPage before deferred MainStack is created

### DIFF
--- a/src/qml/StackControl.qml
+++ b/src/qml/StackControl.qml
@@ -175,8 +175,9 @@ Item {
         }
     }
 
-    // Switch the deferred MainStack into image-view mode; no-op until the Loader finishes.
+    // Record the target page before the deferred MainStack is created.
     function switchMainStackView() {
+        GStatus.stackPage = Number(Album.Types.ImageViewPage)
         if (mainStack.item)
             mainStack.item.switchImageView()
     }


### PR DESCRIPTION
## Root Cause Analysis

When opening an image via D-Bus (right-click → "Open With" → "Album"), the album cold-starts and the deferred MainStack Loader hasn't created its item yet (1 ms timer). `switchMainStackView()` silently skipped `switchImageView()` because `mainStack.item` was null, leaving `GStatus.stackPage` at its default `OpenImagePage`. When the Loader finished, `MainStack.Component.onCompleted` saw `stackPage != ImageViewPage` and loaded the blank `OpenImageWidget.qml` instead of `FullImageView.qml`.

Key evidence: `StackControl.qml:179-182` (null-guard skip), `MainStack.qml:69-76` (onCompleted branch), `globalstatus.h:342` (default = OpenImagePage). Regression introduced by `f99533c4` (defer MainStack/SliderShow to event loop).

## Fix

Set `GStatus.stackPage = Number(Album.Types.ImageViewPage)` unconditionally before the `if (mainStack.item)` check in `switchMainStackView()`. When the item exists, `switchImageView()` sets the same value (harmless redundancy); when it is null, the page is already correct for `Component.onCompleted`.

> Note: The analysis report (section 9) suggested an `if/else` branch. The actual fix uses an unconditional pre-set instead — simpler, avoids an else branch, and is semantically equivalent since `switchImageView()` sets the same value when the item exists.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- All modified lines (178-182) were introduced by the regression commit `f99533c4` itself — no prior fixes to these lines to break.
- When `mainStack.item` is non-null, `switchImageView()` (MainStack.qml:49) sets `GStatus.stackPage = ImageViewPage` — the pre-set is idempotent, no behavioral change on the hot-start path.

### Business Impact Scope

- **Affected module**: Image viewer entry path via D-Bus "Open With" → Album.
- **User scenario**: Right-click an image on desktop/file manager → "Open With" → Album. Before fix: blank screen after "Import succeeded" toast. After fix: image displays correctly in full-image view.
- **No impact on**: Hot-start image viewing (item already exists, original path), slideshow entry (separate null guard), command-line launch (sets stackPage in C++ before QML loads).

### Verification Suggestion

1. Cold-start path: kill album process, right-click a PNG on desktop → "Open With" → Album → verify image displays (not blank).
2. Hot-start regression: with album already open, open another image via right-click → verify normal display (no regression).

---

## 根因分析

通过 D-Bus 打开图片时（右键 →"打开方式"→"相册"），相册冷启动，延迟加载的 MainStack Loader 尚未创建 item（1ms 定时器未触发）。`switchMainStackView()` 因 `mainStack.item` 为 null 静默跳过 `switchImageView()`，`GStatus.stackPage` 保持默认值 `OpenImagePage`。Loader 完成后 `Component.onCompleted` 读取到 `OpenImagePage`，加载空白的 `OpenImageWidget.qml` 而非含图片的 `FullImageView.qml`。

关键证据：`StackControl.qml:179-182`（null 守护跳过）、`MainStack.qml:69-76`（onCompleted 分支）、`globalstatus.h:342`（默认值 = OpenImagePage）。回归由 `f99533c4`（延迟 MainStack/SliderShow 加载）引入。

## 修复方案

在 `switchMainStackView()` 的 `if (mainStack.item)` 检查之前，无条件设置 `GStatus.stackPage = Number(Album.Types.ImageViewPage)`。item 存在时 `switchImageView()` 设置相同值（冗余无害）；item 为 null 时页面值已正确，`Component.onCompleted` 会正确加载图片视图。

> 注：分析报告第九节建议用 `if/else` 分支，实际修复采用无条件预设——更简洁，无需 else 分支，语义等价（item 存在时 `switchImageView()` 设置相同值）。

## 改动安全评估

### 代码安全评估

- **风险等级**：低风险
- 所有改动行（178-182）均由回归 commit `f99533c4` 本身引入——不存在更早的修复会被破坏。
- `mainStack.item` 非 null 时，`switchImageView()`（MainStack.qml:49）已设置 `GStatus.stackPage = ImageViewPage`——预设值幂等，热启动路径无行为变化。

### 业务影响范围

- **受影响模块**：D-Bus"打开方式"→相册的看图入口路径。
- **用户场景**：桌面/文件管理器右键图片 →"打开方式"→相册。修复前："导入成功"提示后空白；修复后：正常显示图片。
- **不受影响**：热启动看图（item 已存在，走原路径）、幻灯片入口（独立 null 守护）、命令行启动（C++ 预设 stackPage）。

### 验证建议

1. 冷启动路径：杀掉相册进程，桌面右键 PNG →"打开方式"→相册 → 验证图片正常显示（非空白）。
2. 热启动回归：相册已打开时再通过右键打开另一张图片 → 验证正常显示（无回归）。

## Summary by Sourcery

Bug Fixes:
- Ensure image-view mode is selected during deferred startup so images opened through D-Bus display correctly instead of a blank page.