### PR TITLE
fix(sidebar): enable behind-window blur transparency

### DIFF
--- a/src/qml/MainAlbumView.qml
+++ b/src/qml/MainAlbumView.qml
@@ -91,7 +91,7 @@ FadeInoutAnimation {
     Binding {
         target: leftBgArea
         property: "visible"
-        value: leftSidebar.x === 0
+        value: leftSidebar.x > -GStatus.sideBarWidth
     }
 
     Binding {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -10,6 +10,7 @@ import QtQuick.Controls
 import QtQuick.Dialogs
 
 import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DS
 import org.deepin.album 1.0 as Album
 
 import "./Control/Animation"
@@ -19,6 +20,7 @@ ApplicationWindow {
 
     property bool isFullScreen: window.visibility === Window.FullScreen
     property bool backgroundBlurReady: false
+    color: "transparent"
 
     // Bug fix: 使用 ListView 替换 PathView 时，出现内部的 mouseArea 鼠标操作会被 DWindow 截取
     // 导致 flicking 时拖动窗口，此处使用此标志禁用此行为
@@ -27,6 +29,7 @@ ApplicationWindow {
     // 设置 dtk 风格窗口
     DWindow.enabled: true
     DWindow.alphaBufferSize: 8
+    DWindow.enableBlurWindow: true
     title: ""
     header: AlbumTitle {
         id: titleAlubmRect
@@ -38,8 +41,31 @@ ApplicationWindow {
 
     background: Rectangle {
         anchors.fill: parent
-        visible: GStatus.stackControlCurrent === 0 ? true : false
         color: "transparent"
+
+        // uos-design: right content area opaque base — must not extend under the
+        // blur sidebar or the frosted area degrades into a solid panel.
+        Rectangle {
+            id: rightContentBg
+            visible: GStatus.stackControlCurrent === 0
+            anchors {
+                top: parent.top
+                bottom: parent.bottom
+                left: parent.left
+                leftMargin: leftBgArea.width
+                right: parent.right
+            }
+            color: DTK.themeType === ApplicationHelper.LightType ? "#f8f8f8" : "#202020"
+        }
+
+        // Opaque base for image viewer / slideshow so a transparent window
+        // surface doesn't show the desktop behind content.
+        Rectangle {
+            visible: GStatus.stackControlCurrent !== 0
+            anchors.fill: parent
+            color: DTK.themeType === ApplicationHelper.LightType ? "#f8f8f8" : "#202020"
+        }
+
         Row {
             anchors.fill: parent
             Loader {
@@ -48,10 +74,23 @@ ApplicationWindow {
                 height: parent.height
                 anchors.top: parent.top
                 active: window.backgroundBlurReady && GStatus.stackControlCurrent === 0
-                sourceComponent: BehindWindowBlur {
+                sourceComponent: StyledBehindWindowBlur {
+                    // uos-design: sidebar frosted-glass surface via the verified DTK
+                    // compositor behind-window blur path (dde-control-center baseline).
+                    control: window
                     anchors.fill: parent
-                    blendColor: DTK.themeType === ApplicationHelper.LightType ? "#eaf7f7f7"
-                                                                              : "#ee252525"
+                    blendColor: {
+                        // Compositor blur available: translucent tint so the blur reads through.
+                        if (valid) {
+                            return DS.Style.control.selectColor(undefined,
+                                Qt.rgba(238 / 255, 238 / 255, 238 / 255, 0.8),
+                                Qt.rgba(20 / 255, 20 / 255, 20 / 255, 0.8))
+                        }
+                        // No compositor blur: solid panel via the system no-blur token.
+                        return DS.Style.control.selectColor(undefined,
+                            DS.Style.behindWindowBlur.lightNoBlurColor,
+                            DS.Style.behindWindowBlur.darkNoBlurColor)
+                    }
                     Rectangle {
                         width: 1
                         height: parent.height
@@ -63,6 +102,7 @@ ApplicationWindow {
             }
             Loader {
                 active: window.backgroundBlurReady
+                visible: GStatus.stackControlCurrent === 0
                 width: parent.width
                 height: 50
                 sourceComponent: Rectangle {


### PR DESCRIPTION
## 问题

相册侧边栏缺少透明模糊效果。`ApplicationWindow` 的窗口表面默认使用不透明的 `palette.window` 颜色，将合成器级别的 behind-window blur 完全遮挡，导致 `StyledBehindWindowBlur` 的模糊效果不可见。

## 修改内容

1. 将 `ApplicationWindow.color` 设为 `"transparent"`，使窗口表面透明，让合成器模糊层透出
2. 将未注册的 `BehindWindowBlur` 替换为已注册的 `StyledBehindWindowBlur`，并绑定 `control: window`
3. 重写 `blendColor`：合成器模糊可用时使用半透明 tint（alpha `0.8`），不可用时回退到 `DS.Style.behindWindowBlur` 无模糊纯色 token
4. 启用 `DWindow.enableBlurWindow` 获取合成器级模糊支持
5. 新增右侧内容区不透明底色（`#f8f8f8`/`#202020`），锚定到侧边栏边缘，确保模糊区域保持磨砂效果而内容区保持不透明
6. 为图片查看器和幻灯片模式添加全窗不透明底色，避免窗口透明后这些模式变透明

## 验证

- `cmake --build build --target deepin-album` 构建通过
- 在 Deepin 桌面环境实机验证侧边栏磨砂玻璃模糊效果正常显示

## 关联

PMS: https://pms.uniontech.com/bug-view-355999.html

## Summary by Sourcery

Enable compositor-backed transparent blur for the album sidebar while preserving opaque backgrounds for content views and blur fallbacks.

Bug Fixes:
- Restore visible behind-window blur transparency for the album sidebar while providing an opaque fallback when compositor blur is unavailable.
- Keep image viewer and slideshow content opaque after making the application window transparent.

Enhancements:
- Refine sidebar and content-area layering so the frosted sidebar remains distinct from the opaque main content region.
- Improve sidebar background visibility during sidebar transitions.