### PR TITLE
fix: update Arabic (ar) translations

### DIFF
--- a/src/translations/deepin-album_ar.ts
+++ b/src/translations/deepin-album_ar.ts
@@ -190,6 +190,7 @@
     </message>
     <message>
         <location filename="../src/albumControl.cpp" line="2173"/>
+        <location filename="../src/albumControl.cpp" line="2177"/>
         <source>%1Year%2Month%3Day</source>
         <translation>%1 سنة %2 شهر %3 يوم</translation>
     </message>
@@ -248,21 +249,25 @@
     </message>
     <message>
         <location filename="../qml/AlbumTitle.qml" line="262"/>
+        <location filename="../qml/AlbumTitle.qml" line="340"/>
         <source>Y</source>
         <translation>ي</translation>
     </message>
     <message>
         <location filename="../qml/AlbumTitle.qml" line="274"/>
+        <location filename="../qml/AlbumTitle.qml" line="341"/>
         <source>M</source>
         <translation>م</translation>
     </message>
     <message>
         <location filename="../qml/AlbumTitle.qml" line="285"/>
+        <location filename="../qml/AlbumTitle.qml" line="342"/>
         <source>D</source>
         <translation>يوم</translation>
     </message>
     <message>
         <location filename="../qml/AlbumTitle.qml" line="296"/>
+        <location filename="../qml/AlbumTitle.qml" line="343"/>
         <source>All</source>
         <translation>كل</translation>
     </message>
@@ -362,21 +367,30 @@
     <name>DBManager</name>
     <message>
         <location filename="../src/dbmanager/dbmanager.cpp" line="480"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="497"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="522"/>
         <source>Screen Capture</source>
         <translation>التقاط الشاشة</translation>
     </message>
     <message>
         <location filename="../src/dbmanager/dbmanager.cpp" line="481"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="498"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="527"/>
         <source>Camera</source>
         <translation>كاميرا</translation>
     </message>
     <message>
         <location filename="../src/dbmanager/dbmanager.cpp" line="482"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="532"/>
         <source>Draw</source>
         <translation>الرسم</translation>
     </message>
     <message>
         <location filename="../src/dbmanager/dbmanager.cpp" line="2021"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2041"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2045"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2047"/>
+        <location filename="../src/dbmanager/dbmanager.cpp" line="2053"/>
         <source>(copy)</source>
         <translation>(نسخ)</translation>
     </message>
@@ -514,11 +528,13 @@
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="189"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="192"/>
         <source>Import</source>
         <translation>استيراد</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="189"/>
+        <location filename="../qml/ThumbnailImageView/DeviceAlbum/DeviceAlbum.qml" line="192"/>
         <source>New Album</source>
         <translation>ألبوم جديد</translation>
     </message>
@@ -628,6 +644,7 @@
     </message>
     <message>
         <location filename="../qml/Control/ExportDialog.qml" line="127"/>
+        <location filename="../qml/Control/ExportDialog.qml" line="143"/>
         <source>Select other directories</source>
         <translation>اختر مجلدات أخرى</translation>
     </message>
@@ -691,6 +708,7 @@
     </message>
     <message>
         <location filename="../src/filecontrol.cpp" line="858"/>
+        <location filename="../src/filecontrol.cpp" line="950"/>
         <source>Copy</source>
         <translation>نسخ</translation>
     </message>
@@ -855,6 +873,7 @@
     </message>
     <message>
         <location filename="../qml/GlobalVar.qml" line="38"/>
+        <location filename="../qml/GlobalVar.qml" line="46"/>
         <source>The file format is not supported</source>
         <translation>ملف غير مدعوم</translation>
     </message>
@@ -891,6 +910,7 @@
     <name>ImportTimeLineView</name>
     <message>
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="211"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="430"/>
         <source>Import</source>
         <translation>استيراد</translation>
     </message>
@@ -904,36 +924,60 @@
         <source>1 video</source>
         <translation>1 فيديو</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="345"/>
         <source>%n photos</source>
