### PR TITLE
chore: update version to 6.0.66

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-album (6.0.66) unstable; urgency=medium
+
+  * fix(preview): resolve invalid IV-prefixed references in NormalImageDelegate
+
+ -- Wang Yu <wangyu@uniontech.com>  Fri, 28 Aug 2026 14:12:16 +0800
+
 deepin-album (6.0.65) unstable; urgency=medium
 
   * fix: set stackPage before deferred MainStack is created

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.album
   name: deepin-album
-  version: 6.0.65.1
+  version: 6.0.66.1
   kind: app
   description: |
     album for deepin os.


### PR DESCRIPTION
- bump version to 6.0.66

Log : bump version to 6.0.66

## Summary by Sourcery

Chores:
- Update the package version from 6.0.65.1 to 6.0.66.1 and record the release in the Debian changelog.