### PR TITLE
chore: update version to 6.0.65

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+deepin-album (6.0.65) unstable; urgency=medium
+
+  * fix: set stackPage before deferred MainStack is created
+  * test(accessibility): add AT-SPI YAML test suites for album
+  * fix: resolve crash when unmounting a device being parsed
+  * chore: Sync by https://github.com/linuxdeepin/.github/commit/a300f8523d4876677112edab6a0772f7ad112976
+  * feat(accessibility): add AT-SPI names to collection and toolbar QML
+  * feat(accessibility): add AT-SPI names to preview viewer navigation QML
+  * feat(accessibility): add AT-SPI names to sidebar and device view QML
+  * feat(accessibility): add AT-SPI names to preview viewer thumbnail QML
+  * feat(accessibility): add AT-SPI names to preview viewer item QML
+  * chore: add SPDX header to expected_names.yaml
+  * feat(accessibility): add AT-SPI names to C++ child widgets
+  * chore: update copyright year of ClassificationView to 2026
+  * feat(accessibility): add AT-SPI names to album view QML elements
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 27 Aug 2026 19:58:34 +0800
+
 deepin-album (6.0.64) unstable; urgency=medium
 
   * fix: preserve literal percent signs in trash restore/delete paths

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.64.1
+  version: 6.0.65.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
- bump version to 6.0.65

Log : bump version to 6.0.65

## Summary by Sourcery

Build:
- Update the application package version to 6.0.65.1 and record the 6.0.65 release in the Debian changelog.