### PR TITLE
fix(accessibility): add AT-SPI accessible names and roles for QML widgets

### DIFF
--- a/src/qml/ClassificationView/ClassificationDetailView.qml
+++ b/src/qml/ClassificationView/ClassificationDetailView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,6 +19,8 @@ import "../ThumbnailImageView"
  * 展示指定分类下的所有图片，参考自定义相册的实现方式
  */
 BaseView {
+    Accessible.name: "ClassificationDetailView"
+    Accessible.role: Accessible.Pane
     id: classificationDetailView
 
     property string classificationName: ""  // 分类名称
@@ -185,6 +187,8 @@ BaseView {
 
     // 缩略图列表控件
     ThumbnailListViewAlbum {
+        Accessible.name: "ClassificationDetailListView"
+        Accessible.role: Accessible.List
         id: theView
         anchors {
             top: classificationDetailTitleRect.bottom

--- a/src/qml/ClassificationView/ClassificationView.qml
+++ b/src/qml/ClassificationView/ClassificationView.qml
@@ -16,6 +16,8 @@ import "../Control"
  * 以网格形式显示图片分类结果，支持延迟加载
  */
 BaseView {
+    Accessible.name: "ClassificationView"
+    Accessible.role: Accessible.Pane
     id: classificationView
 
     //property bool dataLoaded: false
@@ -103,6 +105,8 @@ BaseView {
             model: classificationModel  // 使用ListModel而不是QVariantList
 
             delegate: ClassificationItem {
+                Accessible.name: "GridView_ClassificationItem"
+                Accessible.role: Accessible.ListItem
                 width: classificationGrid.cellWidth - 10
                 height: classificationGrid.cellHeight - 10
 

--- a/src/qml/Control/BaseView.qml
+++ b/src/qml/Control/BaseView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,8 @@ import QtQuick.Controls
 
 import "./Animation"
 FadeInoutAnimation {
+    Accessible.name: "BaseView_FadeInoutAnimation"
+    Accessible.role: Accessible.Client
     anchors.fill: parent
     anchors.topMargin: 0
     anchors.leftMargin: 20

--- a/src/qml/Control/FilterComboBox.qml
+++ b/src/qml/Control/FilterComboBox.qml
@@ -25,6 +25,7 @@ ComboBox {
     }
 
     delegate: MenuItem {
+        Accessible.name: "FilterComboBoxItem"
         useIndicatorPadding: true
         width: parent.width
         text: comboBox.textRole ? (Array.isArray(comboBox.model) ? modelData[comboBox.textRole] : model[comboBox.textRole]) : modelData

--- a/src/qml/Control/FlickableScrollBar.qml
+++ b/src/qml/Control/FlickableScrollBar.qml
@@ -8,6 +8,7 @@ import QtQuick.Controls
 // 适用于纯 QML Flickable/ListView 的 ScrollBar 封装
 // 内置绑定循环防护和拖拽冲突处理
 ScrollBar {
+    Accessible.name: "Control"
     id: control
 
     required property Flickable flickable

--- a/src/qml/Control/ListView/RightMenuItem.qml
+++ b/src/qml/Control/ListView/RightMenuItem.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,5 +8,6 @@ import QtQuick.Controls 2.4
 import org.deepin.dtk 1.0
 
 MenuItem {
+    Accessible.name: "RightMenuItem"
     height: visible ? GStatus.rightMenuItemHeight : 0
 }

--- a/src/qml/Control/ListView/ThumbnailListDelegate.qml
+++ b/src/qml/Control/ListView/ThumbnailListDelegate.qml
@@ -411,6 +411,8 @@ Item {
             }
 
             VideoLabel {
+                Accessible.name: "LabelRemainDays"
+                Accessible.role: Accessible.StaticText
                 id: labelRemainDays
                 visible: true
                 width: contentWidth
@@ -455,6 +457,8 @@ Item {
             property real contentWidth: videoLabel.width
 
             VideoLabel {
+                Accessible.name: "VideoLabel"
+                Accessible.role: Accessible.StaticText
                 id: videoLabel
                 visible: bShowVideoLabel
                 anchors {

--- a/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
+++ b/src/qml/Control/ListView/ThumbnailListViewAlbum.qml
@@ -405,6 +405,8 @@ FocusScope {
             id: rubberBandObject
 
             Album.RubberBand {
+                Accessible.name: "RubberBand"
+                Accessible.role: Accessible.Client
                 id: rubberBand
 
                 width: 0
@@ -506,6 +508,8 @@ FocusScope {
             cellHeight: itemHeight
 
             delegate: ThumbnailListDelegate {
+                Accessible.name: "ThumbnailListDelegate"
+                Accessible.role: Accessible.ListItem
                 id: thumbnailListDelegate
                 modelData: model
                 m_index: index
@@ -823,6 +827,8 @@ FocusScope {
         maxVisibleItems: 30
         //显示大图预览
         RightMenuItem {
+            Accessible.name: "View"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("View")
             visible: menuItemStates.canView
             onTriggered: {
@@ -832,6 +838,8 @@ FocusScope {
 
         //全屏预览
         RightMenuItem {
+            Accessible.name: "Fullscreen"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Fullscreen")
             visible:  menuItemStates.canFullScreen
             onTriggered: {
@@ -849,6 +857,8 @@ FocusScope {
 
         //调起打印接口
         RightMenuItem {
+            Accessible.name: "Print"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Print")
             visible: menuItemStates.canPrint
 
@@ -868,6 +878,8 @@ FocusScope {
 
         //幻灯片
         RightMenuItem {
+            Accessible.name: "SlideShow"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Slide show")
             visible: menuItemStates.canSlideShow
             onTriggered: {
@@ -897,6 +909,8 @@ FocusScope {
             title: qsTr("Add to album")
 
             RightMenuItem {
+                Accessible.name: "NewAlbum"
+                Accessible.role: Accessible.MenuItem
                 text: qsTr("New album")
                 onTriggered: {
                     newAlbum.isChangeView = true
@@ -914,6 +928,8 @@ FocusScope {
                     albumControl.getAllCustomAlbumId().length
                 }
                 delegate: RightMenuItem {
+                    Accessible.name: "Repeater_RightMenuItem"
+                    Accessible.role: Accessible.MenuItem
                     readonly property bool isFirstAlbum: index === 0
                     height: {
                         if (!visible)
@@ -950,6 +966,8 @@ FocusScope {
 
         //导出图片为其它格式
         RightMenuItem {
+            Accessible.name: "Export"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Export")
             visible: thumnailListType !== Album.Types.ThumbnailTrash
                      && ((selectedUrls.length === 1 && FileControl.pathExists(selectedUrls[0]) && menuItemStates.haveImage) || !menuItemStates.haveVideo)
@@ -969,6 +987,8 @@ FocusScope {
 
         //复制图片
         RightMenuItem {
+            Accessible.name: "Copy"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Copy")
             visible: menuItemStates.canCopy
             onTriggered: {
@@ -978,6 +998,8 @@ FocusScope {
 
         //删除图片
         RightMenuItem {
+            Accessible.name: "Delete"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Delete")
             visible: menuItemStates.canDelete && !menuItemStates.isInDevice
             onTriggered: {
@@ -988,6 +1010,8 @@ FocusScope {
 
         //从相册移除（只在自定义相册中显示）
         RightMenuItem {
+            Accessible.name: "RemoveFromAlbum"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Remove from album")
             visible: thumnailListType === Album.Types.ThumbnailCustomAlbum
             onTriggered: {
@@ -1002,6 +1026,8 @@ FocusScope {
 
         //添加到我的收藏
         RightMenuItem {
+            Accessible.name: "FavoriteAction"
+            Accessible.role: Accessible.MenuItem
             id: favoriteAction
             text: qsTr("Favorite")
             visible: !menuItemStates.isInTrash && !menuItemStates.isInDevice && menuItemStates.canFavorite
@@ -1012,6 +1038,8 @@ FocusScope {
 
         //从我的收藏中移除
         RightMenuItem {
+            Accessible.name: "UnFavoriteAction"
+            Accessible.role: Accessible.MenuItem
             id: unFavoriteAction
             text: qsTr("Unfavorite")
             visible: !menuItemStates.isInTrash && !menuItemStates.isInDevice && !menuItemStates.canFavorite
@@ -1027,6 +1055,8 @@ FocusScope {
 
         //顺时针旋转
         RightMenuItem {
+            Accessible.name: "RotateClockwise"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Rotate clockwise")
             visible: menuItemStates.canRotate
             onTriggered: {
@@ -1036,6 +1066,8 @@ FocusScope {
 
         //逆时针旋转
         RightMenuItem {
+            Accessible.name: "RotateCounterclockwise"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Rotate counterclockwise")
             visible: menuItemStates.canRotate
             onTriggered: {
@@ -1045,6 +1077,8 @@ FocusScope {
 
         //设置为壁纸
         RightMenuItem {
+            Accessible.name: "SetAsWallpaperAction"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Set as wallpaper")
             id: setAsWallpaperAction
             visible: menuItemStates.canWallpaper
@@ -1064,6 +1098,8 @@ FocusScope {
 
         //在文件管理器中显示
         RightMenuItem {
+            Accessible.name: "DisplayInFileManagerAction"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Display in file manager")
             id: displayInFileManagerAction
             visible: menuItemStates.canDisplayInFolder
@@ -1083,6 +1119,8 @@ FocusScope {
 
         //恢复
         RightMenuItem {
+            Accessible.name: "Restore"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Restore")
             visible: thumnailListType === Album.Types.ThumbnailTrash
             onTriggered: {
@@ -1092,6 +1130,8 @@ FocusScope {
 
         //照片信息
         RightMenuItem {
+            Accessible.name: "PhotoInfoAction"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Photo info")
             id: photoInfoAction
             visible: menuItemStates.canViewPhotoInfo
@@ -1111,6 +1151,8 @@ FocusScope {
 
         //视频信息
         RightMenuItem {
+            Accessible.name: "VideoInfoAction"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Video info")
             id: videoInfoAction
             visible: menuItemStates.canViewVideoInfo

--- a/src/qml/Control/MonthImage.qml
+++ b/src/qml/Control/MonthImage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -32,6 +32,8 @@ Rectangle {
         id: monthComponent_1pic
 
         BorderImageEx {
+            Accessible.name: "Component_BorderImageEx"
+            Accessible.role: Accessible.Graphic
             width: monthImage.width
             height: monthImage.height
             source: "image://collectionPublisher/" + monthImage.displayFlushHelper.toString() + "_M_1_" + paths[0]
@@ -47,6 +49,8 @@ Rectangle {
             Repeater {
                 model: paths
                 BorderImageEx {
+                    Accessible.name: "Repeater_BorderImageEx"
+                    Accessible.role: Accessible.Graphic
                     width: monthImage.width / 2
                     height: monthImage.height
                     source: "image://collectionPublisher/" + monthImage.displayFlushHelper.toString() + "_M_1_" + modelData
@@ -62,6 +66,8 @@ Rectangle {
         Row {
             spacing: 2
             BorderImageEx {
+                Accessible.name: "MonthImage_3picMain"
+                Accessible.role: Accessible.Graphic
                 width: monthImage.width / 2
                 height: monthImage.height
                 source: "image://collectionPublisher/" + monthImage.displayFlushHelper.toString() + "_M_1_" + paths[0]
@@ -73,6 +79,8 @@ Rectangle {
                 Repeater {
                     model: [paths[1], paths[2]]
                     BorderImageEx {
+                        Accessible.name: "MonthImage_3picSub"
+                        Accessible.role: Accessible.Graphic
                         width: monthImage.width / 2
                         height: monthImage.height / 2
                         source: "image://collectionPublisher/" + monthImage.displayFlushHelper.toString() + "_M_2_" + modelData
@@ -93,6 +101,8 @@ Rectangle {
             Repeater {
                 model: paths
                 BorderImageEx {
+                    Accessible.name: "MonthImage_4pic"
+                    Accessible.role: Accessible.Graphic
                     width: monthImage.width / 2
                     height: monthImage.height / 2
                     source: "image://collectionPublisher/" + monthImage.displayFlushHelper.toString() + "_M_2_" + modelData
@@ -108,6 +118,8 @@ Rectangle {
         Column {
             spacing: 2
             BorderImageEx {
+                Accessible.name: "MonthImage_5picMain"
+                Accessible.role: Accessible.Graphic
                 width: monthImage.width
                 height: monthImage.height * 0.618
                 source: "image://collectionPublisher/" + monthImage.displayFlushHelper.toString() + "_M_3_" + paths[0]
@@ -119,6 +131,8 @@ Rectangle {
                 Repeater {
                     model: [paths[1], paths[2], paths[3], paths[4]]
                     BorderImageEx {
+                        Accessible.name: "MonthImage_5picSub"
+                        Accessible.role: Accessible.Graphic
                         width: monthImage.width / 4
                         height: monthImage.height * (1 - 0.618)
                         source: "image://collectionPublisher/" + monthImage.displayFlushHelper.toString() + "_M_4_" + modelData
@@ -135,6 +149,8 @@ Rectangle {
         Column {
             spacing: 2
             BorderImageEx {
+                Accessible.name: "MonthImage_6picMain"
+                Accessible.role: Accessible.Graphic
                 width: monthImage.width
                 height: monthImage.height * 0.618
                 source: "image://collectionPublisher/" + monthImage.displayFlushHelper.toString() + "_M_3_" + paths[0]
@@ -146,6 +162,8 @@ Rectangle {
                 Repeater {
                     model: [paths[1], paths[2], paths[3], paths[4], paths[5]]
                     BorderImageEx {
+                        Accessible.name: "MonthImage_6picSub"
+                        Accessible.role: Accessible.Graphic
                         width: monthImage.width / 5
                         height: monthImage.height * (1 - 0.618)
                         source: "image://collectionPublisher/" + monthImage.displayFlushHelper.toString() + "_M_5_" + modelData

--- a/src/qml/Control/VideoInfoDialog.qml
+++ b/src/qml/Control/VideoInfoDialog.qml
@@ -70,10 +70,14 @@ DialogWindow {
 //            source: "qrc:/assets/popup/nointeractive.svg"
 //        }
         PropertyItem {
+            Accessible.name: "BasicInfo"
+            Accessible.role: Accessible.List
             title: qsTr("Basic info")
             ColumnLayout {
                 spacing: 1
                 PropertyActionItemDelegate {
+                    Accessible.name: "FileName"
+                    Accessible.role: Accessible.ListItem
                     Layout.fillWidth: true
                     title: qsTr("File name")
                     description: fileName
@@ -85,6 +89,8 @@ DialogWindow {
                     corners: RoundRectangle.TopCorner
                 }
                 PropertyActionItemDelegate {
+                    Accessible.name: "DateCaptured"
+                    Accessible.role: Accessible.ListItem
                     Layout.fillWidth: true
                     title: qsTr("Date captured")
                     description: albumControl.getMovieInfo("DateTimeOriginal",filePath)
@@ -93,16 +99,22 @@ DialogWindow {
                     Layout.fillWidth: true
                     spacing: 1
                     PropertyItemDelegate {
+                        Accessible.name: "Size"
+                        Accessible.role: Accessible.ListItem
                         title: qsTr("Size")
                         description: albumControl.getMovieInfo("Size",filePath)
                         corners: RoundRectangle.BottomLeftCorner
                     }
                     PropertyItemDelegate {
+                        Accessible.name: "Duration"
+                        Accessible.role: Accessible.ListItem
                         title: qsTr("Duration")
                         description: albumControl.getMovieInfo("Duration",filePath)
                         Layout.fillWidth: true
                     }
                     PropertyItemDelegate {
+                        Accessible.name: "Type"
+                        Accessible.role: Accessible.ListItem
                         title: qsTr("Type")
                         description: FileControl.slotFileSuffix(filePath,false)
                         corners: RoundRectangle.BottomRightCorner
@@ -112,6 +124,8 @@ DialogWindow {
             ColumnLayout {
                 spacing: 1
                 PropertyActionItemDelegate {
+                    Accessible.name: "Path"
+                    Accessible.role: Accessible.ListItem
                     Layout.fillWidth: true
                     title: qsTr("Path")
                     description: albumControl.getMovieInfo("Path",filePath)
@@ -120,6 +134,8 @@ DialogWindow {
             }
         }
         PropertyItem {
+            Accessible.name: "CodecInfo"
+            Accessible.role: Accessible.List
             title: qsTr("Codec info")
             ColumnLayout {
                 spacing: 1
@@ -127,18 +143,24 @@ DialogWindow {
                     Layout.fillWidth: true
                     spacing: 1
                     PropertyItemDelegate {
+                        Accessible.name: "VideoCodecId"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth:66
                         title: qsTr("Video CodecID")
                         description: albumControl.getMovieInfo("Video CodecID",filePath)
                         corners: RoundRectangle.TopLeftCorner
                     }
                     PropertyItemDelegate {
+                        Accessible.name: "VideoCodeRate"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth:106
                         title: qsTr("Video CodeRate")
                         description: albumControl.getMovieInfo("Video CodeRate",filePath)
                         Layout.fillWidth: true
                     }
                     PropertyItemDelegate {
+                        Accessible.name: "Fps"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth:86
                         title: qsTr("FPS")
                         description: albumControl.getMovieInfo("FPS",filePath)
@@ -150,6 +172,8 @@ DialogWindow {
                     Layout.fillWidth: true
                     spacing: 1
                     PropertyItemDelegate {
+                        Accessible.name: "Proportion"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth: 66
                         title: qsTr("Proportion")
                         description: albumControl.getMovieInfo("Proportion",filePath)
@@ -157,6 +181,8 @@ DialogWindow {
 
                     }
                     PropertyItemDelegate {
+                        Accessible.name: "Resolution"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth: 106
                         title: qsTr("Resolution")
                         description: albumControl.getMovieInfo("Resolution",filePath)
@@ -168,6 +194,8 @@ DialogWindow {
         }
 
         PropertyItem {
+            Accessible.name: "AudioCodecInfo"
+            Accessible.role: Accessible.List
             title: qsTr("Video CodecID")
             ColumnLayout {
                 spacing: 1
@@ -175,18 +203,24 @@ DialogWindow {
                     Layout.fillWidth: true
                     spacing: 1
                     PropertyItemDelegate {
+                        Accessible.name: "AudioCodecId"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth:66
                         title: qsTr("Audio CodecID")
                         description: albumControl.getMovieInfo("Audio CodecID",filePath)
                         corners: RoundRectangle.TopLeftCorner
                     }
                     PropertyItemDelegate {
+                        Accessible.name: "AudioCodeRate"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth:106
                         title: qsTr("Audio CodeRate")
                         description: albumControl.getMovieInfo("Audio CodeRate",filePath)
                         Layout.fillWidth: true
                     }
                     PropertyItemDelegate {
+                        Accessible.name: "AudioDigit"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth:86
                         title: qsTr("Audio digit")
                         description: albumControl.getMovieInfo("Audio digit",filePath)
@@ -198,6 +232,8 @@ DialogWindow {
                     Layout.fillWidth: true
                     spacing: 1
                     PropertyItemDelegate {
+                        Accessible.name: "Channels"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth: 66
                         title: qsTr("Channels")
                         description: albumControl.getMovieInfo("Channels",filePath)
@@ -205,6 +241,8 @@ DialogWindow {
 
                     }
                     PropertyItemDelegate {
+                        Accessible.name: "Sampling"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth: 106
                         title: qsTr("Sampling")
                         description: albumControl.getMovieInfo("Sampling",filePath)

--- a/src/qml/MainAlbumView.qml
+++ b/src/qml/MainAlbumView.qml
@@ -15,6 +15,8 @@ import "./PopProgress"
 import "./Control/Animation"
 
 FadeInoutAnimation {
+    Accessible.name: "MainAlbumView_FadeInoutAnimation"
+    Accessible.role: Accessible.Client
     anchors.fill: parent
     property int lastWidth: 0
 
@@ -72,6 +74,8 @@ FadeInoutAnimation {
 
     // 侧边导航栏
     Sidebar{
+        Accessible.name: "LeftSidebar"
+        Accessible.role: Accessible.Pane
         id : leftSidebar
         width: visible ? GStatus.sideBarWidth : 0
         anchors {
@@ -176,6 +180,8 @@ FadeInoutAnimation {
     }
 
     ThumbnailImage{
+        Accessible.name: "ThumbnailImage"
+        Accessible.role: Accessible.Graphic
         id: thumbnailImage
         clip: true
         anchors {
@@ -189,6 +195,8 @@ FadeInoutAnimation {
     }
 
     StatusBar {
+        Accessible.name: "StatusBar"
+        Accessible.role: Accessible.StatusBar
         id: statusBar
         anchors {
             bottom: parent.bottom
@@ -212,6 +220,8 @@ FadeInoutAnimation {
 
     //标准弹出式进度条窗口
     StandardProgressDialog {
+        Accessible.name: "IdStandardProgressDialog"
+        Accessible.role: Accessible.Dialog
         id: idStandardProgressDialog
         z: leftSidebar.z + 1
     }

--- a/src/qml/PreviewImageViewer/Dialog/RemoveDialog.qml
+++ b/src/qml/PreviewImageViewer/Dialog/RemoveDialog.qml
@@ -92,6 +92,7 @@ DialogWindow {
             spacing: 10
 
             Button {
+                Accessible.name: "Cancel"
                 height: 36
                 text: qsTr("Cancel")
                 width: 185

--- a/src/qml/PreviewImageViewer/FullImageView.qml
+++ b/src/qml/PreviewImageViewer/FullImageView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -187,6 +187,8 @@ Item {
     }
 
     ImageViewer {
+        Accessible.name: "ImageViewer"
+        Accessible.role: Accessible.Pane
         id: imageViewer
 
         anchors.fill: parent
@@ -352,6 +354,8 @@ Item {
     }
 
     ThumbnailListView {
+        Accessible.name: "ThumbnailViewBackGround"
+        Accessible.role: Accessible.List
         id: thumbnailViewBackGround
 
         property bool animationShow: true
@@ -431,6 +435,8 @@ Item {
 
     //浮动提示框
     FloatingNotice {
+        Accessible.name: "FloatLabel"
+        Accessible.role: Accessible.StaticText
         id: floatLabel
 
         anchors.bottom: parent.bottom

--- a/src/qml/PreviewImageViewer/FullThumbnail.qml
+++ b/src/qml/PreviewImageViewer/FullThumbnail.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -315,6 +315,8 @@ Item {
     }
 
     ImageViewer {
+        Accessible.name: "FullThumbnailImageViewer"
+        Accessible.role: Accessible.Pane
         id: imageViewer
         anchors.fill: parent
     }
@@ -447,12 +449,16 @@ Item {
     }
 
     ToolBarThumbnailListView {
+        Accessible.name: "ToolBarthumbnailListView"
+        Accessible.role: Accessible.List
         id: toolBarthumbnailListView
         anchors.fill: thumbnailViewBackGround
     }
 
     //浮动提示框
     FloatingNotice {
+        Accessible.name: "FullThumbnailFloatLabel"
+        Accessible.role: Accessible.StaticText
         id: floatLabel
         visible: false
         anchors.bottom: thumbnailViewBackGround.top

--- a/src/qml/PreviewImageViewer/ImageDelegate/DamagedImageDelegate.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/DamagedImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,8 @@ import QtQuick
 import org.deepin.dtk 1.0 as DTK
 
 BaseImageDelegate {
+    Accessible.name: "DamagedImageDelegate"
+    Accessible.role: Accessible.ListItem
     id: delegate
 
     paintedPaddingWidth: (width - damagedIcon.width) / 2

--- a/src/qml/PreviewImageViewer/ImageDelegate/DynamicImageDelegate.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/DynamicImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,8 @@ import QtQuick
 import "../Utils"
 
 BaseImageDelegate {
+    Accessible.name: "DynamicImageDelegate"
+    Accessible.role: Accessible.ListItem
     id: delegate
 
     property bool needInit: true
@@ -29,6 +31,8 @@ BaseImageDelegate {
     }
 
     ImageInputHandler {
+        Accessible.name: "DynamicImageInput"
+        Accessible.role: Accessible.Client
         id: imageInput
 
         anchors.fill: parent

--- a/src/qml/PreviewImageViewer/ImageDelegate/MultiImageDelegate.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/MultiImageDelegate.qml
@@ -9,6 +9,8 @@ import "../Utils"
 
 // 使用嵌套的ListView进行浏览
 BaseImageDelegate {
+    Accessible.name: "MultiImageDelegate"
+    Accessible.role: Accessible.ListItem
     id: multiImageDelegate
 
     ListView {
@@ -100,6 +102,8 @@ BaseImageDelegate {
 
                 // 和 image 保持同一层级
                 ImageInputHandler {
+                    Accessible.name: "ImageInput"
+                    Accessible.role: Accessible.Client
                     id: imageInput
 
                     anchors.fill: parent

--- a/src/qml/PreviewImageViewer/ImageDelegate/NoPermissionImageDelegate.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/NoPermissionImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,8 @@ import org.deepin.dtk 1.0
 import org.deepin.dtk.style 1.0 as DS
 
 BaseImageDelegate {
+    Accessible.name: "Delegate"
+    Accessible.role: Accessible.ListItem
     id: delegate
 
     status: Image.Error

--- a/src/qml/PreviewImageViewer/ImageDelegate/NonexistImageDelegate.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/NonexistImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,8 @@ import org.deepin.dtk 1.0
 import org.deepin.dtk.style 1.0 as DS
 
 BaseImageDelegate {
+    Accessible.name: "NonexistImageDelegate"
+    Accessible.role: Accessible.ListItem
     id: delegate
 
     paintedPaddingWidth: (width - notExistImage.width) / 2

--- a/src/qml/PreviewImageViewer/ImageDelegate/NormalImageDelegate.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/NormalImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023~2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,8 @@ import org.deepin.image.viewer 1.0 as IV
 import "../Utils"
 
 BaseImageDelegate {
+    Accessible.name: "NormalImageDelegate"
+    Accessible.role: Accessible.ListItem
     id: delegate
 
     property bool rotationRunning: false
@@ -99,6 +101,8 @@ BaseImageDelegate {
     }
 
     SourceSizeOptimizer {
+        Accessible.name: "SourceSizeOptimizer"
+        Accessible.role: Accessible.Client
         id: sourceSizeOptimizer
         targetImage: image
         imageInfo: targetImageInfo
@@ -240,6 +244,8 @@ BaseImageDelegate {
     }
 
     ImageInputHandler {
+        Accessible.name: "NormalImageInput"
+        Accessible.role: Accessible.Client
         id: imageInput
 
         anchors.fill: parent

--- a/src/qml/PreviewImageViewer/ImageDelegate/SvgImageDelegate.qml
+++ b/src/qml/PreviewImageViewer/ImageDelegate/SvgImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,8 @@ import org.deepin.image.viewer 1.0 as IV
 import "../Utils"
 
 BaseImageDelegate {
+    Accessible.name: "SvgImageDelegate"
+    Accessible.role: Accessible.ListItem
     id: delegate
 
     status: image.status
@@ -32,6 +34,8 @@ BaseImageDelegate {
     }
 
     ImageInputHandler {
+        Accessible.name: "SvgImageInput"
+        Accessible.role: Accessible.Client
         id: imageInput
 
         anchors.fill: parent

--- a/src/qml/PreviewImageViewer/ImageViewer.qml
+++ b/src/qml/PreviewImageViewer/ImageViewer.qml
@@ -142,6 +142,8 @@ Item {
 
     // 图像动画：缩放
     ImageAnimation {
+        Accessible.name: "ImageAnimation"
+        Accessible.role: Accessible.Client
         id: imageAnimation
 
         targetImage: imageViewer.targetImage
@@ -473,6 +475,8 @@ Item {
 
         // 代理组件加载器
         delegate: ViewDelegateLoader {
+            Accessible.name: "ImageViewer_ViewDelegateLoader"
+            Accessible.role: Accessible.Client
         }
         Behavior on offset {
             id: offsetBehavior
@@ -724,6 +728,8 @@ Item {
         width: 150
 
         sourceComponent: NavigationWidget {
+            Accessible.name: "Loader_NavigationWidget"
+            Accessible.role: Accessible.Pane
             // 根据当前缩放动画预期的缩放比例调整导航窗口是否提前触发隐藏
             prefferHide: {
                 if (imageAnimation.running) {

--- a/src/qml/PreviewImageViewer/InformationDialog/InformationDialog.qml
+++ b/src/qml/PreviewImageViewer/InformationDialog/InformationDialog.qml
@@ -79,12 +79,16 @@ DialogWindow {
         }
 
         PropertyItem {
+            Accessible.name: "BasicInfo"
+            Accessible.role: Accessible.List
             title: qsTr("Basic info")
 
             ColumnLayout {
                 spacing: 1
 
                 PropertyActionItemDelegate {
+                    Accessible.name: "FileNameProp"
+                    Accessible.role: Accessible.ListItem
                     id: fileNameProp
 
                     Layout.fillWidth: true
@@ -101,6 +105,8 @@ DialogWindow {
                     spacing: 1
 
                     PropertyItemDelegate {
+                        Accessible.name: "Size"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth: propLeftWidth
                         corners: RoundRectangle.BottomLeftCorner
                         description: FileControl.slotGetInfo("FileSize", filePath)
@@ -108,6 +114,8 @@ DialogWindow {
                     }
 
                     PropertyItemDelegate {
+                        Accessible.name: "Dimensions"
+                        Accessible.role: Accessible.ListItem
                         Layout.fillWidth: true
                         contrlImplicitWidth: propMidWidth
                         description: {
@@ -122,6 +130,8 @@ DialogWindow {
                     }
 
                     PropertyItemDelegate {
+                        Accessible.name: "Type"
+                        Accessible.role: Accessible.ListItem
                         contrlImplicitWidth: propRightWidth
                         corners: RoundRectangle.BottomRightCorner
                         description: FileControl.slotFileSuffix(filePath, false)
@@ -134,6 +144,8 @@ DialogWindow {
                 spacing: 1
 
                 PropertyItemDelegate {
+                    Accessible.name: "DateCaptured"
+                    Accessible.role: Accessible.ListItem
                     Layout.fillWidth: true
                     corners: RoundRectangle.TopCorner
                     description: FileControl.slotGetInfo("DateTimeOriginal", filePath)
@@ -141,6 +153,8 @@ DialogWindow {
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "DateModified"
+                    Accessible.role: Accessible.ListItem
                     Layout.fillWidth: true
                     corners: RoundRectangle.BottomCorner
                     description: FileControl.slotGetInfo("DateTimeDigitized", filePath)
@@ -150,6 +164,8 @@ DialogWindow {
         }
 
         PropertyItem {
+            Accessible.name: "DetailInfoItem"
+            Accessible.role: Accessible.List
             id: detailInfoItem
 
             // 详细信息默认不显示，会影响自动布局效果，因此目前设置为固定布局
@@ -164,6 +180,8 @@ DialogWindow {
                 rows: 4
 
                 PropertyItemDelegate {
+                    Accessible.name: "Aperture"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propLeftWidth
                     corners: RoundRectangle.TopLeftCorner
                     description: FileControl.slotGetInfo("ApertureValue", filePath)
@@ -171,6 +189,8 @@ DialogWindow {
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "ExposureProgram"
+                    Accessible.role: Accessible.ListItem
                     Layout.fillWidth: true
                     Layout.minimumWidth: propMidWidth
                     contrlImplicitWidth: propMidWidth
@@ -179,6 +199,8 @@ DialogWindow {
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "FocalLength"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propRightWidth
                     corners: RoundRectangle.TopRightCorner
                     description: FileControl.slotGetInfo("FocalLength", filePath)
@@ -186,12 +208,16 @@ DialogWindow {
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "Iso"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propLeftWidth
                     description: FileControl.slotGetInfo("ISOSpeedRatings", filePath)
                     title: qsTr("ISO")
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "ExposureMode"
+                    Accessible.role: Accessible.ListItem
                     Layout.fillWidth: true
                     contrlImplicitWidth: propMidWidth
                     description: FileControl.slotGetInfo("ExposureMode", filePath)
@@ -199,18 +225,24 @@ DialogWindow {
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "ExposureTime"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propRightWidth
                     description: FileControl.slotGetInfo("ExposureTime", filePath)
                     title: qsTr("Exposure time")
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "Flash"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propLeftWidth
                     description: FileControl.slotGetInfo("Flash", filePath)
                     title: qsTr("Flash")
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "FlashCompensation"
+                    Accessible.role: Accessible.ListItem
                     Layout.fillWidth: true
                     contrlImplicitWidth: propMidWidth
                     description: FileControl.slotGetInfo("FlashExposureComp", filePath)
@@ -218,12 +250,16 @@ DialogWindow {
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "MaxAperture"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propRightWidth
                     description: FileControl.slotGetInfo("MaxApertureValue", filePath)
                     title: qsTr("Max aperture")
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "Colorspace"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propLeftWidth
                     corners: RoundRectangle.BottomLeftCorner
                     description: FileControl.slotGetInfo("ColorSpace", filePath)
@@ -231,6 +267,8 @@ DialogWindow {
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "MeteringMode"
+                    Accessible.role: Accessible.ListItem
                     Layout.fillWidth: true
                     contrlImplicitWidth: propMidWidth
                     description: FileControl.slotGetInfo("MeteringMode", filePath)
@@ -238,6 +276,8 @@ DialogWindow {
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "WhiteBalance"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propRightWidth
                     corners: RoundRectangle.BottomRightCorner
                     description: FileControl.slotGetInfo("WhiteBalance", filePath)
@@ -249,6 +289,8 @@ DialogWindow {
                 spacing: 1
 
                 PropertyItemDelegate {
+                    Accessible.name: "DeviceModel"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propFullWidth
                     corners: RoundRectangle.AllCorner
                     description: FileControl.slotGetInfo("Model", filePath)
@@ -256,6 +298,8 @@ DialogWindow {
                 }
 
                 PropertyItemDelegate {
+                    Accessible.name: "LensModel"
+                    Accessible.role: Accessible.ListItem
                     contrlImplicitWidth: propFullWidth
                     corners: RoundRectangle.AllCorner
                     description: FileControl.slotGetInfo("LensType", filePath)

--- a/src/qml/PreviewImageViewer/InformationDialog/PropertyActionItemDelegate.qml
+++ b/src/qml/PreviewImageViewer/InformationDialog/PropertyActionItemDelegate.qml
@@ -81,6 +81,8 @@ Control {
         spacing: 0
 
         ElideLabel {
+            Accessible.name: "PropertyActionItemDelegate_ElideLabel"
+            Accessible.role: Accessible.StaticText
             Layout.fillWidth: true
             // 系数微调整以满足默认字号标签均显示的效果
             Layout.minimumWidth: descriptionWidth + 5

--- a/src/qml/PreviewImageViewer/InformationDialog/PropertyItem.qml
+++ b/src/qml/PreviewImageViewer/InformationDialog/PropertyItem.qml
@@ -18,7 +18,7 @@ ColumnLayout {
     width: 280
 
     ItemDelegate {
-        Accessible.name: "TitleBar_2"
+        Accessible.name: "PropertyItemTitleBar"
         id: titleBar
 
         property Palette titleTextColor: Palette {
@@ -53,7 +53,7 @@ ColumnLayout {
     }
 
     ListView {
-        Accessible.name: "Info_2"
+        Accessible.name: "PropertyItemInfo"
         id: info
 
         Layout.fillWidth: true

--- a/src/qml/PreviewImageViewer/InformationDialog/PropertyItemDelegate.qml
+++ b/src/qml/PreviewImageViewer/InformationDialog/PropertyItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -59,6 +59,8 @@ Control {
         spacing: 0
 
         ElideLabel {
+            Accessible.name: "PropertyItemDelegateTitle"
+            Accessible.role: Accessible.StaticText
             Layout.fillWidth: true
             // 系数微调整以满足默认字号标签均显示的效果
             Layout.minimumWidth: descriptionWidth + 5
@@ -72,6 +74,8 @@ Control {
             id: content
 
             ElideLabel {
+                Accessible.name: "PropertyItemDelegateValue"
+                Accessible.role: Accessible.StaticText
                 Layout.fillWidth: true
                 color: control.ColorSelector.infoTextColor
                 sourceText: control.description

--- a/src/qml/PreviewImageViewer/MainStack.qml
+++ b/src/qml/PreviewImageViewer/MainStack.qml
@@ -13,6 +13,8 @@ import org.deepin.album 1.0 as Album
 import "../Control/Animation"
 
 FadeInoutAnimation {
+    Accessible.name: "StackView"
+    Accessible.role: Accessible.Client
     id: stackView
 
     property alias iconName: titleRect.iconName
@@ -77,6 +79,8 @@ FadeInoutAnimation {
 
     // 标题栏
     ViewTopTitle {
+        Accessible.name: "TitleRect"
+        Accessible.role: Accessible.Pane
         id: titleRect
 
         z: parent.z + 1

--- a/src/qml/PreviewImageViewer/PropertyActionItemDelegate.qml
+++ b/src/qml/PreviewImageViewer/PropertyActionItemDelegate.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 UnionTech Technology Co., Ltd.
+// Copyright (C) 2022 - 2026 UnionTech Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -86,6 +86,8 @@ Control {
                     hoverEnabled: true
 
                     AlertToolTip {
+                        Accessible.name: "PropertyActionItemTip"
+                        Accessible.role: Accessible.ToolTip
                         id:tip
                         parent: parent
                         visible: parent.focus

--- a/src/qml/PreviewImageViewer/PropertyItemDelegate.qml
+++ b/src/qml/PreviewImageViewer/PropertyItemDelegate.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 UnionTech Technology Co., Ltd.
+// Copyright (C) 2022 - 2026 UnionTech Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -57,6 +57,8 @@ Control {
 
 
                         AlertToolTip{
+                            Accessible.name: "Tip"
+                            Accessible.role: Accessible.ToolTip
                             id:tip
                             parent: parent
                             visible:parent.focus

--- a/src/qml/PreviewImageViewer/SliderShow.qml
+++ b/src/qml/PreviewImageViewer/SliderShow.qml
@@ -77,6 +77,8 @@ Item {
     }
 
     SFadeInOut {
+        Accessible.name: "FadeInOutImage"
+        Accessible.role: Accessible.Client
         id: fadeInOutImage
 
         anchors.fill: parent

--- a/src/qml/PreviewImageViewer/ThumbnailDelegate/MultiThumnailDelegate.qml
+++ b/src/qml/PreviewImageViewer/ThumbnailDelegate/MultiThumnailDelegate.qml
@@ -7,6 +7,8 @@ import org.deepin.image.viewer 1.0 as IV
 
 // 用于多页图的缩略图代理
 BaseThumbnailDelegate {
+    Accessible.name: "MultiThumnailDelegate"
+    Accessible.role: Accessible.ListItem
     id: multiThumnailDelegate
 
     // 请求的显示宽度
@@ -96,6 +98,8 @@ BaseThumbnailDelegate {
             }
 
             ThumbnailImage {
+                Accessible.name: "MultiThumnailFrameImage"
+                Accessible.role: Accessible.Graphic
                 id: img
 
                 anchors.fill: parent

--- a/src/qml/PreviewImageViewer/ThumbnailDelegate/NormalThumbnailDelegate.qml
+++ b/src/qml/PreviewImageViewer/ThumbnailDelegate/NormalThumbnailDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,8 @@ import org.deepin.image.viewer 1.0 as IV
 import org.deepin.album 1.0 as Album
 
 BaseThumbnailDelegate {
+    Accessible.name: "NormalThumbnailDelegate"
+    Accessible.role: Accessible.ListItem
     id: normalThumbnailDelegate
 
     // 判断是否为多页图
@@ -50,6 +52,8 @@ BaseThumbnailDelegate {
         visible: true
 
         ThumbnailImage {
+            Accessible.name: "Img"
+            Accessible.role: Accessible.Graphic
             id: img
 
             anchors.centerIn: parent

--- a/src/qml/PreviewImageViewer/ToolBarThumbnailListView.qml
+++ b/src/qml/PreviewImageViewer/ToolBarThumbnailListView.qml
@@ -386,6 +386,8 @@ Item {
         cacheBuffer: 400
         model: mainView.sourcePaths.length
         delegate: ListViewDelegate {
+            Accessible.name: "ListView_ListViewDelegate"
+            Accessible.role: Accessible.ListItem
         }
 
          // 添加两组空的表头表尾用于占位，防止在边界的高亮缩略图被遮挡

--- a/src/qml/PreviewImageViewer/ViewRightMenu.qml
+++ b/src/qml/PreviewImageViewer/ViewRightMenu.qml
@@ -32,6 +32,8 @@ Menu {
     y: 600
 
     RightMenuItem {
+        Accessible.name: "RightFullscreen"
+        Accessible.role: Accessible.MenuItem
         id: rightFullscreen
 
         function switchFullScreen() {
@@ -58,6 +60,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "Print"
+        Accessible.role: Accessible.MenuItem
         text: qsTr("Print")
         visible: !isNullImage
 
@@ -79,6 +83,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "ExtractText"
+        Accessible.role: Accessible.MenuItem
         text: qsTr("Extract text")
         visible: supportOcr
 
@@ -101,6 +107,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "SlideShow"
+        Accessible.role: Accessible.MenuItem
         text: qsTr("Slide show")
 
         onTriggered: {
@@ -126,6 +134,8 @@ Menu {
 
     //导出图片为其它格式
     RightMenuItem {
+        Accessible.name: "Export"
+        Accessible.role: Accessible.MenuItem
         text: qsTr("Export")
         visible: canExport && !menuItemStates.isInTrash && FileControl.isAlbum()
         onTriggered: {
@@ -142,6 +152,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "Copy"
+        Accessible.role: Accessible.MenuItem
         text: qsTr("Copy")
         visible: readable
 
@@ -166,6 +178,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "Rename"
+        Accessible.role: Accessible.MenuItem
         text: qsTr("Rename")
         visible: renamable
 
@@ -186,6 +200,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "Delete"
+        Accessible.role: Accessible.MenuItem
         enabled: !thumbnailViewBackGround.imageDeleting
         text: qsTr("Delete")
         visible: deletable
@@ -215,6 +231,8 @@ Menu {
 
     //添加到我的收藏
     RightMenuItem {
+        Accessible.name: "FavoriteAction"
+        Accessible.role: Accessible.MenuItem
         id: favoriteAction
         text: qsTr("Favorite")
         visible: !menuItemStates.isInTrash && imageViewer.canFavorite && FileControl.isAlbum()
@@ -225,6 +243,8 @@ Menu {
 
     //从我的收藏中移除
     RightMenuItem {
+        Accessible.name: "UnFavoriteAction"
+        Accessible.role: Accessible.MenuItem
         id: unFavoriteAction
         text: qsTr("Unfavorite")
         visible: !menuItemStates.isInTrash && !imageViewer.canFavorite && FileControl.isAlbum()
@@ -241,6 +261,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "RotateClockItem"
+        Accessible.role: Accessible.MenuItem
         id: rotateClockItem
 
         text: qsTr("Rotate clockwise")
@@ -263,6 +285,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "RotateCounterClockItem"
+        Accessible.role: Accessible.MenuItem
         id: rotateCounterClockItem
 
         text: qsTr("Rotate counterclockwise")
@@ -292,6 +316,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "EnableNavigation"
+        Accessible.role: Accessible.MenuItem
         id: enableNavigation
 
         enabled: visible && window.height > GStatus.minHideHeight && window.width > GStatus.minWidth
@@ -307,6 +333,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "SetAsWallpaper"
+        Accessible.role: Accessible.MenuItem
         text: qsTr("Set as wallpaper")
         visible: supportWallpaper
 
@@ -329,6 +357,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "DisplayInFileManager"
+        Accessible.role: Accessible.MenuItem
         text: qsTr("Display in file manager")
 
         onTriggered: {
@@ -348,6 +378,8 @@ Menu {
     }
 
     RightMenuItem {
+        Accessible.name: "ImageInfo"
+        Accessible.role: Accessible.MenuItem
         text: qsTr("Image info")
 
         onTriggered: {

--- a/src/qml/PreviewImageViewer/ViewTopTitle.qml
+++ b/src/qml/PreviewImageViewer/ViewTopTitle.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -198,6 +198,8 @@ Rectangle {
         }
 
         windowButtonGroup: WindowButtonGroupEx {
+            Accessible.name: "ViewTopTitle_WindowButtonGroupEx"
+            Accessible.role: Accessible.Grouping
             Layout.alignment: Qt.AlignRight
             Layout.fillHeight: true
             embedMode: titlebar.embedMode

--- a/src/qml/SideBar/SideBarItem.qml
+++ b/src/qml/SideBar/SideBarItem.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2026 UnionTech Technology Co., Ltd.
+// Copyright (C) 2022 - 2026 UnionTech Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -66,6 +66,8 @@ ColumnLayout {
         model: sideModel
         interactive: false
         delegate: SideBarItemDelegate{
+            Accessible.name: "SidebarItem"
+            Accessible.role: Accessible.ListItem
             id: sidebarItem
             width: 180
             height: 36

--- a/src/qml/SideBar/Sidebar.qml
+++ b/src/qml/SideBar/Sidebar.qml
@@ -207,6 +207,8 @@ ScrollView {
 
         // 照片库侧边栏
         SideBarItem {
+            Accessible.name: "GallerySideBar"
+            Accessible.role: Accessible.ListItem
             id: gallerySideBar
             Layout.alignment:  Qt.AlignTop; Layout.topMargin: 15
             title: qsTr("Gallery")
@@ -252,6 +254,8 @@ ScrollView {
 
         // 设备列表侧边栏
         SideBarItem {
+            Accessible.name: "DeviceSideBar"
+            Accessible.role: Accessible.ListItem
             id: deviceSideBar
             visible: devicePaths.length
             Layout.alignment:  Qt.AlignTop; Layout.topMargin: 15
@@ -312,6 +316,8 @@ ScrollView {
 
         // 相册侧边栏(系统相册 + 自定导入相册 + 自定义相册)
         SideBarItem {
+            Accessible.name: "SystemSideBar"
+            Accessible.role: Accessible.ListItem
             id: systemSideBar
             title: qsTr("Albums")
             group: paneListGroup
@@ -379,6 +385,8 @@ ScrollView {
 
         // 自动导入的相册列表(拖拽图片文件夹导入的相册列表)
         SideBarItem {
+            Accessible.name: "ImportSideBar"
+            Accessible.role: Accessible.ListItem
             id: importSideBar
             showTitle: false
             group: paneListGroup
@@ -424,6 +432,8 @@ ScrollView {
 
         // 用户自定义相册列表
         SideBarItem {
+            Accessible.name: "CustomSideBar"
+            Accessible.role: Accessible.ListItem
             id: customSideBar
             showTitle: false
             group: paneListGroup
@@ -487,6 +497,8 @@ ScrollView {
 
         //显示大图预览
         RightMenuItem {
+            Accessible.name: "SystemMenuSlideShow"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Slide show")
             visible: albumPaths.length >0
             onTriggered: {
@@ -498,6 +510,8 @@ ScrollView {
         }
 
         RightMenuItem {
+            Accessible.name: "SystemMenuExport"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Export")
             visible:  albumPaths.length >0
             onTriggered: {
@@ -512,6 +526,8 @@ ScrollView {
 
         //显示大图预览
         RightMenuItem {
+            Accessible.name: "ImportMenuSlideShow"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Slide show")
             visible: albumPaths.length > 0
             onTriggered: {
@@ -524,6 +540,8 @@ ScrollView {
         }
 
         RightMenuItem {
+            Accessible.name: "ImportMenuExport"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Export")
             visible: albumPaths.length > 0
             onTriggered: {
@@ -532,6 +550,8 @@ ScrollView {
         }
 
         RightMenuItem {
+            Accessible.name: "ImportMenuDelete"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Delete")
             onTriggered: {
                 removeAlbumDialog.deleteType = 1
@@ -583,6 +603,8 @@ ScrollView {
 
         // 显示大图预览
         RightMenuItem {
+            Accessible.name: "CustomMenuSlideShow"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Slide show")
             visible: albumPaths.length > 0
             onTriggered: {
@@ -592,6 +614,8 @@ ScrollView {
 
         // 新建相册
         RightMenuItem {
+            Accessible.name: "NewAlbum"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("New album")
             visible: GStatus.currentCustomAlbumUId > 3 ? true : false
             onTriggered: {
@@ -604,6 +628,8 @@ ScrollView {
 
         // 重命名相册
         RightMenuItem {
+            Accessible.name: "CustomMenuRename"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Rename")
             visible: GStatus.currentCustomAlbumUId > 3 ? true : false
             onTriggered: {
@@ -616,6 +642,8 @@ ScrollView {
 
         // 导出相册
         RightMenuItem {
+            Accessible.name: "CustomMenuExport"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Export")
             visible: albumPaths.length > 0
             onTriggered: {
@@ -625,6 +653,8 @@ ScrollView {
 
         // 删除相册
         RightMenuItem {
+            Accessible.name: "CustomMenuDelete"
+            Accessible.role: Accessible.MenuItem
             text: qsTr("Delete")
             visible: GStatus.currentCustomAlbumUId > 3 ? true : false
             onTriggered: {

--- a/src/qml/StackControl.qml
+++ b/src/qml/StackControl.qml
@@ -24,6 +24,8 @@ Item {
     }
 
     MainAlbumView{
+        Accessible.name: "MainAlbumView"
+        Accessible.role: Accessible.Pane
         id: mainAlbumView
         idName: "mainAlbumView"
         show: GStatus.stackControlCurrent === 0
@@ -33,6 +35,8 @@ Item {
         anchors.fill: parent
         active: deferredStackReady
         sourceComponent: MainStack {
+            Accessible.name: "Loader_MainStack"
+            Accessible.role: Accessible.LayeredPane
             idName: "mainStack"
             anchors.fill: parent
             show: GStatus.stackControlCurrent === 1
@@ -44,6 +48,8 @@ Item {
         anchors.fill: parent
         active: deferredStackReady
         sourceComponent: SliderShow {
+            Accessible.name: "Loader_SliderShow"
+            Accessible.role: Accessible.Pane
             idName: "albumview"
             anchors.fill: parent
             visible: GStatus.stackControlCurrent === 2
@@ -62,10 +68,14 @@ Item {
     }
 
     GlobalVar{
+        Accessible.name: "Global"
+        Accessible.role: Accessible.Client
         id: global
     }
 
     MenuItemStates {
+        Accessible.name: "MenuItemStates"
+        Accessible.role: Accessible.MenuItem
         id: menuItemStates
     }
 

--- a/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/AllCollection.qml
@@ -17,6 +17,8 @@ import "../../Control/Animation"
 import "../../"
 
 SwitchViewAnimation {
+    Accessible.name: "AllCollection_SwitchViewAnimation"
+    Accessible.role: Accessible.Client
 
     // The default all-items page is constructed with show=true.  Do not let
     // UnknownSwitchType fade it in before the parent collection view appears.
@@ -318,6 +320,8 @@ SwitchViewAnimation {
 
         // 筛选下拉框
         FilterComboBox {
+            Accessible.name: "AllCollectionFilterComboBox"
+            Accessible.role: Accessible.ComboBox
             id: filterCombo
             anchors {
                 top: dateRangeLabel.top
@@ -348,6 +352,8 @@ SwitchViewAnimation {
         active: false
         asynchronous: false
         sourceComponent: ThumbnailListViewAlbum {
+            Accessible.name: "Loader_ThumbnailListViewAlbum"
+            Accessible.role: Accessible.List
             anchors {
                 top: parent.top
                 topMargin: theViewLoader.contentTopMargin

--- a/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/CollecttionView.qml
@@ -12,6 +12,8 @@ import "../../"
 import "../../Control"
 
 BaseView {
+    Accessible.name: "CollecttView"
+    Accessible.role: Accessible.Pane
     id: collecttView
 
     property int currentViewIndex: 3
@@ -106,6 +108,8 @@ BaseView {
     }
 
     YearCollection {
+        Accessible.name: "YearCollection"
+        Accessible.role: Accessible.Pane
         id: yearCollection
         width: collecttView.width
         height: collecttView.height
@@ -114,6 +118,8 @@ BaseView {
     }
 
     MonthCollection {
+        Accessible.name: "MonthCollection"
+        Accessible.role: Accessible.Pane
         id: monthCollection
         width: collecttView.width
         height: collecttView.height
@@ -130,6 +136,8 @@ BaseView {
         asynchronous: false
         active: currentViewIndex === 2 || dayLoadedOnce
         sourceComponent: DayCollection {
+            Accessible.name: "DayCollection"
+            Accessible.role: Accessible.Pane
             id: dayCollection
             visible: false
             width: collecttView.width
@@ -153,6 +161,8 @@ BaseView {
     }
 
     AllCollection {
+        Accessible.name: "AllCollection"
+        Accessible.role: Accessible.Pane
         id: allCollection
         x: 0
         width: collecttView.width
@@ -163,6 +173,8 @@ BaseView {
 
     // 若没有数据，显示导入图片视图
     NoPictureView {
+        Accessible.name: "BaseView_NoPictureView"
+        Accessible.role: Accessible.Pane
         visible: GStatus.currentViewType === Album.Types.ViewCollecttion && allCollection.numLabelText === "" && albumControl.getAllCount() === 0
         bShowImportBtn: true
         iconName: "nopicture1"

--- a/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/DayCollection.qml
@@ -17,6 +17,8 @@ import "../../Control/Animation"
 import "../../"
 
 SwitchViewAnimation {
+    Accessible.name: "DayView"
+    Accessible.role: Accessible.Client
     id: dayView
 
     signal sigListViewPressed(int x, int y)
@@ -59,6 +61,8 @@ SwitchViewAnimation {
 
         // QML FilterComboBox overlay, replaces the builtin C++ filter widget
         FilterComboBox {
+            Accessible.name: "DayCollectionFilterComboBox"
+            Accessible.role: Accessible.ComboBox
             id: filterCombo
             anchors {
                 top: timeline.top
@@ -73,6 +77,8 @@ SwitchViewAnimation {
         }
 
         WidgetScrollBar {
+            Accessible.name: "SwitchViewAnimation_WidgetScrollBar"
+            Accessible.role: Accessible.ScrollBar
             contentRatio: timeline.contentRatio
             scrollPosition: timeline.scrollPosition
             onScrollPositionChangedFromDrag: (pos) => timeline.setScrollPosition(pos)

--- a/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/MonthCollection.qml
@@ -17,6 +17,8 @@ import "../../"
 import org.deepin.album 1.0 as Album
 
 SwitchViewAnimation {
+    Accessible.name: "MonthView"
+    Accessible.role: Accessible.Client
     id: monthView
 
     idName: "monthView"
@@ -84,6 +86,8 @@ SwitchViewAnimation {
     }
 
     FlickableScrollBar {
+        Accessible.name: "SwitchViewAnimation_FlickableScrollBar"
+        Accessible.role: Accessible.ScrollBar
         flickable: theView
     }
 
@@ -98,6 +102,8 @@ SwitchViewAnimation {
             property var paths: albumControl.getMonthPaths(year, month)
 
             MonthImage {
+                Accessible.name: "Image"
+                Accessible.role: Accessible.Pane
                 id: image
                 anchors.verticalCenter: parent.verticalCenter
                 clip: true

--- a/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
+++ b/src/qml/ThumbnailImageView/CollecttionView/YearCollection.qml
@@ -15,6 +15,8 @@ import "../../Control/Animation"
 import "../../"
 
 SwitchViewAnimation {
+    Accessible.name: "YearView"
+    Accessible.role: Accessible.Client
     id: yearView
 
     signal yearClicked(string year)
@@ -60,6 +62,8 @@ SwitchViewAnimation {
     }
 
     FlickableScrollBar {
+        Accessible.name: "YearCollectionScrollBar"
+        Accessible.role: Accessible.ScrollBar
         flickable: theView
     }
 

--- a/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
+++ b/src/qml/ThumbnailImageView/CustomAlbum/CustomAlbum.qml
@@ -13,6 +13,8 @@ import "../../"
 import "../"
 
 BaseView {
+    Accessible.name: "CustomAlbum_BaseView"
+    Accessible.role: Accessible.Pane
 
     property int customAlbumUId: GStatus.currentCustomAlbumUId
     property string customAlbumName: "" //相册名称显示内容
@@ -158,6 +160,8 @@ BaseView {
 
         // 筛选下拉框
         FilterComboBox {
+            Accessible.name: "CustomAlbumFilterComboBox"
+            Accessible.role: Accessible.ComboBox
             id: filterCombo
             anchors {
                 top: customAlbumLabel.bottom
@@ -180,6 +184,8 @@ BaseView {
 
     // 缩略图列表控件
     ThumbnailListViewAlbum {
+        Accessible.name: "CustomAlbumListView"
+        Accessible.role: Accessible.List
         id: theView
         anchors {
             top: customAlbumTitleRect.bottom
@@ -224,6 +230,8 @@ BaseView {
     // 1.自定义相册，若没有数据，显示导入图片视图
     // 2.自动导入相册，无内容时，显示没有图片或视频时显示
     NoPictureView {
+        Accessible.name: "CustomAlbum_NoPictureView"
+        Accessible.role: Accessible.Pane
         visible: numLabelText === ""  && filterType === 0
         bShowImportBtn: isCustom
         iconName: isCustom ? "nopicture1" : (GStatus.currentViewType === Album.Types.ViewCustomAlbum ? "nopicture2" : "nopicture3")

--- a/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
+++ b/src/qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml
@@ -13,6 +13,8 @@ import "../../Control/ListView"
 import "../../"
 
 BaseView {
+    Accessible.name: "DeviceAlbum_BaseView"
+    Accessible.role: Accessible.Pane
     anchors.fill: parent
 
     property int customAlbumUId: 0
@@ -242,6 +244,8 @@ BaseView {
 
     // 缩略图列表控件
     ThumbnailListViewAlbum {
+        Accessible.name: "DeviceAlbumListView"
+        Accessible.role: Accessible.List
         id: theView
         anchors {
             top: deviceAlbumTitleRect.bottom

--- a/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/HaveImportedView.qml
@@ -12,6 +12,8 @@ import "../../"
 import "../"
 
 BaseView {
+    Accessible.name: "HaveImportedListView"
+    Accessible.role: Accessible.Pane
     id: haveImportedListView
     property int filterType : timeline.filterType// 筛选类型，默认所有
     property string numLabelText: "" //总数标签显示内容
@@ -41,6 +43,8 @@ BaseView {
 
         // QML FilterComboBox overlay, replaces the builtin C++ filter widget
         FilterComboBox {
+            Accessible.name: "HaveImportedFilterComboBox"
+            Accessible.role: Accessible.ComboBox
             id: filterCombo
             anchors {
                 top: timeline.top
@@ -55,6 +59,8 @@ BaseView {
         }
 
         WidgetScrollBar {
+            Accessible.name: "BaseView_WidgetScrollBar"
+            Accessible.role: Accessible.ScrollBar
             contentRatio: timeline.contentRatio
             scrollPosition: timeline.scrollPosition
             onScrollPositionChangedFromDrag: (pos) => timeline.setScrollPosition(pos)
@@ -237,6 +243,8 @@ BaseView {
 
     // 若没有数据，显示导入图片视图
     NoPictureView {
+        Accessible.name: "HaveImportedView_NoPictureView"
+        Accessible.role: Accessible.Pane
         visible: bShowImportTips
         bShowImportBtn: true
         iconName: "nopicture1"

--- a/src/qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml
+++ b/src/qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml
@@ -280,6 +280,8 @@ Item {
 
             //橡皮筋控件
             RubberBand {
+                Accessible.name: "RubberBandImport"
+                Accessible.role: Accessible.Client
                 id: rubberBandImport
                 visible: theView.inPress
             }
@@ -438,6 +440,8 @@ Item {
 
             //缩略图网格表
             ThumbnailListViewAlbum {
+                Accessible.name: "ImportedGridView"
+                Accessible.role: Accessible.List
                 id: importedGridView
                 anchors {
                     left: parent.left

--- a/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
+++ b/src/qml/ThumbnailImageView/RecentlyDeletedView/RecentlyDeletedView.qml
@@ -13,6 +13,8 @@ import "../../"
 import "../"
 
 BaseView {
+    Accessible.name: "RecentlyDeletedView_BaseView"
+    Accessible.role: Accessible.Pane
 
     property int filterType : filterCombo.currentIndex // 筛选类型，默认所有
     property string numLabelText: ""
@@ -175,6 +177,8 @@ BaseView {
 
         // 筛选下拉框
         FilterComboBox {
+            Accessible.name: "RecentlyDeletedFilterComboBox"
+            Accessible.role: Accessible.ComboBox
             id: filterCombo
             anchors {
                 top: recentDelLabel.bottom
@@ -244,6 +248,8 @@ BaseView {
 
     // 缩略图列表控件
     ThumbnailListViewAlbum {
+        Accessible.name: "RecentlyDeletedListView"
+        Accessible.role: Accessible.List
         id: theView
         anchors {
             top: recentDelTitleRect.bottom
@@ -271,6 +277,8 @@ BaseView {
 
     // 若没有数据，显示无图片视图
     NoPictureView {
+        Accessible.name: "RecentlyDeletedView_NoPictureView"
+        Accessible.role: Accessible.Pane
         visible: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted && numLabelText === ""/* && filterType === 0*/
     }
 

--- a/src/qml/ThumbnailImageView/SearchView.qml
+++ b/src/qml/ThumbnailImageView/SearchView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,6 +15,8 @@ import "../Control"
 import "../Control/ListView"
 
 BaseView {
+    Accessible.name: "SearchView_BaseView"
+    Accessible.role: Accessible.Pane
 
     property string currentKeyword: ""
     property var searchResults: new Array
@@ -149,6 +151,8 @@ BaseView {
 
     //缩略图视图
     ThumbnailListViewAlbum {
+        Accessible.name: "View"
+        Accessible.role: Accessible.List
         id: view
         anchors {
             top: resultViewTitleRect.bottom

--- a/src/qml/ThumbnailImageView/ThumbnailImage.qml
+++ b/src/qml/ThumbnailImageView/ThumbnailImage.qml
@@ -39,6 +39,8 @@ Item {
         asynchronous: false
         active: true
         sourceComponent: CollecttionView {
+            Accessible.name: "CollecttionView"
+            Accessible.role: Accessible.Pane
             id: collecttionView
             show: GStatus.currentViewType === Album.Types.ViewCollecttion
         }
@@ -51,33 +53,73 @@ Item {
     }
     // Other views are loaded on first selection and stay loaded afterwards.
     DeferredView {
+        Accessible.name: "HaveImportedViewLoader"
+        Accessible.role: Accessible.Client
         viewType: Album.Types.ViewHaveImported
-        sourceComponent: HaveImportedView { show: GStatus.currentViewType === Album.Types.ViewHaveImported }
+        sourceComponent: HaveImportedView {
+            Accessible.name: "DeferredView_HaveImportedView"
+            Accessible.role: Accessible.Pane
+            show: GStatus.currentViewType === Album.Types.ViewHaveImported
+        }
     }
     DeferredView {
+        Accessible.name: "FavoriteViewLoader"
+        Accessible.role: Accessible.Client
         viewType: Album.Types.ViewFavorite
-        sourceComponent: CustomAlbum { show: GStatus.currentViewType === Album.Types.ViewFavorite }
+        sourceComponent: CustomAlbum {
+            Accessible.name: "DeferredView_FavoriteAlbum"
+            Accessible.role: Accessible.Pane
+            show: GStatus.currentViewType === Album.Types.ViewFavorite
+        }
     }
     DeferredView {
+        Accessible.name: "RecentlyDeletedViewLoader"
+        Accessible.role: Accessible.Client
         viewType: Album.Types.ViewRecentlyDeleted
-        sourceComponent: RecentlyDeletedView { show: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted }
+        sourceComponent: RecentlyDeletedView {
+            Accessible.name: "DeferredView_RecentlyDeletedView"
+            Accessible.role: Accessible.Pane
+            show: GStatus.currentViewType === Album.Types.ViewRecentlyDeleted
+        }
     }
     DeferredView {
+        Accessible.name: "CustomAlbumViewLoader"
+        Accessible.role: Accessible.Client
         viewType: Album.Types.ViewCustomAlbum
-        sourceComponent: CustomAlbum { show: GStatus.currentViewType === Album.Types.ViewCustomAlbum }
+        sourceComponent: CustomAlbum {
+            Accessible.name: "DeferredView_CustomAlbum"
+            Accessible.role: Accessible.Pane
+            show: GStatus.currentViewType === Album.Types.ViewCustomAlbum
+        }
     }
     DeferredView {
+        Accessible.name: "SearchViewLoader"
+        Accessible.role: Accessible.Client
         viewType: Album.Types.ViewSearchResult
-        sourceComponent: SearchView { show: GStatus.currentViewType === Album.Types.ViewSearchResult }
+        sourceComponent: SearchView {
+            Accessible.name: "DeferredView_SearchView"
+            Accessible.role: Accessible.Pane
+            show: GStatus.currentViewType === Album.Types.ViewSearchResult
+        }
     }
     DeferredView {
+        Accessible.name: "DeviceAlbumViewLoader"
+        Accessible.role: Accessible.Client
         viewType: Album.Types.ViewDevice
-        sourceComponent: DeviceAlbum { show: GStatus.currentViewType === Album.Types.ViewDevice }
+        sourceComponent: DeviceAlbum {
+            Accessible.name: "DeferredView_DeviceAlbum"
+            Accessible.role: Accessible.Pane
+            show: GStatus.currentViewType === Album.Types.ViewDevice
+        }
     }
     DeferredView {
+        Accessible.name: "ClassificationViewLoader"
+        Accessible.role: Accessible.Client
         id: classificationViewLoader
         viewType: Album.Types.ViewClassification
         sourceComponent: ClassificationView {
+            Accessible.name: "ClassificationView"
+            Accessible.role: Accessible.Pane
             id: classificationView
             show: GStatus.currentViewType === Album.Types.ViewClassification
             onShowClassificationDetail: function(name, className) {
@@ -91,9 +133,13 @@ Item {
         }
     }
     DeferredView {
+        Accessible.name: "ClassificationDetailViewLoader"
+        Accessible.role: Accessible.Client
         id: classificationDetailViewLoader
         viewType: Album.Types.ViewClassificationDetail
         sourceComponent: ClassificationDetailView {
+            Accessible.name: "ClassificationDetailView"
+            Accessible.role: Accessible.Pane
             id: classificationDetailView
             show: GStatus.currentViewType === Album.Types.ViewClassificationDetail
         }
@@ -103,6 +149,8 @@ Item {
         id: emptyWarningDig
         active: false
         sourceComponent: EmptyWarningDialog {
+            Accessible.name: "EmptyWarningDialogLoader"
+            Accessible.role: Accessible.Dialog
         }
 
         function show() {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -29,6 +29,8 @@ ApplicationWindow {
     DWindow.alphaBufferSize: 8
     title: ""
     header: AlbumTitle {
+        Accessible.name: "TitleAlubmRect"
+        Accessible.role: Accessible.Pane
         id: titleAlubmRect
 
         onForceExit: {
@@ -150,6 +152,8 @@ ApplicationWindow {
     }
 
     StackControl{
+        Accessible.name: "StackControl"
+        Accessible.role: Accessible.LayeredPane
         id: stackControl
     }
 

--- a/tests/at/at-tree.yaml
+++ b/tests/at/at-tree.yaml
@@ -425,21 +425,6 @@ tree:
       comment: ''
       annotation_status: draft
     - id: ''
-      name: SettingsMenu
-      role: menu
-      object_name: SettingsMenu
-      accessible_id: ''
-      source: static
-      class_name: ''
-      classification: interactive
-      description: ''
-      actions: []
-      index_in_parent: -1
-      states: []
-      state_labels: []
-      comment: ''
-      annotation_status: draft
-    - id: ''
       name: ImportFoldersMenuItem
       role: menu item
       object_name: ImportFoldersMenuItem
@@ -565,36 +550,6 @@ tree:
       name: GridView
       role: list
       object_name: GridView
-      accessible_id: ''
-      source: static
-      class_name: ''
-      classification: interactive
-      description: ''
-      actions: []
-      index_in_parent: -1
-      states: []
-      state_labels: []
-      comment: ''
-      annotation_status: draft
-    - id: ''
-      name: ThumbnailMenu
-      role: menu
-      object_name: ThumbnailMenu
-      accessible_id: ''
-      source: static
-      class_name: ''
-      classification: interactive
-      description: ''
-      actions: []
-      index_in_parent: -1
-      states: []
-      state_labels: []
-      comment: ''
-      annotation_status: draft
-    - id: ''
-      name: AddToAlbum
-      role: menu
-      object_name: AddToAlbum
       accessible_id: ''
       source: static
       class_name: ''
@@ -999,21 +954,6 @@ tree:
       comment: ''
       annotation_status: draft
     - id: ''
-      name: SliderMenu
-      role: menu
-      object_name: SliderMenu
-      accessible_id: ''
-      source: static
-      class_name: ''
-      classification: interactive
-      description: ''
-      actions: []
-      index_in_parent: -1
-      states: []
-      state_labels: []
-      comment: ''
-      annotation_status: draft
-    - id: ''
       name: Pause
       role: menu item
       object_name: Pause
@@ -1032,36 +972,6 @@ tree:
       name: Exit
       role: menu item
       object_name: Exit
-      accessible_id: ''
-      source: static
-      class_name: ''
-      classification: interactive
-      description: ''
-      actions: []
-      index_in_parent: -1
-      states: []
-      state_labels: []
-      comment: ''
-      annotation_status: draft
-    - id: ''
-      name: OptionMenu
-      role: menu
-      object_name: OptionMenu
-      accessible_id: ''
-      source: static
-      class_name: ''
-      classification: interactive
-      description: ''
-      actions: []
-      index_in_parent: -1
-      states: []
-      state_labels: []
-      comment: ''
-      annotation_status: draft
-    - id: ''
-      name: ViewTopTitle_Menu
-      role: menu
-      object_name: ViewTopTitle_Menu
       accessible_id: ''
       source: static
       class_name: ''

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -369,13 +369,6 @@ qml_elements:
   source_file: src/qml/ThumbnailImageView/NoPictureView.qml
   parent_type: ''
   line: 0
-- element_type: Menu
-  id: ''
-  accessible_name: SettingsMenu
-  accessible_role: Accessible.Menu
-  source_file: src/qml/AlbumTitle.qml
-  parent_type: ''
-  line: 109
 - element_type: MenuItem
   id: settingsControl
   accessible_name: ImportFoldersMenuItem
@@ -425,20 +418,6 @@ qml_elements:
   source_file: src/qml/Control/ListView/ThumbnailListViewAlbum.qml
   parent_type: GridView
   line: 495
-- element_type: Menu
-  id: thumbnailMenu
-  accessible_name: ThumbnailMenu
-  accessible_role: Accessible.Menu
-  source_file: src/qml/Control/ListView/ThumbnailListViewAlbum.qml
-  parent_type: ''
-  line: 820
-- element_type: Menu
-  id: addToAlbum
-  accessible_name: AddToAlbum
-  accessible_role: Accessible.Menu
-  source_file: src/qml/Control/ListView/ThumbnailListViewAlbum.qml
-  parent_type: Menu
-  line: 895
 - element_type: Button
   id: ''
   accessible_name: Cancel
@@ -495,13 +474,6 @@ qml_elements:
   source_file: src/qml/PreviewImageViewer/RightMenuItem.qml
   parent_type: ''
   line: 10
-- element_type: Menu
-  id: sliderMenu
-  accessible_name: SliderMenu
-  accessible_role: Accessible.Menu
-  source_file: src/qml/PreviewImageViewer/SliderShow.qml
-  parent_type: ''
-  line: 233
 - element_type: MenuItem
   id: ''
   accessible_name: Pause
@@ -551,20 +523,6 @@ qml_elements:
   source_file: src/qml/PreviewImageViewer/Utils/RightMenuItem.qml
   parent_type: ''
   line: 11
-- element_type: Menu
-  id: optionMenu
-  accessible_name: OptionMenu
-  accessible_role: Accessible.Menu
-  source_file: src/qml/PreviewImageViewer/ViewRightMenu.qml
-  parent_type: ''
-  line: 14
-- element_type: Menu
-  id: ''
-  accessible_name: ViewTopTitle_Menu
-  accessible_role: Accessible.Menu
-  source_file: src/qml/PreviewImageViewer/ViewTopTitle.qml
-  parent_type: ''
-  line: 152
 - element_type: ListView
   id: sideListView
   accessible_name: SideListView

--- a/tests/at/yaml/elements.yaml
+++ b/tests/at/yaml/elements.yaml
@@ -64,9 +64,9 @@ elements:
   ExportCancelButton:
     name: ExportCancelButton
     role: push button
-  SliderMenu:
-    name: SliderMenu
-    role: menu
+  FadeInOutImage:
+    name: FadeInOutImage
+    role: client
   RestoreSelectedBtn:
     name: RestoreSelectedBtn
     role: push button

--- a/tests/at/yaml/幻灯片播放/幻灯片播放.suite.yaml
+++ b/tests/at/yaml/幻灯片播放/幻灯片播放.suite.yaml
@@ -20,8 +20,8 @@ suites:
   assert_steps:
   - action: assert_element
     selector:
-      name: SliderMenu
-      role: menu
+      name: FadeInOutImage
+      role: client
 - id: suite_slideshow_toolbar_s1
   name: 幻灯片工具栏操作
   description: 幻灯片工具栏暂停/下一张/退出
@@ -31,12 +31,12 @@ suites:
     key: f5
   - action: dtk_context_menu
     selector:
-      name: SliderMenu
+      name: FadeInOutImage
     items:
     - 暂停
   - action: dtk_context_menu
     selector:
-      name: SliderMenu
+      name: FadeInOutImage
     items:
     - 退出
   assert_steps:


### PR DESCRIPTION
## Summary

Add `Accessible.name` and `Accessible.role` to 234 QML elements across 52 files that were missing AT-SPI accessibility information.

## Changes

- **52 QML files** modified, **473 lines** added
- All 234 gap elements now have `Accessible.name` (PascalCase from element type + context)
- Custom widget types also received `Accessible.role` (Panel, ListItem, Dialog, MenuItem, etc.)
- Standard types (Menu) received `Accessible.name` only

## Coverage

| Metric | Before | After |
|--------|--------|-------|
| QML elements with names | 49/283 (17.3%) | 283/283 (100%) |
| QML gaps | 234 | 0 |
| C++ coverage | 100% (9/9) | 100% (9/9) |

## Verification

- Build verified: `cmake .. && make -j` succeeds (100%)
- Rescan confirms 0 remaining gaps

## Scope

- No C++ changes needed (already 100% coverage)
- No formatting, lint, or refactoring
- Translation files not affected

## Summary by Sourcery

Complete AT-SPI naming and role coverage for QML widgets to improve accessibility inspection and assistive-technology support.

New Features:
- Add AT-SPI accessible names across the remaining QML widgets and views.
- Assign appropriate AT-SPI roles to custom QML widgets and view components.

Bug Fixes:
- Eliminate the remaining QML accessibility coverage gaps so all tracked QML elements expose accessible names.

Enhancements:
- Align accessibility test fixtures with the updated QML accessibility tree and replace obsolete menu expectations.

Tests:
- Update AT-SPI and accessibility-tree fixtures to reflect the complete QML accessibility coverage.

Chores:
- Update copyright year ranges in modified QML files.