-        <translation>%n صور</translation>
+        <translation>
+            <numerusform>%n صورة</numerusform>
+            <numerusform>%n صورتان</numerusform>
+            <numerusform>%n صور</numerusform>
+            <numerusform>%n صورة</numerusform>
+            <numerusform>%n صور</numerusform>
+            <numerusform>%n صور</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="347"/>
         <source>%n videos</source>
-        <translation>%n فيديوهات</translation>
+        <translation>
+            <numerusform>%n مقطع فيديو</numerusform>
+            <numerusform>%n مقطعا فيديو</numerusform>
+            <numerusform>%n مقاطع فيديو</numerusform>
+            <numerusform>%n مقطع فيديو</numerusform>
+            <numerusform>%n مقطع فيديو</numerusform>
+            <numerusform>%n مقطع فيديو</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="349"/>
         <source>%n items</source>
-        <translation>%n عناصر</translation>
+        <translation>
+            <numerusform>%n عنصر</numerusform>
+            <numerusform>%n عنصران</numerusform>
+            <numerusform>%n عناصر</numerusform>
+            <numerusform>%n عنصرا</numerusform>
+            <numerusform>%n عنصر</numerusform>
+            <numerusform>%n عنصر</numerusform>
+        </translation>
     </message>
 </context>
 <context>
     <name>ImportedlListView</name>
     <message>
         <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="150"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="423"/>
         <source>Imported on</source>
         <translation>تم الاستيراد في</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="150"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="423"/>
         <source>1 item</source>
         <translation>عنصر واحد</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="150"/>
+        <location filename="../qml/ThumbnailImageView/HaveImportedView/ImportedlListView.qml" line="423"/>
         <source>%1 items</source>
         <translation>%1 عنصر/ عنصرين/ عناصر</translation>
     </message>
@@ -1060,11 +1104,13 @@
     </message>
     <message>
         <location filename="../qml/MainAlbumView.qml" line="246"/>
+        <location filename="../qml/MainAlbumView.qml" line="252"/>
         <source>Imported:</source>
         <translation>المستردة:</translation>
     </message>
     <message>
         <location filename="../qml/MainAlbumView.qml" line="253"/>
+        <location filename="../qml/MainAlbumView.qml" line="290"/>
         <source>%1/%2</source>
         <translation>%1 \ %2</translation>
     </message>
@@ -1075,6 +1121,7 @@
     </message>
     <message>
         <location filename="../qml/MainAlbumView.qml" line="270"/>
+        <location filename="../qml/MainAlbumView.qml" line="276"/>
         <source>Import failed</source>
         <translation>فشل الاستيراد</translation>
     </message>
@@ -1208,6 +1255,7 @@
     <name>PropertyActionItemDelegate</name>
     <message>
         <location filename="../qml/PreviewImageViewer/PropertyActionItemDelegate.qml" line="67"/>
+        <location filename="../qml/PreviewImageViewer/InformationDialog/PropertyActionItemDelegate.qml" line="95"/>
         <source>The file already exists, please use another name</source>
         <translation>الملف موجود بالفعل، يرجى استخدام اسم آخر</translation>
     </message>
@@ -1216,6 +1264,7 @@
     <name>QObject</name>
     <message>
         <location filename="../src/albumControl.cpp" line="635"/>
+        <location filename="../src/albumControl.cpp" line="684"/>
         <source>%1/%2/%3 %4:%5</source>
         <translation>%1 \ %2 \ %3   %4:%5</translation>
     </message>
@@ -1231,21 +1280,28 @@
     </message>
     <message>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="289"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="325"/>
+        <location filename="../src/albumControl.cpp" line="678"/>
         <source>%1/%2/%3</source>
         <translation>%1/%2/%3</translation>
     </message>
     <message>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="361"/>
