### PR TITLE
fix: set stackPage before deferred MainStack is created

### DIFF
--- a/src/qml/StackControl.qml
+++ b/src/qml/StackControl.qml
@@ -175,8 +175,9 @@ Item {
         }
     }
 
-    // Switch the deferred MainStack into image-view mode; no-op until the Loader finishes.
+    // Record the target page before the deferred MainStack is created.
     function switchMainStackView() {
+        GStatus.stackPage = Number(Album.Types.ImageViewPage)
         if (mainStack.item)
             mainStack.item.switchImageView()
     }


### PR DESCRIPTION
Set GStatus.stackPage before checking the deferred MainStack item.
在检查延迟加载的MainStack item之前设置GStatus.stackPage。

Log: 修复D-Bus冷启动打开图片时显示空白页面的问题
PMS: BUG-375259
Influence: 修复右键用相册打开图片时因MainStack延迟加载导致显示空白页面的问题