+        <location filename="../src/widgets/timelineview/timelineview.cpp" line="368"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="397"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="404"/>
         <source>All</source>
         <translation>الكل</translation>
     </message>
     <message>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="376"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="412"/>
         <source>Photos</source>
         <translation>الصور</translation>
     </message>
     <message>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="383"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="419"/>
         <source>Videos</source>
         <translation>الفيديوهات</translation>
     </message>
@@ -1287,11 +1343,20 @@
     </message>
     <message>
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="236"/>
+        <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="48"/>
+        <location filename="../src/widgets/thumbnail/timelinedatewidget.cpp" line="164"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2106"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
+        <location filename="../src/widgets/importtimelineview/importtimelineview.cpp" line="440"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="1360"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2115"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="2121"/>
         <source>Unselect</source>
         <translation>إلغاء التحديد</translation>
     </message>
@@ -1389,8 +1454,8 @@
     <name>RemoveDialog</name>
     <message>
         <location filename="../qml/PreviewImageViewer/Dialog/RemoveDialog.qml" line="66"/>
-        <source>Cannot move "%1" to the trash. Do you want to permanently delete it?</source>
-        <translation>لا يمكن نقل "%1" إلى السلة. هل ترغب في حذفه نهائيًا؟</translation>
+        <source>Cannot move &quot;%1&quot; to the trash. Do you want to permanently delete it?</source>
+        <translation>لا يمكن نقل &quot;%1&quot; إلى السلة. هل ترغب في حذفه نهائيًا؟</translation>
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/Dialog/RemoveDialog.qml" line="84"/>
@@ -1455,6 +1520,7 @@
     <name>Sidebar</name>
     <message>
         <location filename="../qml/SideBar/Sidebar.qml" line="127"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="151"/>
         <source>Album “%1” removed</source>
         <translation>تم حذف الإلبوم “1%”</translation>
     </message>
@@ -1515,16 +1581,21 @@
     </message>
     <message>
         <location filename="../qml/SideBar/Sidebar.qml" line="455"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="480"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="534"/>
         <source>Slide show</source>
         <translation>عرض الشرائح</translation>
     </message>
     <message>
         <location filename="../qml/SideBar/Sidebar.qml" line="466"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="492"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="567"/>
         <source>Export</source>
         <translation>تصدير</translation>
     </message>
     <message>
         <location filename="../qml/SideBar/Sidebar.qml" line="500"/>
+        <location filename="../qml/SideBar/Sidebar.qml" line="576"/>
         <source>Delete</source>
         <translation>حذف</translation>
     </message>
@@ -1548,11 +1619,13 @@
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="181"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="232"/>
         <source>Pause</source>
         <translation>إيقاف مؤقت</translation>
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="181"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="232"/>
         <source>Play</source>
         <translation>تشغيل</translation>
     </message>
@@ -1563,6 +1636,7 @@
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="212"/>
+        <location filename="../qml/PreviewImageViewer/SliderShow.qml" line="253"/>
         <source>Exit</source>
         <translation>خروج</translation>
     </message>
@@ -1584,6 +1658,14 @@
     <name>ThumbnailListView</name>
     <message>
         <location filename="../qml/PreviewImageViewer/ThumbnailListView.qml" line="610"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="762"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="764"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="804"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="807"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="809"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="819"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="948"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="965"/>
         <source>Delete</source>
         <translation>حذف</translation>
     </message>
@@ -1619,11 +1701,23 @@
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/ThumbnailListView.qml" line="335"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="772"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="776"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="828"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="836"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="838"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="969"/>
         <source>Favorite</source>
         <translation>تفضيل</translation>
     </message>
     <message>
         <location filename="../qml/PreviewImageViewer/ThumbnailListView.qml" line="335"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="773"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="775"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="830"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="835"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="839"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="970"/>
         <source>Unfavorite</source>
         <translation>عدم التفضيل</translation>
     </message>
@@ -1639,66 +1733,123 @@
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="723"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="726"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="730"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="782"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="868"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="876"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="882"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="950"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="979"/>
         <source>Photo info</source>
         <translation>معلومات الصورة</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="724"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="727"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="731"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="783"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="869"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="872"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="883"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="951"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="980"/>
         <source>Video info</source>
         <translation>معلومات الفيديو</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="746"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="798"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="931"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="957"/>
         <source>View</source>
         <translation>عرض</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="747"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="799"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="870"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="877"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="958"/>
         <source>Fullscreen</source>
         <translation>ملء الشاشة</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="748"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="874"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="888"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="897"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="960"/>
         <source>Slide show</source>
         <translation>عرض الشرائح</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="749"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="754"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="817"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="875"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="889"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="962"/>
         <source>Export</source>
         <translation>تصدير</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="759"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="963"/>
         <source>Copy</source>
         <translation>نسخ</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="767"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="844"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="966"/>
         <source>Remove from album</source>
         <translation>حذف من الإلبوم</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="769"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="873"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="887"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="959"/>
         <source>Print</source>
         <translation>طباعة</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="779"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="859"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="862"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="903"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="906"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="973"/>
         <source>Rotate clockwise</source>
         <translation>تدوير بإتجاه عقارب الساعة</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="780"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="860"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="863"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="904"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="907"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="974"/>
         <source>Rotate counterclockwise</source>
         <translation>تدوير بعكس إتجاه عقارب الساعة</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="781"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="881"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="978"/>
         <source>Display in file manager</source>
         <translation>عرض في مدير الملفات</translation>
     </message>
     <message>
         <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="784"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="790"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="791"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="878"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="914"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="916"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="919"/>
+        <location filename="../src/widgets/thumbnail/thumbnaillistview.cpp" line="977"/>
         <source>Set as wallpaper</source>
         <translation>اجعلها كخلفية</translation>
     </message>
@@ -1833,20 +1984,41 @@
         <source>1 video</source>
         <translation>1 فيديو</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="308"/>
         <source>%n photos</source>
-        <translation>%n صور</translation>
+        <translation>
+            <numerusform>%n صورة</numerusform>
+            <numerusform>%n صورتان</numerusform>
+            <numerusform>%n صور</numerusform>
+            <numerusform>%n صورة</numerusform>
+            <numerusform>%n صور</numerusform>
+            <numerusform>%n صور</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="310"/>
         <source>%n videos</source>
-        <translation>%n فيديوهات</translation>
+        <translation>
+            <numerusform>%n مقطع فيديو</numerusform>
+            <numerusform>%n مقطعا فيديو</numerusform>
+            <numerusform>%n مقاطع فيديو</numerusform>
+            <numerusform>%n مقطع فيديو</numerusform>
+            <numerusform>%n مقطع فيديو</numerusform>
+            <numerusform>%n مقطع فيديو</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/widgets/timelineview/timelineview.cpp" line="312"/>
         <source>%n items</source>
-        <translation>%n عناصر</translation>
+        <translation>
+            <numerusform>%n عنصر</numerusform>
+            <numerusform>%n عنصران</numerusform>
+            <numerusform>%n عناصر</numerusform>
+            <numerusform>%n عنصرا</numerusform>
+            <numerusform>%n عنصر</numerusform>
+            <numerusform>%n عنصر</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -1946,6 +2118,7 @@
     </message>
     <message>
         <location filename="../qml/Control/VideoInfoDialog.qml" line="130"/>
+        <location filename="../qml/Control/VideoInfoDialog.qml" line="170"/>
         <source>Video CodecID</source>
         <translation>معرف ترميز فيديو</translation>
     </message>


### PR DESCRIPTION
Update Arabic (ar) translations

## Summary by Sourcery

Update the Arabic localization to improve plural handling and keep translated UI strings synchronized across the application.

Bug Fixes:
- Correct Arabic pluralization for photo, video, and item counts across timeline and import views.

Enhancements:
- Refresh Arabic translation metadata and coverage for album, import, timeline, thumbnail, slideshow, and media-management actions.
- Escape quotation marks in the Arabic deletion confirmation message for valid translation markup.